### PR TITLE
fix early free in 'window.eval' IPC command

### DIFF
--- a/src/window/linux.cc
+++ b/src/window/linux.cc
@@ -59,11 +59,13 @@ namespace SSC {
           );
 
           if (!result) {
-            g_error_free(error);
-            return ctx->reply(IPC::Result::Err { ctx->message, JSON::Object::Entries {
-              {"code", std::to_string(error->code)},
+            ctx->reply(IPC::Result::Err { ctx->message, JSON::Object::Entries {
+              {"code", error->code},
               {"message", String(error->message)}
             }});
+
+            g_error_free(error);
+            return;
           } else {
             auto value = webkit_javascript_result_get_js_value(result);
 
@@ -84,6 +86,11 @@ namespace SSC {
 
               if (exception) {
                 auto message = jsc_exception_get_message(exception);
+
+                if (message == nullptr) {
+                  message = "An unknown error occured";
+                }
+
                 ctx->reply(IPC::Result::Err { ctx->message, JSON::Object::Entries {
                   {"message", String(message)}
                 }});


### PR DESCRIPTION
Just noticed if an error occurs, it crashes:

```js
• Welcome to the Socket Runtime (v0.1.0) REPL
# node
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string: construction from null is not valid
Aborted (core dumped)
```

Instead I should see:

```js
• Welcome to the Socket Runtime (v0.1.0) REPL
# node
Uncaught ReferenceError: Can't find variable: node
    at from@file:///home/werle/repos/socketsupply/socket-repl/build/linux/socket-repl_v0.1.7-1_amd64/opt/socket-repl/index.js:3807:33
    at @file:///home/werle/repos/socketsupply/socket-repl/build/linux/socket-repl_v0.1.7-1_amd64/opt/socket-repl/index.js:4103:37
    at file:///home/werle/repos/socketsupply/socket-repl/build/linux/socket-repl_v0.1.7-1_amd64/opt/socket-repl/index.html:1:25
```