### PR TITLE
fix(install): Fix Platform-Specific Build Tool Detection

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -59,12 +59,11 @@ function advice {
 }
 
 quiet command -v make
-die $? "not ok - missing build tools, try \"$(advice "automake")\""
-
-quiet command -v autoconf
-die $? "not ok - missing build tools, try \"$(advice "automake")\""
+die $? "not ok - missing build tools, try \"$(advice "make")\""
 
 if [ "$(uname)" == "Darwin" ]; then
+  quiet command -v automake
+  die $? "not ok - missing build tools, try \"$(advice "automake")\""
   quiet command -v glibtoolize
   die $? "not ok - missing build tools, try 'brew install libtool'"
   quiet command -v libtool
@@ -72,6 +71,8 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 if [ "$(uname)" == "Linux" ]; then
+  quiet command -v autoconf
+  die $? "not ok - missing build tools, try \"$(advice "autoconf")\""
   quiet command -v pkg-config
   die $? "not ok - missing pkg-config tool, \"$(advice 'pkg-config')\""
 fi


### PR DESCRIPTION
# 👋  Check It Out!

On a fresh install of `socket` on macOS / Darwin (12.6), the dependency check does not properly require `automake` (rather, `make`).

Without `automake`, `install.sh` proceeds to call `./configure`, which promptly fails due to the lack of required deps.

Accordingly, this PR **properly checks for `automake` on macOS / Darwin** and dies if not present.

Similarly, as `autoconf` is the Linux equivalent, this PR moves its respective check to the Linux-specific block.