### PR TITLE
Lots of changes for Windows

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -37,7 +37,7 @@ Function Build {
 
   if (-not (Test-Path -Path "$WORKING_BUILD_PATH\lib\uv_a.lib" -PathType Leaf)) {
     (New-Item -ItemType Directory -Force -Path "$WORKING_BUILD_PATH\lib") > $null
-    Copy-Item $WORKING_BUILD_PATH\libuv\build\Release\uv_a.lib -Destination "$WORKING_BUILD_PATH\lib\uv_a.lib"
+    Copy-Item "$WORKING_BUILD_PATH\libuv\build\Release\uv_a.lib" -Destination "$WORKING_BUILD_PATH\lib\uv_a.lib"
   }
 
   if (-not (Test-Path -Path "$WORKING_BUILD_PATH\include\uv.h" -PathType Leaf)) {

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -26,7 +26,7 @@ Function Build {
   if (-not (Test-Path -Path "$WORKING_BUILD_PATH\libuv\build\Release\uv_a.lib" -PathType Leaf)) {
     (New-Item -ItemType Directory -Force -Path "$WORKING_BUILD_PATH\libuv\build") > $null
 
-    Write-Output "# bulding libuv..."
+    Write-Output "# building libuv..."
     cd "$WORKING_BUILD_PATH\libuv\build"
     (cmake ..) > $null
 

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -28,7 +28,7 @@ Function Build {
 
     Write-Output "# building libuv..."
     cd "$WORKING_BUILD_PATH\libuv\build"
-    (cmake ..) > $null
+    (cmake .. -DBUILD_TESTING=OFF) > $null
 
     cd "$WORKING_BUILD_PATH\libuv"
     (cmake --build "$WORKING_BUILD_PATH\libuv\build" --config Release) > $null
@@ -48,8 +48,8 @@ Function Build {
   cd "$WORKING_PATH"
   (New-Item -ItemType Directory -Force -Path "$WORKING_BUILD_PATH\bin") > $null
   Write-Output "# compiling the build tool..."
-  clang++ src\cli\cli.cc -o $WORKING_BUILD_PATH\bin\ssc.exe -std=c++2a -DSSC_BUILD_TIME="$($BUILD_TIME)" -DSSC_VERSION_HASH="$($VERSION_HASH)" -DSSC_VERSION="$($VERSION)"
-  # -I 'C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\shared' `
+  clang++ -Xlinker /NODEFAULTLIB:libcmt -I"$WORKING_BUILD_PATH\include" -L"$WORKING_BUILD_PATH\lib" src\process\win.cc src\cli\cli.cc -o $WORKING_BUILD_PATH\bin\ssc.exe -std=c++2a -DSSC_BUILD_TIME="$($BUILD_TIME)" -DSSC_VERSION_HASH="$($VERSION_HASH)" -DSSC_VERSION="$($VERSION)"
+  ## -I 'C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\shared' `
 
   if ($? -ne 1) {
     Write-Output "not ok - the build tool failed to compile. Here's what you can do..."
@@ -96,16 +96,6 @@ Function Install-Files {
   (New-Item -ItemType Directory -Force -Path "$LIB_PATH") > $null
   (New-Item -ItemType Directory -Force -Path "$SRC_PATH") > $null
   (New-Item -ItemType Directory -Force -Path "$INCLUDE_PATH") > $null
-
-  # install `.\include\*`
-  if (Test-Path -Path "$WORKING_PATH\include" -PathType Container) {
-    Copy-Item -Path "$WORKING_PATH\include\*" -Destination "$INCLUDE_PATH" -Recurse -Force -Container
-  }
-
-  # install `.\lib\*`
-  if (Test-Path -Path "$WORKING_PATH\lib" -PathType Container) {
-    Copy-Item -Path "$WORKING_PATH\lib\*" -Destination "$LIB_PATH" -Recurse -Force -Container
-  }
 
   # install `.\src\*`
   Copy-Item -Path "$WORKING_PATH\src\*" -Destination "$SRC_PATH" -Recurse -Force -Container

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -408,7 +408,7 @@ function _check_compiler_features {
     int main () { return 0; }
 EOF_CC
 
-  die $? "not ok - $CXX (`$CXX -dumpversion`) clang > 11 is required for building socket"
+  die $? "not ok - $CXX (`$CXX -dumpversion`) clang >= 11 is required for building socket"
 }
 
 function onsignal () {

--- a/src/app/app.cc
+++ b/src/app/app.cc
@@ -128,6 +128,10 @@ namespace SSC {
 #elif defined(_WIN32)
     static auto mainThread = GetCurrentThreadId();
     auto threadCallback = (LPARAM) new std::function<void()>(callback);
+    if (this->isReady) {
+      PostThreadMessage(mainThread, WM_APP, 0, threadCallback);
+      return;
+    }
     std::thread t([&, threadCallback] {
 
       // TODO(trevnorris): Need to also check a shouldExit so this doesn't run forever in case

--- a/src/app/app.cc
+++ b/src/app/app.cc
@@ -86,6 +86,10 @@ namespace SSC {
       [NSApp terminate:nil];
     }
 #elif defined(_WIN32)
+    if (isDebugEnabled()) {
+      fclose(console);
+      FreeConsole();
+    }
     PostQuitMessage(0);
 #endif
   }
@@ -203,10 +207,8 @@ namespace SSC {
     this->hInstance = (HINSTANCE) h;
 
     if (isDebugEnabled()) {
-      #if DEBUG == 1
-        AllocConsole();
-        freopen_s(&console, "CONOUT$", "w", stdout);
-      #endif
+      AllocConsole();
+      freopen_s(&console, "CONOUT$", "w", stdout);
     }
 
     // this fixes bad default quality DPI.

--- a/src/app/app.cc
+++ b/src/app/app.cc
@@ -205,22 +205,6 @@ namespace SSC {
       #endif
     }
 
-    HMODULE hUxtheme = LoadLibraryExW(L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-
-    SSC::setWindowCompositionAttribute = reinterpret_cast<SSC::SetWindowCompositionAttribute>(GetProcAddress(
-      GetModuleHandleW(L"user32.dll"),
-      "SetWindowCompositionAttribute")
-    );
-
-    if (hUxtheme) {
-      refreshImmersiveColorPolicyState = GetProcAddress(hUxtheme, MAKEINTRESOURCEA(104));
-      shouldSystemUseDarkMode = GetProcAddress(hUxtheme, MAKEINTRESOURCEA(138));
-      allowDarkModeForApp = GetProcAddress(hUxtheme, MAKEINTRESOURCEA(135));
-    }
-
-    allowDarkModeForApp(shouldSystemUseDarkMode());
-    refreshImmersiveColorPolicyState();
-
     // this fixes bad default quality DPI.
     SetProcessDPIAware();
 
@@ -245,7 +229,7 @@ namespace SSC {
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon(hInstance, IDI_APPLICATION);
     wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wcex.hbrBackground = bgBrush;
+    wcex.hbrBackground = CreateSolidBrush(RGB(0, 0, 0));
     wcex.lpszMenuName = NULL;
     wcex.lpszClassName = TEXT("DesktopApp");
     wcex.hIconSm = icon; // ico doesn't auto scale, needs 16x16 icon lol fuck you bill

--- a/src/app/app.cc
+++ b/src/app/app.cc
@@ -24,6 +24,10 @@ static dispatch_queue_t queue = dispatch_queue_create(
 #endif
 
 namespace SSC {
+#if defined(_WIN32)
+  FILE* console;
+#endif
+
   App::App () {
     this->core = new Core();
   }

--- a/src/app/app.hh
+++ b/src/app/app.hh
@@ -42,8 +42,5 @@ namespace SSC {
       void * getWindowManager () const;
   };
 
-#if defined(_WIN32)
-  extern FILE* console;
-#endif
 }
 #endif

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1564,7 +1564,13 @@ int main (const int argc, const char* argv[]) {
         fs::current_path().string(),
         [](SSC::String const &out) { stdWrite(out, false); },
         [](SSC::String const &out) { stdWrite(out, true); },
-        [](SSC::String const &code) { exit(std::stoi(code)); }
+        [](SSC::String const &code) {
+          if (std::stoi(code) != 0) {
+            log("build failed, exiting with code " + code);
+            // TODO(trevnorris): Force non-windows to exit the process.
+            exit(std::stoi(code));
+          }
+        }
       );
       process->open();
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -22,6 +22,23 @@
 #include <wrl.h>
 #pragma comment(lib, "Shlwapi.lib")
 #pragma comment(lib, "Urlmon.lib")
+#pragma comment(lib, "advapi32.lib")
+#pragma comment(lib, "comdlg32.lib")
+#pragma comment(lib, "gdi32.lib")
+#pragma comment(lib, "iphlpapi.lib")
+#pragma comment(lib, "kernel32.lib")
+#pragma comment(lib, "msvcrt.lib")
+#pragma comment(lib, "ole32.lib")
+#pragma comment(lib, "oleaut32.lib")
+#pragma comment(lib, "psapi.lib")
+#pragma comment(lib, "shell32.lib")
+#pragma comment(lib, "user32.lib")
+#pragma comment(lib, "userenv.lib")
+#pragma comment(lib, "uuid.lib")
+#pragma comment(lib, "uv_a.lib")
+#pragma comment(lib, "winspool.lib")
+#pragma comment(lib, "ws2_32.lib")
+
 #else
 #include <unistd.h>
 #endif
@@ -1474,7 +1491,11 @@ int main (const int argc, const char* argv[]) {
       auto prefix = prefixFile();
 
       flags = " -std=c++2a"
+        " -D_MT"
+        " -D_DLL"
+        " -DWIN32"
         " -DWIN32_LEAN_AND_MEAN"
+        " -Xlinker /NODEFAULTLIB:libcmt"
         " -Wno-nonportable-include-path"
         " -I" + prefix +
         " -I" + prefix + "\\include"

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1909,6 +1909,7 @@ int main (const int argc, const char* argv[]) {
         << " -DSSC_VERSION_HASH=" << SSC::VERSION_HASH_STRING
       ;
 
+      // TODO(trevnorris): Output build string on debug builds.
       // log(compileCommand.str());
 
       auto r = exec(compileCommand.str());

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -366,7 +366,7 @@ void runIOSSimulator (const fs::path& path, Map& settings) {
 };
 
 static String getCxxFlags() {
-  auto flags = getEnv("CXX_FLAGS");
+  auto flags = getEnv("CXXFLAGS");
   return flags.size() > 0 ? " " + flags : "";
 }
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1505,6 +1505,7 @@ int main (const int argc, const char* argv[]) {
 
       files += prefixFile("src\\init.cc");
       files += prefixFile("src\\app\\app.cc");
+      files += prefixFile("src\\core\\bluetooth.cc");
       files += prefixFile("src\\core\\core.cc");
       files += prefixFile("src\\core\\fs.cc");
       files += prefixFile("src\\core\\javascript.cc");

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -74,7 +74,11 @@ void log (const String s) {
 
   auto now = system_clock::now();
   auto delta = duration_cast<milliseconds>(now - start).count();
+  #ifdef _WIN32
+  std::cout << "• " << s << " " << delta << "ms" << std::endl;
+  #else
   std::cout << "• " << s << " \033[0;32m+" << delta << "ms\033[0m" << std::endl;
+  #endif
   start = std::chrono::system_clock::now();
 }
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -85,7 +85,7 @@ inline String prefixFile (String s) {
   }
 
   String local = getEnv ("LOCALAPPDATA");
-  return String(local + "\\Programs\\socketsupply\\" + s + " ");
+  return String("\"" + local + "\\Programs\\socketsupply\\" + s + "\" ");
 }
 
 inline String prefixFile () {
@@ -1497,10 +1497,10 @@ int main (const int argc, const char* argv[]) {
         " -DWIN32_LEAN_AND_MEAN"
         " -Xlinker /NODEFAULTLIB:libcmt"
         " -Wno-nonportable-include-path"
-        " -I" + prefix +
-        " -I" + prefix + "\\include"
-        " -I" + prefix + "\\src"
-        " -L" + prefix + "\\lib"
+        " -I\"" + prefix + "\""
+        " -I\"" + prefix + "\\include\""
+        " -I\"" + prefix + "\\src\""
+        " -L\"" + prefix + "\\lib\""
       ;
 
       files += prefixFile("src\\init.cc");
@@ -1562,7 +1562,9 @@ int main (const int argc, const char* argv[]) {
 
         // @TODO(jwerle): use `setEnv()` if #148 is closed
         #if _WIN32
-          setEnv("PREFIX=prefix");
+          std::string prefix_ = "PREFIX=";
+          prefix_ += prefix;
+          setEnv(prefix_.c_str());
         #else
           setenv("PREFIX", prefix, 1);
         #endif

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -163,6 +163,7 @@ int runApp (const fs::path& path, const String& args) {
 }
 
 void runIOSSimulator (const fs::path& path, Map& settings) {
+  #ifndef _WIN32
   if (settings["ios_simulator_device"].size() == 0) {
     log("error: 'ios_simulator_device' option is empty");
     exit(1);
@@ -357,6 +358,7 @@ void runIOSSimulator (const fs::path& path, Map& settings) {
     }
     exit(rlaunchApp.exitCode);
   }
+  #endif
 };
 
 static String getCxxFlags() {

--- a/src/common.hh
+++ b/src/common.hh
@@ -65,6 +65,11 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
+
+#undef _WINSOCKAPI_
+#define _WINSOCKAPI_
+
+#include <WinSock2.h>
 #include <windows.h>
 
 #include <dwmapi.h>

--- a/src/common.hh
+++ b/src/common.hh
@@ -181,7 +181,13 @@ namespace SSC {
   inline const auto VERSION_STRING = ToString(STR_VALUE(SSC_VERSION));
 
   const char* getSettingsSource ();
-  bool isDebugEnabled ();
+  inline constexpr bool isDebugEnabled () {
+    #if defined(DEBUG) && DEBUG
+      return true;
+    #else
+      return false;
+    #endif
+  }
   const char* getDevHost ();
   int getDevPort ();
 

--- a/src/core/core.hh
+++ b/src/core/core.hh
@@ -1,11 +1,7 @@
 #ifndef SSC_CORE_CORE_H
 #define SSC_CORE_CORE_H
 
-#if defined(_WIN32)
-#undef _WINSOCKAPI_
-#define _WINSOCKAPI_
-#endif
-
+#include "../common.hh"
 #include <uv.h>
 
 #if defined(__APPLE__)
@@ -36,10 +32,13 @@
 #pragma comment(lib, "version.lib")
 #pragma comment(lib, "user32.lib")
 #pragma comment(lib, "WebView2LoaderStatic.lib")
+#pragma comment(lib, "Ws2_32.lib")
+#pragma comment(lib, "iphlpapi.lib")
+#pragma comment(lib, "psapi.lib")
+#pragma comment(lib, "userenv.lib")
 #pragma comment(lib, "uv_a.lib")
 #endif
 
-#include "../common.hh"
 #include "json.hh"
 #include "runtime-preload.hh"
 

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -814,9 +814,6 @@ MAIN {
 
   auto defaultWindow = windowManager.createDefaultWindow(WindowOptions { });
 
-  // windowManager.getOrCreateWindow(0);
-  windowManager.getOrCreateWindow(1);
-
   defaultWindow->show(EMPTY_SEQ);
 
   if (_port > 0) {

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -10,7 +10,7 @@
 #if defined(_WIN32)
 #define MAIN                         \
   static const int argc = __argc;    \
-  static const char** argv = __argv; \
+  static char** argv = __argv;       \
   int CALLBACK WinMain (             \
     _In_ HINSTANCE instanceId,       \
     _In_ HINSTANCE hPrevInstance,    \

--- a/src/init.cc
+++ b/src/init.cc
@@ -7,13 +7,6 @@ namespace SSC {
     return source;
   }
 
-  bool isDebugEnabled () {
-  #if defined(DEBUG) && DEBUG
-    return true;
-  #endif
-    return false;
-  }
-
   const char* getDevHost () {
     static const char* host = STR_VALUE(HOST);
     return host;

--- a/src/process/unix.cc
+++ b/src/process/unix.cc
@@ -18,75 +18,7 @@ namespace SSC {
 static SSC::MessageCallback exitCallback;
 static SSC::StringStream initial;
 
-ExecOutput exec (SSC::String command) {
-  command = command + " 2>&1";
-
-  ExecOutput eo;
-  FILE* pipe;
-  size_t count;
-  int exitCode = 0;
-  const int bufsize = 128;
-  std::array<char, 128> buffer;
-
-  #ifdef _WIN32
-    //
-    // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/popen-wpopen?view=msvc-160
-    // _popen works fine in a console application... ok fine that's all we need it for... thanks.
-    //
-    pipe = _popen((const char*) command.c_str(), "rt");
-  #else
-    pipe = popen((const char*) command.c_str(), "r");
-  #endif
-
-  if (pipe == NULL) {
-    std::cout << "error: unable to open the command" << std::endl;
-    exit(1);
-  }
-
-  do {
-    if ((count = fread(buffer.data(), 1, bufsize, pipe)) > 0) {
-      eo.output.insert(eo.output.end(), std::begin(buffer), std::next(std::begin(buffer), count));
-    }
-  } while (count > 0);
-
-  #ifdef _WIN32
-    exitCode = _pclose(pipe);
-  #else
-    exitCode = pclose(pipe);
-  #endif
-
-  if (!WIFEXITED(exitCode) || exitCode != 0) {
-    auto status = WEXITSTATUS(exitCode);
-    if (status && exitCode) {
-      exitCode = status;
-    }
-  }
-
-  eo.exitCode = exitCode;
-
-  return eo;
-}
-
 Process::Data::Data() noexcept : id(-1) {}
-
-Process::Process(
-  const SSC::String &command,
-  const SSC::String &argv,
-  const SSC::String &path,
-  SSC::MessageCallback read_stdout,
-  SSC::MessageCallback read_stderr,
-  SSC::MessageCallback on_exit,
-  bool open_stdin,
-  const Config &config) noexcept
-    : closed(true),
-      open_stdin(true),
-      read_stdout(std::move(read_stdout)),
-      read_stderr(std::move(read_stderr)),
-      on_exit(std::move(on_exit)) {
-  this->command = command;
-  this->argv = argv;
-  this->path = path;
-}
 
 Process::Process(
   const std::function<int()> &function,
@@ -256,16 +188,6 @@ Process::id_type Process::open(const SSC::String &command, const SSC::String &pa
 
     return execl("/bin/sh", "/bin/sh", "-c", command_c_str, nullptr);
   });
-}
-
-bool Process::write (const SSC::String &s) {
-  return Process::write(s.c_str(), s.size());
-}
-
-void Process::open () noexcept {
-  if (this->command.size() == 0) return;
-  open(this->command + this->argv, this->path);
-  read();
 }
 
 void Process::read() noexcept {

--- a/src/process/win.cc
+++ b/src/process/win.cc
@@ -1,9 +1,9 @@
+#include "process.hh"
+
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
 #include <tlhelp32.h>
-
-#include "process.hh"
 
 namespace SSC {
 

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -699,8 +699,6 @@ namespace SSC {
               window,
               Microsoft::WRL::Callback<IConHandler>(
                 [&, preload](HRESULT result, ICoreWebView2Controller* c) -> HRESULT {
-                  hide("");
-
                   if (c != nullptr) {
                     controller = c;
                     controller->get_CoreWebView2(&webview);

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -1034,7 +1034,7 @@ namespace SSC {
     });
   }
 
-  SSC::string Window::getTitle () {
+  SSC::String Window::getTitle () {
     // TODO: implement.
   }
 

--- a/src/window/window.hh
+++ b/src/window/window.hh
@@ -216,7 +216,6 @@ namespace SSC {
               status = WindowStatus::WINDOW_CLOSING;
               Window::close(code);
               status = WindowStatus::WINDOW_CLOSED;
-              // gc();
             }
           }
 
@@ -523,10 +522,6 @@ namespace SSC {
   using IRecHandler = ICoreWebView2WebMessageReceivedEventHandler;
   using IArgs = ICoreWebView2WebMessageReceivedEventArgs;
 
-	// constexpr COLORREF darkBkColor = 0x383838;
-	// constexpr COLORREF darkTextColor = 0xFFFFFF;
-	// static HBRUSH hbrBkgnd = nullptr;
-
   enum WINDOWCOMPOSITIONATTRIB {
     WCA_UNDEFINED = 0,
     WCA_NCRENDERING_ENABLED = 1,
@@ -563,18 +558,6 @@ namespace SSC {
     PVOID pvData;
     SIZE_T cbData;
   };
-
-  using RefreshImmersiveColorPolicyState = VOID(WINAPI*)();
-  using SetWindowCompositionAttribute = BOOL(WINAPI *)(HWND hWnd, WINDOWCOMPOSITIONATTRIBDATA*);
-  using ShouldSystemUseDarkMode = BOOL(WINAPI*)();
-  using AllowDarkModeForApp = BOOL(WINAPI*)(BOOL allow);
-
-  extern RefreshImmersiveColorPolicyState refreshImmersiveColorPolicyState;
-  extern SetWindowCompositionAttribute setWindowCompositionAttribute;
-  extern ShouldSystemUseDarkMode shouldSystemUseDarkMode;
-  extern AllowDarkModeForApp allowDarkModeForApp;
-
-  auto bgBrush = CreateSolidBrush(RGB(0, 0, 0));
 #endif
 }
 #endif


### PR DESCRIPTION
This can build the tests of the `ipc-cleanup` branch in the `io` repo, but then the test runner fails hard when it attempts to execute the tests. Going to investigate if that has anything to do with `ssc` or if it's just because of the changes to the `io` repo.

Also for some reason this patch fixes 2 tests in the `io` repo's `ipc-cleanup` branch on Linux.

Side note: we might need to do something similar to ab366a5 for Linux. As far as I can see it currently also won't handle spaces in paths.