### PR TITLE
Process wait

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1744,7 +1744,9 @@ int main (const int argc, const char* argv[]) {
           }
         }
       );
+
       process->open();
+      process->wait();
 
       log("ran user build command");
 

--- a/src/process/process.hh
+++ b/src/process/process.hh
@@ -119,10 +119,6 @@ namespace SSC {
     std::atomic<int> status = -1;
     id_type id = 0;
 
-  #ifndef _WIN32
-    std::thread* waitThread = nullptr;
-  #endif
-
   private:
 
     class Data {
@@ -159,19 +155,6 @@ namespace SSC {
 #endif
 
     ~Process() noexcept {
-    #ifndef _WIN32
-      auto waitThread = this->waitThread;
-      this->waitThread = nullptr;
-
-      if (waitThread != nullptr) {
-        if (waitThread->joinable()) {
-          waitThread->join();
-        }
-
-        delete waitThread;
-      }
-    #endif
-
       close_fds();
     };
 


### PR DESCRIPTION
This pull request introduces `Process::wait()` to allow the caller to wait for the child process to exit with a status code. @heapwolf observed a race condition in the build step as the main process (`ssc`) was not blocking after `process->open()` was called.