### PR TITLE
add a link to config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ UDP and File I/O.
 
 Please read (and contribute to) the documentation [here](https://sockets.sh).
 
+* [ssc.config](https://sockets.sh/config/)
+
 ### Roadmap
 
 ```mermaid


### PR DESCRIPTION
Link to the `ssc.config` docs directly. I had trouble finding that page on the main website.

related to #60 