### PR TITLE
Custom build source directory with 'SOCKET_HOME'

### DIFF
--- a/bin/build-runtime-library.sh
+++ b/bin/build-runtime-library.sh
@@ -78,7 +78,7 @@ mkdir -p "$output_directory"
 
 cd "$(dirname "$output_directory")"
 
-echo "# building runtime static libary"
+echo "# building runtime static libary ($arch-$platform)"
 for source in "${sources[@]}"; do
   declare src_directory="$root/src"
   declare object="${source/.cc/.o}"

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 declare root="$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)"
 declare arch=""
 declare platform=""

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -7,10 +7,10 @@ LIPO=""
 declare CWD=`pwd`
 declare PREFIX="${PREFIX:-"/usr/local"}"
 declare BUILD_DIR="$CWD/build"
-declare SOCKET_DIR="${SOCKET_DIR:-"${XDG_DATA_HOME:-"$HOME/.local/share"}/socket"}"
+declare SOCKET_HOME="${SOCKET_HOME:-"${XDG_DATA_HOME:-"$HOME/.local/share"}/socket"}"
 
 if [ -n "$LOCALAPPDATA" ]; then
-  SOCKET_DIR="$LOCALAPPDATA/Programs/socketsupply"
+  SOCKET_HOME="$LOCALAPPDATA/Programs/socketsupply"
 fi
 
 if [ ! "$CXX" ]; then
@@ -238,13 +238,13 @@ function _prebuild_ios_simulator_main () {
 
 function _prepare {
   echo "# preparing directories..."
-  rm -rf "$SOCKET_DIR"
+  rm -rf "$SOCKET_HOME"
 
-  mkdir -p "$SOCKET_DIR"/{lib,src,bin,include,objects}
-  mkdir -p "$SOCKET_DIR"/{lib,objects}/"$(uname -m)-desktop"
+  mkdir -p "$SOCKET_HOME"/{lib,src,bin,include,objects}
+  mkdir -p "$SOCKET_HOME"/{lib,objects}/"$(uname -m)-desktop"
 
   if [[ "$(uname -s)" = "Darwin" ]]; then
-    mkdir -p "$SOCKET_DIR"/{lib,objects}/{arm64-iPhoneOS,x86_64-iPhoneSimulator}
+    mkdir -p "$SOCKET_HOME"/{lib,objects}/{arm64-iPhoneOS,x86_64-iPhoneSimulator}
   fi
 
   if [ ! -d "$BUILD_DIR/uv" ]; then
@@ -260,50 +260,50 @@ function _prepare {
 function _install {
   declare arch="$1"
   declare platform="$2"
-  echo "# copying sources to $SOCKET_DIR/src"
-  cp -r "$CWD"/src/* "$SOCKET_DIR/src"
+  echo "# copying sources to $SOCKET_HOME/src"
+  cp -r "$CWD"/src/* "$SOCKET_HOME/src"
 
   if test -d "$BUILD_DIR/$arch-$platform/objects"; then
-    echo "# copying objects to $SOCKET_DIR/objects/$arch-$platform"
-    rm -rf "$SOCKET_DIR/objects/$arch-$platform"
-    mkdir -p "$SOCKET_DIR/objects/$arch-$platform"
-    cp -r "$BUILD_DIR/$arch-$platform/objects"/* "$SOCKET_DIR/objects/$arch-$platform"
+    echo "# copying objects to $SOCKET_HOME/objects/$arch-$platform"
+    rm -rf "$SOCKET_HOME/objects/$arch-$platform"
+    mkdir -p "$SOCKET_HOME/objects/$arch-$platform"
+    cp -r "$BUILD_DIR/$arch-$platform/objects"/* "$SOCKET_HOME/objects/$arch-$platform"
   fi
 
   if test -d "$BUILD_DIR"/lib; then
-    echo "# copying libraries to $SOCKET_DIR/lib"
-    mkdir -p "$SOCKET_DIR/lib"
-    cp -fr "$BUILD_DIR"/lib/*.a "$SOCKET_DIR/lib/"
+    echo "# copying libraries to $SOCKET_HOME/lib"
+    mkdir -p "$SOCKET_HOME/lib"
+    cp -fr "$BUILD_DIR"/lib/*.a "$SOCKET_HOME/lib/"
   fi
 
   if test -d "$BUILD_DIR/$arch-$platform"/lib; then
-    echo "# copying libraries to $SOCKET_DIR/lib/$arch-$platform"
-    rm -rf "$SOCKET_DIR/lib/$arch-$platform"
-    mkdir -p "$SOCKET_DIR/lib/$arch-$platform"
-    cp -fr "$BUILD_DIR/$arch-$platform"/lib/*.a "$SOCKET_DIR/lib/$arch-$platform"
+    echo "# copying libraries to $SOCKET_HOME/lib/$arch-$platform"
+    rm -rf "$SOCKET_HOME/lib/$arch-$platform"
+    mkdir -p "$SOCKET_HOME/lib/$arch-$platform"
+    cp -fr "$BUILD_DIR/$arch-$platform"/lib/*.a "$SOCKET_HOME/lib/$arch-$platform"
   fi
 
-  rm -rf "$SOCKET_DIR/include"
-  mkdir -p "$SOCKET_DIR/include"
-  #cp -rf "$CWD"/include/* $SOCKET_DIR/include
-  cp -rf "$BUILD_DIR"/uv/include/* $SOCKET_DIR/include
+  rm -rf "$SOCKET_HOME/include"
+  mkdir -p "$SOCKET_HOME/include"
+  #cp -rf "$CWD"/include/* $SOCKET_HOME/include
+  cp -rf "$BUILD_DIR"/uv/include/* $SOCKET_HOME/include
 }
 
 function _install_cli {
   local arch="$(uname -m)"
 
   if [ -z "$TEST" ] && [ -z "$NO_INSTALL" ]; then
-    echo "# moving binary to '$SOCKET_DIR/bin' (prompting to copy file into directory)"
+    echo "# moving binary to '$SOCKET_HOME/bin' (prompting to copy file into directory)"
 
-    cp -f "$BUILD_DIR/$arch-desktop"/bin/* "$SOCKET_DIR/bin"
-    die $? "not ok - unable to move binary into '$SOCKET_DIR'"
+    cp -f "$BUILD_DIR/$arch-desktop"/bin/* "$SOCKET_HOME/bin"
+    die $? "not ok - unable to move binary into '$SOCKET_HOME'"
 
-    local status="$(ln -sf "$SOCKET_DIR/bin"/* "$PREFIX/bin" 2>&1)"
+    local status="$(ln -sf "$SOCKET_HOME/bin"/* "$PREFIX/bin" 2>&1)"
     local rc=$?
 
     if [[ " $status " =~ " Permission denied " ]]; then
       echo "warn - Failed to link binrary to '$PREFIX/bin': Trying 'sudo'"
-      sudo ln -sf "$SOCKET_DIR/bin"/* "$PREFIX/bin"
+      sudo ln -sf "$SOCKET_HOME/bin"/* "$PREFIX/bin"
       die $? "not ok - unable to link binary into '$PREFIX/bin'"
     fi
 
@@ -467,9 +467,9 @@ fi
 _compile_libuv
 echo "ok - built libuv for $platform ($target)"
 
-mkdir -p  $SOCKET_DIR/uv/{src/unix,include}
-cp -fr $BUILD_DIR/uv/src/*.{c,h} $SOCKET_DIR/uv/src
-cp -fr $BUILD_DIR/uv/src/unix/*.{c,h} $SOCKET_DIR/uv/src/unix
+mkdir -p  $SOCKET_HOME/uv/{src/unix,include}
+cp -fr $BUILD_DIR/uv/src/*.{c,h} $SOCKET_HOME/uv/src
+cp -fr $BUILD_DIR/uv/src/unix/*.{c,h} $SOCKET_HOME/uv/src/unix
 die $? "not ok - could not copy headers"
 echo "ok - copied headers"
 cd $CWD

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -83,16 +83,16 @@ void log (const String s) {
 }
 
 String getSocketDirectory () {
-  static String SOCKET_DIR = getEnv("SOCKET_DIR");
-  static String socketDir = "";
+  static String SOCKET_HOME = getEnv("SOCKET_HOME");
+  static String socketHome = "";
   static String sep = platform.win ? "\\" : "/";
 
-  if (socketDir.size() == 0) {
-    if (SOCKET_DIR.size() > 0) {
-      if (SOCKET_DIR.back() != sep[0]) {
-        socketDir = SOCKET_DIR + sep;
+  if (socketHome.size() == 0) {
+    if (SOCKET_HOME.size() > 0) {
+      if (SOCKET_HOME.back() != sep[0]) {
+        socketHome = SOCKET_HOME + sep;
       } else {
-        socketDir = SOCKET_DIR;
+        socketHome = SOCKET_HOME;
       }
     } else if (platform.mac || platform.linux) {
       String dataHome = getEnv("XDG_DATA_HOME");
@@ -102,21 +102,21 @@ String getSocketDirectory () {
         dataHome = local + "/.local/share";
       }
 
-      socketDir = dataHome + "/socket";
+      socketHome = dataHome + "/socket";
     } else if (platform.win) {
       String local = getEnv("LOCALAPPDATA");
-      socketDir = local + "\\Programs\\socketsupply\\";
+      socketHome = local + "\\Programs\\socketsupply\\";
     }
 
-    log("using '" + socketDir + "' as build source");
+    log("using '" + socketHome + "' as 'SOCKET_HOME'");
   }
 
-  return socketDir;
+  return socketHome;
 }
 
 inline String prefixFile (String s) {
-  static String socketDir = getSocketDirectory();
-  return socketDir + s + " ";
+  static String socketHome = getSocketDirectory();
+  return socketHome + s + " ";
 }
 
 inline String prefixFile () {

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -82,14 +82,41 @@ void log (const String s) {
   start = std::chrono::system_clock::now();
 }
 
-inline String prefixFile (String s) {
-  if (platform.mac || platform.linux) {
-    String local = getEnv("HOME");
-    return String(local + "/.config/socket/" + s + " ");
+String getSocketDirectory () {
+  static String SOCKET_DIR = getEnv("SOCKET_DIR");
+  static String socketDir = "";
+  static String sep = platform.win ? "\\" : "/";
+
+  if (socketDir.size() == 0) {
+    if (SOCKET_DIR.size() > 0) {
+      if (SOCKET_DIR.back() != sep[0]) {
+        socketDir = SOCKET_DIR + sep;
+      } else {
+        socketDir = SOCKET_DIR;
+      }
+    } else if (platform.mac || platform.linux) {
+      String dataHome = getEnv("XDG_DATA_HOME");
+      String local = getEnv("HOME");
+
+      if (dataHome.size() == 0) {
+        dataHome = local + "/.local/share";
+      }
+
+      socketDir = dataHome + "/socket";
+    } else if (platform.win) {
+      String local = getEnv("LOCALAPPDATA");
+      socketDir = local + "\\Programs\\socketsupply\\";
+    }
+
+    log("using '" + socketDir + "' as build source");
   }
 
-  String local = getEnv ("LOCALAPPDATA");
-  return String(local + "\\Programs\\socketsupply\\" + s + " ");
+  return socketDir;
+}
+
+inline String prefixFile (String s) {
+  static String socketDir = getSocketDirectory();
+  return socketDir + s + " ";
 }
 
 inline String prefixFile () {


### PR DESCRIPTION
This pull requests introduces configurable install locations with `SOCKET_HOME` and `PREFIX` (for the `ssc` cli). It also migrates where source files are stored from `~.config/socket` to `~/.local/share/socket` to be more in line with `XDG_DATA_HOME` [1].

This PR also includes a change to support `PREFIX` when installing the `ssc` binary allowing me us to run `./bin/install.sh` **without** `sudo`:

```sh
$ PREFIX=$HOME/.local ./bin/install.sh
```

Which installs `ssc` into my `$HOME/.local/bin` directory, which is in my `PATH`. `PREFIX` may be something other that `/usr/local/` which we default to giving the installer an option to place `ssc` where they'd like.

With the `SOCKET_HOME` environment variable, I can tell the installer where to put the build source files too:

```sh
$ PREFIX=$HOME/.local SOCKET_HOME=$HOME/socket ./bin/install.sh
```

When building an app I can specify where the `SOCKET_HOME` directory is:

```sh
SOCKET_HOME=$HOME/socket ssc build -r -o
```

1. https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html