### PR TITLE
Fix crash and remove opaque ptr

### DIFF
--- a/src/app/app.cc
+++ b/src/app/app.cc
@@ -173,11 +173,11 @@ namespace SSC {
     return cwd;
   }
 
-  void App::setWindowManager (void *windowManager) {
+  void App::setWindowManager (WindowManager* windowManager) {
     this->windowManager = windowManager;
   }
 
-  void * App::getWindowManager () const {
+  WindowManager* App::getWindowManager () const {
     return this->windowManager;
   }
 

--- a/src/app/app.hh
+++ b/src/app/app.hh
@@ -4,10 +4,13 @@
 #include "../core/core.hh"
 #include "../ipc/ipc.hh"
 
+
 namespace SSC {
+  class WindowManager;
+
   class App {
     // an opaque pointer to the configured `WindowManager<Window, App>`
-    void *windowManager = nullptr;
+    WindowManager *windowManager = nullptr;
     public:
       static inline std::atomic<bool> isReady = false;
 
@@ -38,8 +41,8 @@ namespace SSC {
       void restart ();
       void dispatch (std::function<void()>);
       SSC::String getCwd ();
-      void setWindowManager (void *);
-      void * getWindowManager () const;
+      void setWindowManager (WindowManager*);
+      WindowManager* getWindowManager () const;
   };
 
 }

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -61,8 +61,17 @@ void navigate (Window* window, const String &cwd, const String &seq, const Strin
 // which on windows is hInstance, on mac and linux this is just an int.
 //
 MAIN {
-  App app(instanceId);
-  WindowManager windowManager(app);
+  // Singletons should be static to remove some possible race conditions in
+  // their instantiation and destruction.
+  static App app(instanceId);
+  static WindowManager windowManager(app);
+
+  // TODO(trevnorris): Since App is a singleton, follow the CppCoreGuidelines
+  // better in how it's handled in the future.
+  // For now make a pointer reference since there is some member variable name
+  // collision in the call to shutdownHandler when it's being called from the
+  // windowManager instance.
+  static App* app_ptr = &app;
 
   app.setWindowManager(&windowManager);
   constexpr auto _port = PORT;
@@ -790,7 +799,7 @@ MAIN {
       process->kill(pid);
     }
     windowManager.destroy();
-    app.kill();
+    app_ptr->kill();
 
     exit(code);
   };

--- a/src/window/linux.cc
+++ b/src/window/linux.cc
@@ -28,7 +28,7 @@ namespace SSC {
     };
 
     this->bridge->router.map("window.eval", [=](auto message, auto router, auto reply) {
-      auto windowManager = reinterpret_cast<WindowManager *>(app.getWindowManager());
+      WindowManager* windowManager = app.getWindowManager();
       if (windowManager == nullptr) {
         // @TODO(jwerle): print warning
         return;


### PR DESCRIPTION
```
window: use unique app ptr in lambda

When shutdownHandler called from the windowManager instance (assigned as
onExit) the member variable "app" is used instead of the stack allocated
App instance.

Trying to access the member variable app after running
windowManager.destroy() causes a segfault since the reference on the
WindowManager instance is no longer valid.

To get around this assign the App instance to a static pointer variable
and use that instead.

Make the App and WindowManager instances static to simplify
initialization order and remove the possibility for a race condition.
```
```
app: don't use opaque ptr

No reason to store the WindowManager instance as an opaque pointer since
none of the member methods of WindowManager are being used. Instead
forward declare it and store the pointer directly.
```