### PR TITLE
Navigate from the frontend and backend process management

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -129,10 +129,10 @@ int runApp (const fs::path& path, const String& args, bool headless) {
     }
 
     status = std::system((headlessCommand + prefix + cmd + " " + args + " --from-ssc").c_str());
-  } else if (platform.mac) {
-    auto s = prefix + cmd;
-    auto part = s.substr(0, s.find(".app/") + 4);
-    status = std::system(("open -n " + part + " --args " + args + " --from-ssc").c_str());
+  // } else if (platform.mac) {
+  //   auto s = prefix + cmd;
+  //   auto part = s.substr(0, s.find(".app/") + 4);
+  //   status = std::system(("open -n " + part + " --args " + args + " --from-ssc").c_str());
   } else {
     status = std::system((prefix + cmd + " " + args + " --from-ssc").c_str());
   }

--- a/src/core/runtime-preload.hh
+++ b/src/core/runtime-preload.hh
@@ -37,12 +37,6 @@ namespace SSC {
         "  window.addEventListener('menuItemSelected', e => {           \n"
         "    window.location.reload();                                  \n"
         "  });                                                          \n"
-        "}                                                              \n"
-        "const uri = `ipc://process.open`;                              \n"
-        "if (window?.webkit?.messageHandlers?.external?.postMessage) {  \n"
-        "  window.webkit.messageHandlers.external.postMessage(uri);     \n"
-        "} else if (window?.chrome?.webview?.postMessage) {             \n"
-        "  window.chrome.webview.postMessage(uri);                      \n"
         "}                                                              \n";
     }
 

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -180,11 +180,12 @@ MAIN {
   }
 
   static Process* process = nullptr;
-  static std::function<void()> createProcess;
+  static std::function<void(bool)> createProcess;
 
   auto createProcessTemplate = []<class... Args>(Args... args) {
-    return [=]() {
+    return [=](bool force) {
       if (process != nullptr) {
+        if (!force) return;
         auto pid = process->getPID();
         process->kill(pid);
         delete process;
@@ -220,7 +221,7 @@ MAIN {
       exit(1);
     }
 
-    createProcess();
+    createProcess(true);
 
     shutdownHandler = [&](int signum) {
       if (process != nullptr) {
@@ -480,7 +481,7 @@ MAIN {
   );
 
   if (cmd.size() > 0) {
-    createProcess();
+    createProcess(true);
   }
 
   //
@@ -508,7 +509,8 @@ MAIN {
 
     if (message.name == "process.open") {
       if (cmd.size() > 0) {
-        createProcess();
+        auto force = message.get("force") == "true" ? true : false;
+        createProcess(force);
         process->open();
       }
       return;

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -548,6 +548,22 @@ MAIN {
     }
 
     if (message.name == "navigate") {
+      if (!value.starts_with("file://")) {
+        debug("Navigation error: only file:// protocol is allowed. Got path %s", value.c_str());
+        return;
+      }
+      if (!value.substr(7).starts_with(cwd)) {
+        debug("Navigation error: only files in the current directory are allowed. Got path %s", value.c_str());
+        return;
+      }
+      if (!value.ends_with(".html")) {
+        debug("Navigation error: only .html files are allowed. Got path %s", value.c_str());
+        return;
+      }
+      if (value.find("/../") != std::string::npos) {
+        debug("Navigation error: relative paths are not allowed. Got path %s", value.c_str());
+        return;
+      }
       const auto seq = message.get("seq");
       window->navigate(seq, decodeURIComponent(value));
       return;

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -547,6 +547,12 @@ MAIN {
       return;
     }
 
+    if (message.name == "navigate") {
+      const auto seq = message.get("seq");
+      window->navigate(seq, decodeURIComponent(value));
+      return;
+    }
+
     if (message.name == "inspect") {
       window->showInspector();
       return;


### PR DESCRIPTION
- [x] Add `navigate` message for the render process
- [x] Add `process.kill`
- [x] Remove automatic `process.open`
- [x] Add the `force` option for `process.open`