### PR TITLE
typed config

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -115,7 +115,6 @@ function _build_cli {
 
   quiet "$CXX"                                 \
     "$BUILD_DIR/$arch-$platform"/cli/*.o       \
-    "$root/src/init.cc"                        \
     "${cflags[@]}" "${ldflags[@]}"             \
     -o "$BUILD_DIR/$arch-$platform/bin/ssc"
 
@@ -242,7 +241,7 @@ function _prepare {
   echo "# preparing directories..."
   rm -rf "$ASSETS_DIR"
 
-  mkdir -p "$ASSETS_DIR"/{lib,src,include,objects}
+  mkdir -p "$ASSETS_DIR"/{lib,src,bin,include,objects}
   mkdir -p "$ASSETS_DIR"/{lib,objects}/"$(uname -m)-desktop"
 
   if [[ "$(uname -s)" = "Darwin" ]]; then

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -385,9 +385,9 @@ static Map getConfig (fs::path p) {
 
   compileConfigCommand
     << getEnv("CXX")
-    << " -std=c++2a -v"
+    << " -std=c++2a"
     << " -I" << prefixFile()
-    << " -I" << prefixFile("src/config.hh")
+    << " -I" << prefixFile("src")
     << " -I" << p
     << " -I" << fs::current_path()
     << " " << prefixFile("src/config.cc")

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1357,7 +1357,7 @@ constexpr auto gDefaultConfig = R"CONFIG(
 // Default configuration file for ssc v{{ssc_version}}.
 //
 
-Config config {
+config = {
   // The shell command to execute when building an application. This is the most
   // important command in this file. This will do all the heavy lifting and should
   // handle 99.9% of your use cases for moving files into place or tweaking

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1351,153 +1351,146 @@ constexpr auto gStoryboardLaunchScreen = R"XML(<?xml version="1.0" encoding="UTF
 )XML";
 
 constexpr auto gDefaultConfig = R"CONFIG(
-#
-# Default configuration file for ssc v{{ssc_version}}. Delete what you don't need.
-#
+// vim: set syntax=c:
 
-# Shell command to build an application.
-# build: bash build.sh
+//
+// Default configuration file for ssc v{{ssc_version}}.
+//
 
-# A unique ID that identifies the bundle (used by all app stores).
-bundle_identifier: com.beepboop
+Config config {
+  // The shell command to execute when building an application. This is the most
+  // important command in this file. This will do all the heavy lifting and should
+  // handle 99.9% of your use cases for moving files into place or tweaking
+  // platform-specific artifacts.
 
-# A string that gets used in the about dialog and package meta info.
-copyright: (c) Beep Boop Corp. 1985
+  .build = "bash build.sh",
 
-# Advanced Compiler Settings for debug purposes (ie C++ compiler -g, etc).
-debug_flags: -g
+  // A unique ID that identifies the bundle (used by all app stores).
+  .bundle_identifier = "com.beepboop",
 
-# A short description of the app.
-description: A UI for the beep boop network
+  // A string that gets used in the about dialog and package meta info.
+  .copyright = "(c) Beep Boop Corp. 1985",
 
-# An array of environment variables, separated by commas.
-# env: USER, TMPDIR, PWD
+  // Advanced Compiler Settings for debug purposes (ie C++ compiler -g, etc).
+  debug = {
+    .flags = "-g"
+  },
 
-# The name of the file to be output.
-executable: boop
+  // A short description of the app.
+  .description = "A UI for the beep boop network",
 
-# Advanced Compiler Settings (ie C++ compiler -02, -03, etc).
-flags: -O3
+  // An list of environment variables, separated by commas.
+  .env = "USER, TMPDIR, PWD",
 
-# Set the limit of files that can be opened by your process.
-file_limit: 1024
+  // The name of the file to be output.
+  .executable = "boop",
 
-# The initial height of the first window.
-height: 750
+  // Advanced Compiler Settings (ie C++ compiler -02, -03, etc).
+  .flags = "-O3",
 
-# A directory is where your application's code is located.
-# input: src
+  // Set the limit of files that can be opened by your process.
+  .file_limit = 1024,
 
-# Localization
-# lang: en-us
+  .window = {
+    // The initial height of the first window.
+    .height = 750,
 
-# A String used in the about dialog and meta info.
-# maintainer: Beep Boop Corp.
+    // The initial width of the first window.
+    .width = 1024
+  },
 
-# The name of the program
-name: beepboop
+  // A directory is where your application's code is located.
+  .input = "src",
 
-# The binary output path. It's recommended to add this path to .gitignore.
-output: dist
+  // Localization
+  .lang = "en-us",
 
-# TODO: maybe the user doesn't need to know about this?
-# revision: 123
+  // A String used in the about dialog and meta info.
+  .maintainer = "Beep Boop Corp.",
 
-# The initial title of the window (can have spaces and symbols etc).
-title: Beep Boop
+  // The name of the program
+  .name = "beepboop",
 
-# A string that indicates the version of the application. It should be a semver triple like 1.0.0
-version: 0.0.1
+  // The binary output path. It's recommended to add this path to .gitignore.
+  .output = "dist",
 
-# The initial width of the first window.
-width: 1024
+  // TODO: maybe the user doesn't need to know about this? 
+  .revision = 123,
 
-#
-# Windows
-# ---
-#
+  // A string that indicates the version of the application. It should be a semver triple like 1.0.0
+  .version = "0.0.1",
 
-# The command to execute to spawn the “back-end” process.
-# win_cmd: beepboop.exe
+  // Files that should be added to the compile step.
+  .files = "native-module1.cc native-module2.cc",
 
-# The icon to use for identifying your app on Windows.
-# win_icon:
+  .win = {
+    // The command to execute to spawn the “back-end” process.
+    .cmd = "beepboop.exe",
 
-# The icon to use for identifying your app on Windows.
-# win_logo: src/icons/icon.png
+    // The icon to use for identifying your app on Windows.
+    .icon = "",
 
-# A relative path to the pfx file used for signing.
-# win_pfx: certs/cert.pfx
+    // The icon to use for identifying your app on Windows.
+    .logo = "src/icons/icon.png",
 
-# The signing information needed by the appx api.
-# win_publisher: CN=Beep Boop Corp., O=Beep Boop Corp., L=San Francisco, S=California, C=US
+    // A relative path to the pfx file used for signing.
+    .pfx = "certs/cert.pfx",
 
-#
-# Linux
-# ---
-#
+    // The signing information needed by the appx api.
+    .publisher = "CN=Beep Boop Corp., O=Beep Boop Corp., L=San Francisco, S=California, C=US"
+  },
 
-# Helps to make your app searchable in Linux desktop environments.
-# linux_categories: Developer Tools
+  .linux = {
+    // Helps to make your app searchable in Linux desktop environments.
+    .categories = "Developer Tools",
 
-# The command to execute to spawn the "back-end" process.
-# linux_cmd: beepboop
+    // The command to execute to spawn the "back-end" process.
+    .cmd = "beepboop",
 
-# The icon to use for identifying your app in Linux desktop environments.
-# linux_icon: src/icon.png
+    // The icon to use for identifying your app in Linux desktop environments.
+    .icon = "src/icon.png"
+  },
 
-#
-# MacOS
-# ---
-#
+  .mac = {
+    // Mac App Store icon
+    .appstore_icon = "src/icons/icon.png",
 
-# macOS code signing guide: https://sockets.sh/guides/#macos-1
+    // A category in the App Store
+    .category = "",
 
-# Mac App Store icon
-# mac_appstore_icon: src/icons/icon.png
+    // The command to execute to spawn the "back-end" process.
+    .cmd = "",
 
-# A category in the App Store
-# mac_category:
+    // The icon to use for identifying your app on MacOS.
+    .icon = "",
 
-# The command to execute to spawn the "back-end" process.
-# mac_cmd:
+    // TODO description & value (signing guide: https://sockets.sh/guides/#macos-1)
+    .sign = "",
 
-# The icon to use for identifying your app on MacOS.
-# mac_icon:
+    // TODO description & value
+    .codesign_identity = "",
 
-# TODO description & value
-# mac_sign:
+    // TODO description & value
+    .sign_paths = ""
+  },
 
-# TODO description & value
-# mac_codesign_identity:
-
-# TODO description & value
-# mac_sign_paths:
-
-#
-# iOS
-# ---
-#
-
-# iOS code signing guide: https://sockets.sh/guides/#ios-1
-
-# TODO description & value
-# ios_codesign_identity:
-
-# Describes how Xcode should export the archive. Available options: app-store, package, ad-hoc, enterprise, development, and developer-id.
-# ios_distribution_method: ad-hoc
-
-# A path to the provisioning profile used for signing iOS app.
-# ios_provisioning_profile:
-
-# which device to target when building for the simulator
-# ios_simulator_device: iPhone 13
-)CONFIG";
+  .ios = {
+    // signing guide: https://sockets.sh/guides/#ios-1
+    .codesign_identity = "",
+    // Describes how Xcode should export the archive. Available options: app-store, package, ad-hoc, enterprise, development, and developer-id.
+    .distribution_method = "ad-hoc",
+    // A path to the provisioning profile used for signing iOS app.
+    .provisioning_profile = "",
+    // which device to target when building for the simulator
+    .simulator_device = "iPhone 14"
+  }
+};)CONFIG";
 
 constexpr auto gDefaultGitignore = R"GITIGNORE(
 # Logs
 logs
 *.log
+*.dat
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/src/common.hh
+++ b/src/common.hh
@@ -1,6 +1,8 @@
 #ifndef SSC_CORE_COMMON_H
 #define SSC_CORE_COMMON_H
 
+#include "config.hh"
+
 // macOS/iOS
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
@@ -346,8 +348,8 @@ namespace SSC {
     map["flags"] = std::string(config.flags);
     map["file_limit"] = std::to_string(config.file_limit);
     map["debug_flags"] = std::string(config.debug.flags);
-    map["window_height"] = std::to_string(config.window.height);
-    map["window_width"] = std::to_string(config.window.width);
+    map["window_height"] = std::string(config.window.height);
+    map["window_width"] = std::string(config.window.width);
     return map;
   }
 

--- a/src/common.hh
+++ b/src/common.hh
@@ -180,7 +180,7 @@ namespace SSC {
   inline const auto VERSION_HASH_STRING = ToString(STR_VALUE(SSC_VERSION_HASH));
   inline const auto VERSION_STRING = ToString(STR_VALUE(SSC_VERSION));
 
-  const char* getSettingsSource ();
+  const Map getSettingsSource ();
   inline constexpr bool isDebugEnabled () {
     #if defined(DEBUG) && DEBUG
       return true;
@@ -303,8 +303,55 @@ namespace SSC {
     #endif
   } platform;
 
-  inline const Vector<String>
-  splitc (const String& s, const char& c) {
+  inline Map configToMap (Config& config) {
+    Map map; // flatten values so they can be accessed in the templates
+    map["win_cmd"] = std::string(config.win.cmd);
+    map["win_icon"] = std::string(config.win.icon);
+    map["win_logo"] = std::string(config.win.logo);
+    map["win_pfx"] = std::string(config.win.pfx);
+    map["win_publisher"] = std::string(config.win.publisher);
+
+    map["linux_categories"] = std::string(config.linux.categories);
+    map["linux_cmd"] = std::string(config.linux.cmd);
+    map["linux_icon"] = std::string(config.linux.icon);
+
+    map["ios_icon"] = std::string(config.ios.icon);
+    map["ios_codesign_identity"] = std::string(config.ios.codesign_identity);
+    map["ios_distribution_method"] = std::string(config.ios.distribution_method);
+    map["ios_provisioning_profile"] = std::string(config.ios.provisioning_profile);
+    map["ios_simulator_device"] = std::string(config.ios.simulator_device);
+
+    map["mac_cmd"] = std::string(config.mac.cmd);
+    map["mac_icon"] = std::string(config.mac.icon);
+    map["mac_appstore_icon"] = std::string(config.mac.appstore_icon);
+    map["mac_appstore_category"] = std::string(config.mac.appstore_category);
+    map["mac_codesign_identity"] = std::string(config.mac.codesign_identity);
+    map["mac_sign"] = std::string(config.mac.sign);
+    map["mac_sign_paths"] = std::string(config.mac.sign_paths);
+
+    map["bundle_identifier"] = std::string(config.bundle_identifier);
+    map["version"] = std::string(config.version);
+    map["revision"] = std::string(config.revision);
+    map["copyright"] = std::string(config.copyright);
+    map["description"] = std::string(config.description);
+    map["name"] = std::string(config.name);
+    map["maintainer"] = std::string(config.maintainer);
+    map["lang"] = std::string(config.lang);
+    map["env"] = std::string(config.env);
+
+    map["build"] = std::string(config.build);
+    map["input"] = std::string(config.input);
+    map["output"] = std::string(config.output);
+    map["executable"] = std::string(config.executable);
+    map["flags"] = std::string(config.flags);
+    map["file_limit"] = std::to_string(config.file_limit);
+    map["debug_flags"] = std::string(config.debug.flags);
+    map["window_height"] = std::to_string(config.window.height);
+    map["window_width"] = std::to_string(config.window.width);
+    return map;
+  }
+
+  inline const Vector<String> splitc (const String& s, const char& c) {
     String buff;
     Vector<String> vec;
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -12,6 +12,7 @@ int main (const int argc, const char* argv[]) {
 
   using namespace SSC;
 
+  Config config;
   #include "ssc.conf" // NOLINT
 
   ws.write((char*) &config, sizeof(Config));

--- a/src/config.cc
+++ b/src/config.cc
@@ -1,0 +1,23 @@
+#include <fstream>
+#include <iostream>
+#include <filesystem>
+#include "config.hh"
+
+int main (const int argc, const char* argv[]) {
+  auto base = std::filesystem::path(argv[1]);
+  std::filesystem::path dest = { base / ".ssc.dat"};
+
+  std::ofstream ws(dest, std::ios::out | std::ios::binary);
+  if (!ws) return 1;
+
+  using namespace SSC;
+
+  #include "ssc.conf" // NOLINT
+
+  ws.write((char*) &config, sizeof(Config));
+  ws.close();
+
+  if (!ws.good()) return 1;
+
+  return 0;
+}

--- a/src/config.hh
+++ b/src/config.hh
@@ -1,0 +1,71 @@
+#include <stdint.h>
+
+namespace SSC {
+  typedef char ConfigString[1024];
+  typedef int32_t ConfigInt;
+  typedef bool ConfigBool;
+
+  struct Config {
+    struct {
+      ConfigString cmd;
+      ConfigString icon;
+      ConfigString logo;
+      ConfigString pfx;
+      ConfigString publisher;
+    } win;
+
+    struct {
+      ConfigString categories;
+      ConfigString cmd;
+      ConfigString icon;
+    } linux;
+
+    struct {
+      ConfigString icon;
+      ConfigString codesign_identity;
+      ConfigString distribution_method = "ad-hoc";
+      ConfigString provisioning_profile;
+      ConfigString simulator_device;
+    } ios;
+
+    struct {
+      ConfigString cmd;
+      ConfigString icon;
+      ConfigString appstore_icon;
+      ConfigString appstore_category;
+      ConfigString codesign_identity;
+      ConfigString sign;
+      ConfigString sign_paths;
+    } mac;
+
+    ConfigString bundle_identifier;
+    ConfigString version;
+    ConfigString revision;
+    ConfigString copyright;
+    ConfigString description;
+    ConfigString name;
+    ConfigString maintainer;
+    ConfigString lang = "en-us";
+    ConfigString env;
+
+    ConfigString build;
+    ConfigString input;
+    ConfigString output;
+    ConfigString executable;
+    ConfigString flags;
+
+    ConfigInt file_limit = 1024;
+
+    struct {
+      ConfigString flags;
+    } debug;
+
+    struct {
+      ConfigInt height = 750;
+      ConfigInt width = 1024;
+      ConfigString title;
+    } window;
+
+    ConfigBool readFromDisk = false;
+  };
+}

--- a/src/config.hh
+++ b/src/config.hh
@@ -61,9 +61,8 @@ namespace SSC {
     } debug;
 
     struct {
-      ConfigInt height = 750;
-      ConfigInt width = 1024;
-      ConfigString title;
+      ConfigString height = "80%";
+      ConfigString width = "80%";
     } window;
 
     ConfigBool readFromDisk = false;

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -65,8 +65,6 @@ MAIN {
   WindowManager windowManager(app);
 
   app.setWindowManager(&windowManager);
-
-  const auto _settings = SSC::getSettingsSource();
   constexpr auto _port = PORT;
 
   const SSC::String OK_STATE = "0";
@@ -74,7 +72,7 @@ MAIN {
   const SSC::String EMPTY_SEQ = SSC::String("");
 
   auto cwd = app.getCwd();
-  app.appData = parseConfig(decodeURIComponent(_settings));
+  app.appData = SSC::getSettingsSource();
 
   SSC::String suffix = "";
 
@@ -261,8 +259,8 @@ MAIN {
     return exitCode;
   }
 
-  String initialHeight = app.appData["height"].size() > 0 ? app.appData["height"] : "100%";
-  String initialWidth = app.appData["width"].size() > 0 ? app.appData["width"] : "100%";
+  String initialHeight = app.appData["window_height"].size() > 0 ? app.appData["window_height"] : "100%";
+  String initialWidth = app.appData["window_width"].size() > 0 ? app.appData["window_width"] : "100%";
 
   bool isHeightInPercent = initialHeight.back() == '%';
   bool isWidthInPercent = initialWidth.back() == '%';
@@ -370,8 +368,9 @@ MAIN {
         return;
       }
 
-      if (message.name == "getConfig") {
-        window->resolvePromise(seq, OK_STATE, _settings);
+      if (message.name == "config") {
+        auto key = message.get("key");
+        window->resolvePromise(seq, OK_STATE, app.appData[key]);
         return;
       }
     });

--- a/src/init.cc
+++ b/src/init.cc
@@ -2,9 +2,9 @@
 
 // These rely on project-specific, compile-time variables.
 namespace SSC {
-  const char* getSettingsSource () {
-    static const char* source = STR_VALUE(SSC_SETTINGS);
-    return source;
+  const Map getSettingsSource () {
+    #include "ssc.conf" // NOLINT
+    return configToMap(config);
   }
 
   const char* getDevHost () {

--- a/src/init.cc
+++ b/src/init.cc
@@ -3,6 +3,7 @@
 // These rely on project-specific, compile-time variables.
 namespace SSC {
   const Map getSettingsSource () {
+    Config config;
     #include "ssc.conf" // NOLINT
     return configToMap(config);
   }

--- a/src/process/process.hh
+++ b/src/process/process.hh
@@ -18,7 +18,7 @@ namespace SSC {
   };
 
   // Additional parameters to Process constructors.
-  struct Config {
+  struct ProcessConfig {
     // Buffer size for reading stdout and stderr. Default is 131072 (128 kB).
     std::size_t buffer_size = 131072;
     // Set to true to inherit file descriptors from parent process. Default is false.
@@ -134,7 +134,7 @@ namespace SSC {
       MessageCallback read_stderr = nullptr,
       MessageCallback on_exit = nullptr,
       bool open_stdin = true,
-      const Config &config = {}) noexcept
+      const ProcessConfig &config = {}) noexcept
       : closed(true),
         open_stdin(true),
         read_stdout(std::move(read_stdout)),
@@ -154,7 +154,7 @@ namespace SSC {
       MessageCallback read_stderr = nullptr,
       MessageCallback on_exit = nullptr,
       bool open_stdin = true,
-      const Config &config = {}) noexcept;
+      const ProcessConfig &config = {}) noexcept;
 #endif
 
     ~Process() noexcept {
@@ -200,7 +200,7 @@ namespace SSC {
     bool open_stdin;
     std::mutex stdin_mutex;
 
-    Config config;
+    ProcessConfig config;
 
     std::unique_ptr<fd_type> stdout_fd, stderr_fd, stdin_fd;
 

--- a/src/process/unix.cc
+++ b/src/process/unix.cc
@@ -25,7 +25,7 @@ Process::Process(
   MessageCallback read_stdout,
   MessageCallback read_stderr,
   MessageCallback on_exit,
-  bool open_stdin, const Config &config
+  bool open_stdin, const ProcessConfig &config
 ) noexcept:
   closed(true),
   read_stdout(std::move(read_stdout)),

--- a/src/process/win.cc
+++ b/src/process/win.cc
@@ -105,7 +105,7 @@ Process::id_type Process::open(const SSC::String &command, const SSC::String &pa
   if (stdin_fd || stdout_fd || stderr_fd)
     startup_info.dwFlags |= STARTF_USESTDHANDLES;
 
-  if (config.show_window != Config::ShowWindow::show_default) {
+  if (config.show_window != ProcessConfig::ShowWindow::show_default) {
     startup_info.dwFlags |= STARTF_USESHOWWINDOW;
     startup_info.wShowWindow = static_cast<WORD>(config.show_window);
   }


### PR DESCRIPTION
This makes `ssc.conf` an actual program. So now its type safe. There are some other obvious upsides and escape hatches. The only requirement of the program is that is produces a variable called "config".

```c++
Config config {
  .build = "node bin/build.js",
  .bundle_identifier = "co.socketsupply.simulator",
  .copyright = "(c) Socket Supply Co.",
  .description = "A UI for visualizing Stream Relay Protocol simulations",
  .env = "USER, TMPDIR, PWD",
  .executable = "srv",
  .flags = "-O3",
  .debug = {
    .flags = "-g"
  },
  .file_limit = 1024,
  .window = {
    .height = 750,
    .width = 1024,
  },
  .lang = "en-us",
  .maintainer = "Beep Boop Corp.",
  .name = "srv",
  .output = "dist",
  .version = "0.0.1"
};
```