### PR TITLE
NPM Modules

### DIFF
--- a/bin/build-runtime-library.sh
+++ b/bin/build-runtime-library.sh
@@ -16,7 +16,14 @@ declare sources=(
 )
 
 declare arch="$(uname -m)"
+declare host="$(uname -s)"
 declare platform="desktop"
+
+if [[ "$host" = "Linux" ]]; then
+  if [ -n "$WSL_DISTRO_NAME" ] || uname -r | grep 'Microsoft'; then
+    HOST="Win32"
+  fi
+fi
 
 if (( TARGET_OS_IPHONE )); then
   arch="arm64"
@@ -55,7 +62,7 @@ while (( $# > 0 )); do
   args+=("$arg")
 done
 
-if [[ "$(uname -s)" = "Darwin" ]]; then
+if [[ "$host" = "Darwin" ]]; then
   cflags+=("-ObjC++")
   sources+=("$root/src/window/apple.mm")
   if (( TARGET_OS_IPHONE)); then
@@ -65,9 +72,12 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
   else
     sources+=("$root/src/process/unix.cc")
   fi
-elif [[ "$(uname -s)" = "Linux" ]]; then
+elif [[ "$host" = "Linux" ]]; then
   sources+=("$root/src/window/linux.cc")
   sources+=("$root/src/process/unix.cc")
+elif [[ "$host" = "Win32" ]]; then
+  sources+=("$root/src/window/win.cc")
+  sources+=("$root/src/process/win.cc")
 fi
 
 declare cflags=($("$root/bin/cflags.sh"))

--- a/bin/cflags.sh
+++ b/bin/cflags.sh
@@ -7,23 +7,28 @@ declare IOS_SIMULATOR_VERSION_MIN="${IOS_SIMULATOR_VERSION_MIN:-$IPHONEOS_VERSIO
 
 declare cflags=()
 declare arch="$(uname -m)"
+declare host="$(uname -s)"
 declare platform="desktop"
 
 declare ios_sdk_path=""
 
-declare ANDROID_HOME=""
+if [[ "$host" = "Linux" ]]; then
+  if [ -n "$WSL_DISTRO_NAME" ] || uname -r | grep 'Microsoft'; then
+    host="Win32"
+  fi
+fi
 
 if [ -z "$ANDROID_HOME" ]; then
-  if [[ "$(uname)" = "Darwin" ]]; then
+  if [[ "$host" = "Darwin" ]]; then
     ANDROID_HOME="$HOME/Library/Android/sdk"
-  elif [[ "$(uname)" = "Linux" ]]; then
+  elif [[ "$host" = "Linux" ]]; then
     ANDROID_HOME="$HOME/android"
   fi
 fi
 
-if [[ "$(uname)" = "Linux" ]] && [[ "$(basename "$CXX")" =~ clang ]]; then
-  cflags+=("-Wno-unused-command-line-argument")
-  if [[ "$(uname)" = "Linux" ]]; then
+if [[ "$(basename "$CXX")" =~ clang ]]; then
+  if [[ "$host" = "Linux" ]] || [[ "$host" = "Win32" ]]; then
+    cflags+=("-Wno-unused-command-line-argument")
     cflags+=("-stdlib=libstdc++")
   fi
 fi
@@ -31,13 +36,18 @@ fi
 cflags+=(
   $CFLAG
   $CXXFLAGS
-  -std=c++20
   -I"$root/include"
   -I"$root/build/uv/include"
   -DSSC_BUILD_TIME="$(date '+%s')"
   -DSSC_VERSION_HASH=`git rev-parse --short HEAD`
   -DSSC_VERSION=`cat "$root/VERSION.txt"`
 )
+
+if [[ "$host" = "Win32" ]]; then
+  cflags+=(-std=c++2a)
+else
+  cflags+=(-std=c++20)
+fi
 
 if (( TARGET_OS_IPHONE )) || (( TARGET_IPHONE_SIMULATOR )); then
   if (( TARGET_OS_IPHONE )); then
@@ -63,18 +73,27 @@ elif (( TARGET_OS_ANDROID )) || (( TARGET_ANDROID_EMULATOR )); then
     cflags+=("-target x86_64-linux-android")
   fi
 
-  if [[ "$(uname)" = "Darwin" ]]; then
+  if [[ "$host" = "Darwin" ]]; then
     cflags+=("--sysroot=$ANDROID_HOME/ndk-bundle/toolchains/llvm/prebuilt/darwin-x86_64/sysroot")
-  elif [[ "$(uname)" = "Linux" ]]; then
+  elif [[ "$host" = "Linux" ]]; then
     cflags+=("--sysroot=$ANDROID_HOME/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/sysroot")
   fi
 fi
 
 if (( !TARGET_OS_ANDROID && !TARGET_ANDROID_EMULATOR )); then
-  if [[ "$(uname -s)" = "Darwin" ]]; then
+  if [[ "$host" = "Darwin" ]]; then
     cflags+=("-ObjC++")
-  elif [[ "$(uname -s)" = "Linux" ]]; then
+  elif [[ "$host" = "Linux" ]]; then
     cflags+=($(pkg-config --cflags --static gtk+-3.0 webkit2gtk-4.1))
+  elif [[ "$host" = "Win32" ]]; then
+    cflags+=(
+      -D_MT
+      -D_DLL
+      -DWIN32
+      -DWIN32_LEAN_AND_MEAN
+      -Xlinker /NODEFAULTLIB:libcmt
+      -Wno-nonportable-include-path
+    )
   fi
 fi
 

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -53,6 +53,7 @@ if [ -n "$arch" ] || [ -n "$platform" ]; then
     "$root/build/$arch-$platform"/tests          \
     "$root/build/$arch-$platform"/*.o            \
     "$root/build/$arch-$platform"/**/*.o         \
+    "$root/build/npm/$platform"
   2>/dev/null))
 else
   targets+=($(find                 \
@@ -69,6 +70,7 @@ else
     "$root"/build/*/tests          \
     "$root"/build/*/*.o            \
     "$root"/build/*/**/*.o         \
+    "$root"/build/npm              \
   2>/dev/null))
 fi
 

--- a/bin/ldflags.sh
+++ b/bin/ldflags.sh
@@ -6,8 +6,16 @@ declare ldflags=()
 
 declare args=()
 declare arch="$(uname -m)"
+declare host="$(uname -s)"
 declare platform="desktop"
+
 declare ios_sdk_path=""
+
+if [[ "$host" = "Linux" ]]; then
+  if [ -n "$WSL_DISTRO_NAME" ] || uname -r | grep 'Microsoft'; then
+    HOST="Win32"
+  fi
+fi
 
 if (( TARGET_OS_IPHONE )); then
   arch="arm64"
@@ -60,7 +68,7 @@ while (( $# > 0 )); do
   args+=("$arg")
 done
 
-if [[ "$(uname -s)" = "Darwin" ]]; then
+if [[ "$host" = "Darwin" ]]; then
   if (( !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR )); then
     ldflags+=("-framework" "Cocoa")
   fi
@@ -88,7 +96,7 @@ if [[ "$(uname -s)" = "Darwin" ]]; then
   ldflags+=("-framework" "UniformTypeIdentifiers")
   ldflags+=("-framework" "WebKit")
   ldflags+=("-framework" "UserNotifications")
-elif [[ "$(uname -s)" = "Linux" ]]; then
+elif [[ "$host" = "Linux" ]]; then
   ldflags+=($(pkg-config --libs gtk+-3.0 webkit2gtk-4.1))
 fi
 

--- a/bin/publish-npm-modules.sh
+++ b/bin/publish-npm-modules.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+declare root="$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)"
+declare archs=($(uname -m))
+declare platform="$(uname -s | tr '[[:upper:]]' '[[:lower:]]')"
+
+declare args=()
+declare dry_run=0
+declare only_platforms=0
+declare only_top_level=0
+
+declare SOCKET_HOME="$root/build/npm/$platform"
+declare PREFIX="$SOCKET_HOME"
+
+if [[ "$platform" = "linux" ]]; then
+  if [ -n "$WSL_DISTRO_NAME" ] || uname -r | grep 'Microsoft'; then
+    platform="win32"
+  fi
+fi
+
+while (( $# > 0 )); do
+  declare arg="$1"; shift
+  if [[ "$arg" = "--dry-run" ]] || [[ "$arg" = "-n" ]]; then
+    dry_run=1
+    continue
+  fi
+
+  if [[ "$arg" = "--only-platforms" ]]; then
+    only_platforms=1
+    continue
+  fi
+
+  if [[ "$arg" = "--only-top-level" ]]; then
+    only_top_level=1
+    continue
+  fi
+
+  args+=("$arg")
+done
+
+rm -rf "$SOCKET_HOME"
+mkdir -p "$SOCKET_HOME"
+
+export SOCKET_HOME
+export PREFIX
+
+if (( !only_top_level )); then
+  "$root/bin/install.sh" || exit $?
+fi
+
+mkdir -p "$SOCKET_HOME/packages/@socketsupply"
+
+if (( !only_platforms || only_top_level )); then
+  declare package="@socketsupply/socket"
+  cp -rf "$root/npm/packages/@socketsupply/socket" "$SOCKET_HOME/packages/$package"
+  mkdir -p "$SOCKET_HOME/packages/$package/bin"
+  cp -rf "$root/npm/bin/ssc.js" "$SOCKET_HOME/packages/$package/bin/ssc.js"
+  cp -f "$root/LICENSE.txt" "$SOCKET_HOME/packages/$package"
+  cp -f "$root/README.md" "$SOCKET_HOME/packages/$package"
+fi
+
+if (( !only_top_level )); then
+  for arch in "${archs[@]}"; do
+    declare package="@socketsupply/socket-$platform-${arch/x86_64/x64}"
+    cp -rf "$root/npm/packages/$package" "$SOCKET_HOME/packages/$package"
+
+    mkdir -p "$SOCKET_HOME/packages/$package/uv"
+    mkdir -p "$SOCKET_HOME/packages/$package/bin"
+    mkdir -p "$SOCKET_HOME/packages/$package/src"
+    mkdir -p "$SOCKET_HOME/packages/$package/include"
+    mkdir -p "$SOCKET_HOME/packages/$package/lib"
+    mkdir -p "$SOCKET_HOME/packages/$package/objects"
+
+    cp -rf "$root/npm/bin"/* "$SOCKET_HOME/packages/$package/bin"
+    cp -rf "$root/npm/src"/* "$SOCKET_HOME/packages/$package/src"
+    cp -f "$root/LICENSE.txt" "$SOCKET_HOME/packages/$package"
+    cp -f "$root/README.md" "$SOCKET_HOME/packages/$package"
+
+    cp -rf "$SOCKET_HOME/uv"/* "$SOCKET_HOME/packages/$package/uv"
+    cp -rf "$SOCKET_HOME/bin"/* "$SOCKET_HOME/packages/$package/bin"
+    cp -rf "$SOCKET_HOME/src"/* "$SOCKET_HOME/packages/$package/src"
+    cp -rf "$SOCKET_HOME/include"/* "$SOCKET_HOME/packages/$package/include"
+
+    cp -rf "$SOCKET_HOME/lib/"$arch-* "$SOCKET_HOME/packages/$package/lib"
+    cp -rf "$SOCKET_HOME/objects/"$arch-* "$SOCKET_HOME/packages/$package/objects"
+
+    ## Install x86_64-iPhoneSimulator files for arm64 too
+    if [ "$platform" = "darwin" ]; then
+      if [ "$(uname -m)" == "arm64" ]; then
+        cp -rf "$SOCKET_HOME/lib/x86_64-iPhoneSimulator" "$SOCKET_HOME/packages/$package/lib"
+        cp -rf "$SOCKET_HOME/objects/x86_64-iPhoneSimulator" "$SOCKET_HOME/packages/$package/objects"
+      fi
+    fi
+
+    cd "$SOCKET_HOME/packages/$package" || exit $?
+    echo "# in directory: '$SOCKET_HOME/packages/$package'"
+
+    if (( !dry_run )) ; then
+      npm publish "$@"
+    else
+      echo "# npm publish "$@""
+    fi
+  done
+fi
+
+if (( !only_platforms || only_top_level )); then
+  cd "$SOCKET_HOME/packages/@socketsupply/socket" || exit $?
+  echo "# in directory: '$SOCKET_HOME/packages/@socketsupply/socket'"
+
+  if (( !dry_run )); then
+    npm publish "$@" || exit $?
+  else
+    echo "# npm publish "$@""
+  fi
+fi

--- a/bin/version-npm-modules.sh
+++ b/bin/version-npm-modules.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+declare root="$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)"
+declare archs=()
+declare platform="$(uname | tr '[[:upper:]]' '[[:lower:]]')"
+
+if [ "$(uname -m)" = "x86_64" ]; then
+  archs+=("x64")
+else
+  archs+=("$(uname -m)")
+fi
+
+if [[ "$platform" = "linux" ]]; then
+  if [ -n "$WSL_DISTRO_NAME" ] || uname -r | grep 'Microsoft'; then
+    platform="win32"
+  fi
+fi
+
+for arch in "${archs[@]}"; do
+  declare package="@socketsupply/socket-$platform-$arch"
+  cd "$root/npm/packages/$package" || exit $?
+  echo "# $package"
+  npm version "$@" || exit $?
+done

--- a/npm/bin/ssc-platform.js
+++ b/npm/bin/ssc-platform.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import installation from '../src/index.js'
+import { spawn } from 'node:child_process'
+
+export default spawn(installation.bin.ssc, process.argv.slice(2), {
+  env: { ...installation.env, ...process.env },
+  stdio: 'inherit',
+  windowsHide: true
+})

--- a/npm/bin/ssc.js
+++ b/npm/bin/ssc.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { fork } from 'node:child_process'
+import { load } from '../index.js'
+
+async function main () {
+  const installation = await load()
+  const child = fork(installation.bin['ssc-platform'], process.argv.slice(2), {
+    env: { ...installation.env, ...process.env },
+    stdio: 'inherit',
+    windowsHide: true
+  })
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/npm/bin/verify-platform.js
+++ b/npm/bin/verify-platform.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import assert from 'assert'
+
+const [ platform, arch ] = process.argv.slice(2)
+assert(process.platform === platform && process.arch === arch)

--- a/npm/packages/@socketsupply/socket-darwin-arm64/package.json
+++ b/npm/packages/@socketsupply/socket-darwin-arm64/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@socketsupply/socket-darwin-arm64",
+  "version": "0.0.1",
+  "description": "A Cross-Platform, Native Runtime for Desktop and Mobile Apps — Create apps using HTML, CSS, and JavaScript. Written from the ground up to be small and maintainable.",
+  "type": "module",
+  "main": "src/index.js",
+  "preferGlobal": true,
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "bin": {
+    "ssc": "bin/ssc-platform.js"
+  },
+  "scripts": {
+    "test": ":",
+    "install": "bin/verify-platform.js darwin arm64"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/socketsupply/socket.git"
+  },
+  "keywords": [
+    "socket",
+    "runtime",
+    "webview",
+    "javascript",
+    "desktop",
+    "mobile",
+    "darwin",
+    "arm64"
+  ],
+  "author": "Socket Supply, Co <info@socketsupply.co>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/socketsupply/socket/issues"
+  },
+  "homepage": "https://github.com/socketsupply/socket#readme"
+}

--- a/npm/packages/@socketsupply/socket-darwin-x64/package.json
+++ b/npm/packages/@socketsupply/socket-darwin-x64/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@socketsupply/socket-darwin-x64",
+  "version": "0.0.1",
+  "description": "A Cross-Platform, Native Runtime for Desktop and Mobile Apps — Create apps using HTML, CSS, and JavaScript. Written from the ground up to be small and maintainable.",
+  "type": "module",
+  "main": "src/index.js",
+  "preferGlobal": true,
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "bin": {
+    "ssc": "bin/ssc-platform.js"
+  },
+  "scripts": {
+    "test": ":",
+    "install": "bin/verify-platform.js darwin x64"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/socketsupply/socket.git"
+  },
+  "keywords": [
+    "socket",
+    "runtime",
+    "webview",
+    "javascript",
+    "desktop",
+    "mobile",
+    "darwin",
+    "arm64"
+  ],
+  "author": "Socket Supply, Co <info@socketsupply.co>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/socketsupply/socket/issues"
+  },
+  "homepage": "https://github.com/socketsupply/socket#readme"
+}

--- a/npm/packages/@socketsupply/socket-linux-arm64/package.json
+++ b/npm/packages/@socketsupply/socket-linux-arm64/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@socketsupply/socket-linux-arm64",
+  "version": "0.0.1",
+  "description": "A Cross-Platform, Native Runtime for Desktop and Mobile Apps — Create apps using HTML, CSS, and JavaScript. Written from the ground up to be small and maintainable.",
+  "type": "module",
+  "main": "src/index.js",
+  "preferGlobal": true,
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "bin": {
+    "ssc": "bin/ssc-platform.js"
+  },
+  "scripts": {
+    "test": ":",
+    "install": "bin/verify-platform.js linux arm64"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/socketsupply/socket.git"
+  },
+  "keywords": [
+    "socket",
+    "runtime",
+    "webview",
+    "javascript",
+    "desktop",
+    "mobile",
+    "linux",
+    "arm64"
+  ],
+  "author": "Socket Supply, Co <info@socketsupply.co>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/socketsupply/socket/issues"
+  },
+  "homepage": "https://github.com/socketsupply/socket#readme"
+}

--- a/npm/packages/@socketsupply/socket-linux-x64/package.json
+++ b/npm/packages/@socketsupply/socket-linux-x64/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@socketsupply/socket-linux-x64",
+  "version": "0.0.1",
+  "description": "A Cross-Platform, Native Runtime for Desktop and Mobile Apps — Create apps using HTML, CSS, and JavaScript. Written from the ground up to be small and maintainable.",
+  "type": "module",
+  "main": "src/index.js",
+  "preferGlobal": true,
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "bin": {
+    "ssc": "bin/ssc-platform.js"
+  },
+  "scripts": {
+    "test": ":",
+    "install": "bin/verify-platform.js linux x64"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/socketsupply/socket.git"
+  },
+  "keywords": [
+    "socket",
+    "runtime",
+    "webview",
+    "javascript",
+    "desktop",
+    "mobile",
+    "linux",
+    "x64"
+  ],
+  "author": "Socket Supply, Co <info@socketsupply.co>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/socketsupply/socket/issues"
+  },
+  "homepage": "https://github.com/socketsupply/socket#readme"
+}

--- a/npm/packages/@socketsupply/socket-win32-x64/package.json
+++ b/npm/packages/@socketsupply/socket-win32-x64/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@socketsupply/socket-win32-x64",
+  "version": "0.0.1",
+  "description": "A Cross-Platform, Native Runtime for Desktop and Mobile Apps — Create apps using HTML, CSS, and JavaScript. Written from the ground up to be small and maintainable.",
+  "type": "module",
+  "main": "src/index.js",
+  "preferGlobal": true,
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "bin": {
+    "ssc": "bin/ssc-platform.js"
+  },
+  "scripts": {
+    "test": ":",
+    "install": "cd bin && node verify-platform.js win32 x64"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/socketsupply/socket.git"
+  },
+  "keywords": [
+    "socket",
+    "runtime",
+    "webview",
+    "javascript",
+    "desktop",
+    "mobile",
+    "linux",
+    "x64"
+  ],
+  "author": "Socket Supply, Co <info@socketsupply.co>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/socketsupply/socket/issues"
+  },
+  "homepage": "https://github.com/socketsupply/socket#readme"
+}

--- a/npm/packages/@socketsupply/socket/index.js
+++ b/npm/packages/@socketsupply/socket/index.js
@@ -1,0 +1,8 @@
+import os from 'node:os'
+
+export async function load () {
+  const platform = os.platform()
+  const arch = os.arch()
+  const info = await import(`@socketsupply/socket-${platform}-${arch}`)
+  return info?.default ?? info ?? null
+}

--- a/npm/packages/@socketsupply/socket/package.json
+++ b/npm/packages/@socketsupply/socket/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@socketsupply/socket",
+  "version": "0.0.1",
+  "description": "A Cross-Platform, Native Runtime for Desktop and Mobile Apps — Create apps using HTML, CSS, and JavaScript. Written from the ground up to be small and maintainable.",
+  "type": "module",
+  "main": "index.js",
+  "preferGlobal": true,
+  "bin": {
+    "ssc": "bin/ssc.js"
+  },
+  "os": [
+    "linux",
+    "darwin",
+    "win32"
+  ],
+  "cpu": [
+    "arm64",
+    "x64"
+  ],
+  "scripts": {
+    "test": ":"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/socketsupply/socket.git"
+  },
+  "keywords": [
+    "socket",
+    "runtime",
+    "webview",
+    "javascript",
+    "desktop",
+    "mobile"
+  ],
+  "author": "Socket Supply, Co <info@socketsupply.co>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/socketsupply/socket/issues"
+  },
+  "homepage": "https://github.com/socketsupply/socket#readme",
+  "optionalDependencies": {
+    "@socketsupply/socket-darwin-arm64": "~0.0.x",
+    "@socketsupply/socket-darwin-x64": "~0.0.x",
+    "@socketsupply/socket-linux-arm64": "~0.0.x",
+    "@socketsupply/socket-linux-x64": "~0.0.x",
+    "@socketsupply/socket-win32-x64": "~0.0.x"
+  }
+}

--- a/npm/src/index.js
+++ b/npm/src/index.js
@@ -1,0 +1,29 @@
+import path from 'node:path'
+import os from 'node:os'
+
+const dirname = path.dirname(import.meta.url.replace('file://', ''))
+
+export const SOCKET_HOME = path.dirname(dirname)
+export const PREFIX = SOCKET_HOME
+
+export const platform = os.platform()
+export const arch = os.arch()
+
+export const env = {
+  SOCKET_HOME,
+  PREFIX
+}
+
+export const bin = {
+  'ssc-platform': path.join(env.PREFIX, 'bin', 'ssc-platform.js'),
+  ssc: os.platform() === 'win32'
+    ? path.join(env.PREFIX, 'bin', 'ssc.exe')
+    : path.join(env.PREFIX, 'bin', 'ssc')
+}
+
+export default {
+  platform,
+  arch,
+  env,
+  bin
+}


### PR DESCRIPTION
This pull request fixes #90 and introduces NPM modules based on platform and architecture as optional dependencies to the `@socketsupply/socket` module. Currently, there is only support for `darwin` and `linux`.

## Versioning

The `package.json` for each module is maintained in `npm/packages/@socketsupply/*`. They should be updated manually. However, there is a connivence script for versioning all platform packages:

```sh
bin/version-npm-modules.sh <npm version args>
```

## Publishing

The modules can be published with a helper script `bin/publish-npm-modules.sh [--dry-run] [--only-top-level] [--only-platforms]`

## Installation

Installing the top level module can be done with:

```sh
npm install -g @socketsupply/socket
```

You may need to set your global [NPM Prefix](https://docs.npmjs.com/cli/v8/commands/npm-prefix) first:

**~/.npm-global:**

```sh
npm set prefix $HOME/.npm-global
```

You should include `$HOME/.npm-global/bin` in your `PATH`

**~/.local:**

```sh
npm set prefix $HOME/.local
```

You should include `$HOME/.local/bin` in your `PATH`

Installing with `sudo` should also work - you may need to run it with `sudo -E` if installing on Linux from GitHub Packages