### PR TITLE
cli: fix build paths for clang

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1644,10 +1644,9 @@ int main (const int argc, const char* argv[]) {
         " -Xlinker /NODEFAULTLIB:libcmt"
         " -Wno-nonportable-include-path"
         " -I\"" + fs::path(paths.platformSpecificOutputPath / "include").string() + "\""
-        " -I\"" + prefix + "\""
-        " -I\"" + prefix + "\\include\""
-        " -I\"" + prefix + "\\src\""
-        " -L\"" + prefix + "\\lib\""
+        " -I\"" + prefix + "include\""
+        " -I\"" + prefix + "src\""
+        " -L\"" + prefix + "lib\""
       ;
 
       files += "\"" + prefixFile("src\\init.cc\"");


### PR DESCRIPTION
There was a trailing \ causing the clang++ compiler to incorrectly interpret the path.