### PR TITLE
config: cleanup

### DIFF
--- a/npm/packages/@socketsupply/socket-darwin-arm64/package.json
+++ b/npm/packages/@socketsupply/socket-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socketsupply/socket-darwin-arm64",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A Cross-Platform, Native Runtime for Desktop and Mobile Apps — Create apps using HTML, CSS, and JavaScript. Written from the ground up to be small and maintainable.",
   "type": "module",
   "main": "src/index.js",

--- a/npm/packages/@socketsupply/socket-darwin-x64/package.json
+++ b/npm/packages/@socketsupply/socket-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socketsupply/socket-darwin-x64",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A Cross-Platform, Native Runtime for Desktop and Mobile Apps — Create apps using HTML, CSS, and JavaScript. Written from the ground up to be small and maintainable.",
   "type": "module",
   "main": "src/index.js",

--- a/npm/packages/@socketsupply/socket/package.json
+++ b/npm/packages/@socketsupply/socket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socketsupply/socket",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "A Cross-Platform, Native Runtime for Desktop and Mobile Apps — Create apps using HTML, CSS, and JavaScript. Written from the ground up to be small and maintainable.",
   "type": "module",
   "main": "index.js",
@@ -38,8 +38,8 @@
   },
   "homepage": "https://github.com/socketsupply/socket#readme",
   "optionalDependencies": {
-    "@socketsupply/socket-darwin-arm64": "^0.0.13",
-    "@socketsupply/socket-darwin-x64": "^0.0.4",
-    "@socketsupply/socket-linux-x64": "^0.0.4"
+    "@socketsupply/socket-darwin-arm64": "^0.0.14",
+    "@socketsupply/socket-darwin-x64": "^0.0.5",
+    "@socketsupply/socket-linux-x64": "^0.0.5"
   }
 }

--- a/src/android/window.cc
+++ b/src/android/window.cc
@@ -19,7 +19,7 @@ namespace SSC::android {
 
     StringStream stream;
 
-    for (auto const &var : split(this->config["env"], ',')) {
+    for (auto const &var : split(this->config["build_env"], ',')) {
       auto key = trim(var);
       auto value = getEnv(key.c_str());
 
@@ -36,7 +36,7 @@ namespace SSC::android {
       "()Ljava/lang/String;"
     ));
 
-    options.headless = this->config["headless"] == "true";
+    options.headless = this->config["build_headless"] == "true";
     options.debug = isDebugEnabled() ? true : false;
     options.env = stream.str();
     options.cwd = rootDirectory.str();

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -518,7 +518,7 @@ int main (const int argc, const char* argv[]) {
       // this follows the .deb file naming convention
       fs::path packageName = (
         settings["build_name"] + "_" +
-        "v" + settings["version"] + "-" +
+        "v" + settings["meta_version"] + "-" +
         settings["meta_revision"] + "_" +
         "amd64"
       );
@@ -533,7 +533,7 @@ int main (const int argc, const char* argv[]) {
     } else if (platform == "win32") {
       paths.pathPackage = {
         paths.platformSpecificOutputPath  /
-        fs::path(settings["build_name"] + "-v" + settings["version"])
+        fs::path(settings["build_name"] + "-v" + settings["meta_version"])
       };
 
       paths.pathBin = paths.pathPackage;
@@ -642,7 +642,7 @@ int main (const int argc, const char* argv[]) {
         // The pre-release and build metadata are not supported
         std::regex semver_pattern("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$");
         // Check if version matches the pattern
-        if (!std::regex_match(settings["version"], semver_pattern)) {
+        if (!std::regex_match(settings["meta_version"], semver_pattern)) {
           log("error: 'version' in socket.ini must be in semver format");
           exit(1);
         }
@@ -650,7 +650,7 @@ int main (const int argc, const char* argv[]) {
         // default values
         settings["build_output"] = settings["build_output"].size() > 0 ? settings["build_output"] : "dist";
         settings["meta_lang"] = settings["meta_lang"].size() > 0 ? settings["meta_lang"] : "en-us";
-        settings["version"] = settings["version"].size() > 0 ? settings["version"] : "1.0.0";
+        settings["meta_version"] = settings["meta_version"].size() > 0 ? settings["meta_version"] : "1.0.0";
         settings["app_title"] = settings["app_title"].size() > 0 ? settings["app_title"] : settings["build_name"];
 
         for (auto const arg : std::span(argv, argc).subspan(2, numberOfOptions)) {
@@ -1687,8 +1687,8 @@ int main (const int argc, const char* argv[]) {
         "AppxManifest.xml"
       };
 
-      if (settings["version"].size() > 0) {
-        auto version = settings["version"];
+      if (settings["meta_version"].size() > 0) {
+        auto version = settings["meta_version"];
         auto winversion = split(version, '-')[0];
 
         settings["win_version"] = winversion + ".0";

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -651,7 +651,7 @@ int main (const int argc, const char* argv[]) {
         settings["build_output"] = settings["build_output"].size() > 0 ? settings["build_output"] : "dist";
         settings["meta_lang"] = settings["meta_lang"].size() > 0 ? settings["meta_lang"] : "en-us";
         settings["meta_version"] = settings["meta_version"].size() > 0 ? settings["meta_version"] : "1.0.0";
-        settings["app_title"] = settings["app_title"].size() > 0 ? settings["app_title"] : settings["build_name"];
+        settings["meta_title"] = settings["meta_title"].size() > 0 ? settings["meta_title"] : settings["build_name"];
 
         for (auto const arg : std::span(argv, argc).subspan(2, numberOfOptions)) {
           if (is(arg, "--prod")) {

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1309,7 +1309,7 @@ int main (const int argc, const char* argv[]) {
       writeFile(src / "main" / "assets" / "__ssc_vital_check_ok_file__.txt", "OK");
 
       auto cflags = flagDebugMode
-        ? settings.count("build_debug_flags") ? settings["build_debug_flags"] : ""
+        ? settings.count("debug_flags") ? settings["debug_flags"] : ""
         : settings.count("build_flags") ? settings["build_flags"] : "";
 
       StringStream pp;
@@ -2093,7 +2093,7 @@ int main (const int argc, const char* argv[]) {
       StringStream compileCommand;
 
       auto extraFlags = flagDebugMode
-        ? settings.count("build_debug_flags") ? settings["build_debug_flags"] : ""
+        ? settings.count("debug_flags") ? settings["debug_flags"] : ""
         : settings.count("build_flags") ? settings["build_flags"] : "";
 
       compileCommand

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -639,6 +639,16 @@ int main (const int argc, const char* argv[]) {
           exit(1);
         }
 
+        // Define regular expression to match semver format
+        // The semver specification is available at https://semver.org/
+        // The pre-release and build metadata are not supported
+        std::regex semver_pattern("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$");
+        // Check if version matches the pattern
+        if (!std::regex_match(settings["version"], semver_pattern)) {
+          log("error: 'version' in socket.ini must be in semver format");
+          exit(1);
+        }
+
         // default values
         settings["output"] = settings["output"].size() > 0 ? settings["output"] : "dist";
         settings["lang"] = settings["lang"].size() > 0 ? settings["lang"] : "en-us";

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -643,7 +643,7 @@ int main (const int argc, const char* argv[]) {
         std::regex semver_pattern("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$");
         // Check if version matches the pattern
         if (!std::regex_match(settings["meta_version"], semver_pattern)) {
-          log("error: 'version' in socket.ini must be in semver format");
+          log("error: 'version' in [meta] section of socket.ini must be in semver format");
           exit(1);
         }
 
@@ -1454,7 +1454,7 @@ int main (const int argc, const char* argv[]) {
         if (!fs::exists(pathToProfile)) {
           log("provisioning profile not found: " + pathToProfile.string() + ". " +
               "Please specify a valid provisioning profile in the " +
-              "ios_provisioning_profile field in your socket.ini");
+              "provisioning_profile field in the [ios] section of your socket.ini");
           exit(1);
         }
         String command = (
@@ -1864,7 +1864,7 @@ int main (const int argc, const char* argv[]) {
       if (rArchive.exitCode != 0) {
         auto const noDevice = rArchive.output.find("The requested device could not be found because no available devices matched the request.");
         if (noDevice != std::string::npos) {
-          log("error: ios_simulator_device " + settings["ios_simulator_device"] + " from your socket.ini was not found");
+          log("error: simulator_device " + settings["ios_simulator_device"] + " from your socket.ini was not found");
           auto const rDevices = exec("xcrun simctl list devices available | grep -e \"  \"");
           log("available devices:\n" + rDevices.output);
           log("please update your socket.ini with a valid device or install Simulator runtime (https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes)");

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1367,9 +1367,6 @@ constexpr auto gDefaultConfig = R"INI(
 
 [build]
 
-; Advanced Compiler Settings for debug purposes (ie C++ compiler -g, etc).
-debug_flags = "-g"
-
 ; An list of environment variables, separated by commas.
 env = USER, TMPDIR, PWD
 
@@ -1390,6 +1387,11 @@ output = "dist"
 
 ; The build script
 ; script = "node build-script.js"
+
+
+[debug]
+; Advanced Compiler Settings for debug purposes (ie C++ compiler -g, etc).
+debug_flags = "-g"
 
 
 [meta]

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1369,7 +1369,7 @@ constexpr auto gDefaultConfig = R"INI(
 ; The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
 app_name = "beepboop"
 
-; The title of the app, which will be displayed in the title bar. Can contain spaces and special characters. Defaults to app_name.
+; The title of the app used in metadata files. This is NOT a window title. Can contain spaces and special characters. Defaults to app_name.
 app_title = "Beep Boop"
 
 ; build = "node build-script.js"

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -123,7 +123,7 @@ constexpr auto gPListInfo = R"XML(<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
   <key>CFBundleName</key>
-  <string>app_name</string>
+  <string>{{app_name}}</string>
   <key>DTSDKName</key>
   <string>macosx10.13</string>
   <key>DTXcode</key>
@@ -209,7 +209,7 @@ constexpr auto gPListInfo = R"XML(<?xml version="1.0" encoding="UTF-8"?>
   <key>LSMinimumSystemVersion</key>
   <string>10.10.0</string>
   <key>CFBundleDisplayName</key>
-  <string>app_name</string>
+  <string>{{app_name}}</string>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
   <key>SoftResourceLimits</key>
@@ -278,7 +278,7 @@ constexpr auto gDestkopManifest = R"INI(
 [Desktop Entry]
 Encoding=UTF-8
 Version=v{{version}}
-Name=app_name
+Name={{app_name}}
 Terminal=false
 Type=Application
 Exec={{linux_executable_path}}
@@ -444,7 +444,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 		17E73FDA28FCC9320087604F /* common.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = common.hh; sourceTree = "<group>"; };
 		17E73FEE28FCD3360087604F /* libuv-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libuv-ios.a"; path = "lib/libuv-ios.a"; sourceTree = "<group>"; };
 		290F7F86276BC2B000486988 /* lib */ = {isa = PBXFileReference; lastKnownFileType = folder; path = lib; sourceTree = "<group>"; };
-		29124C4A27613369001832A0 /* app_name.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "app_name.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		29124C4A27613369001832A0 /* {{app_name}}.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "{{app_name}}.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		29124C5C2761336B001832A0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		29124C5E2761336B001832A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		294A3C792763E9C6007B5B9A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -511,7 +511,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 		29124C4B27613369001832A0 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				29124C4A27613369001832A0 /* app_name.app */,
+				29124C4A27613369001832A0 /* {{app_name}}.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -535,7 +535,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		29124C4927613369001832A0 /* app_name */ = {
+		29124C4927613369001832A0 /* {{app_name}} */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget "app_name" */;
 			buildPhases = (
@@ -547,9 +547,9 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 			);
 			dependencies = (
 			);
-			name = "app_name";
-			productName = "app_name";
-			productReference = 29124C4A27613369001832A0 /* app_name.app */;
+			name = "{{app_name}}";
+			productName = "{{app_name}}";
+			productReference = 29124C4A27613369001832A0 /* {{app_name}}.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -566,7 +566,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 					};
 				};
 			};
-			buildConfigurationList = 29124C4527613369001832A0 /* Build configuration list for PBXProject "app_name" */;
+			buildConfigurationList = 29124C4527613369001832A0 /* Build configuration list for PBXProject "{{app_name}}" */;
 			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -579,7 +579,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				29124C4927613369001832A0 /* app_name */,
+				29124C4927613369001832A0 /* {{app_name}} */,
 			);
 		};
 /* End PBXProject section */
@@ -752,7 +752,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
         GENERATE_INFOPLIST_FILE = YES;
         HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/include";
         INFOPLIST_FILE = Info.plist;
-        INFOPLIST_KEY_CFBundleDisplayName = "app_name";
+        INFOPLIST_KEY_CFBundleDisplayName = "{{app_name}}";
         INFOPLIST_KEY_LSApplicationCategoryType = Developer;
         INFOPLIST_KEY_NSCameraUsageDescription = "This app needs access to the camera";
         INFOPLIST_KEY_NSHumanReadableCopyright = "{{copyright}}";
@@ -803,7 +803,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
         GENERATE_INFOPLIST_FILE = YES;
         HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/include";
         INFOPLIST_FILE = Info.plist;
-        INFOPLIST_KEY_CFBundleDisplayName = "app_name";
+        INFOPLIST_KEY_CFBundleDisplayName = "{{app_name}}";
         INFOPLIST_KEY_LSApplicationCategoryType = Developer;
         INFOPLIST_KEY_NSCameraUsageDescription = "This app needs access to the camera";
         INFOPLIST_KEY_NSHumanReadableCopyright = "{{copyright}}";
@@ -837,7 +837,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-    29124C4527613369001832A0 /* Build configuration list for PBXProject "app_name" */ = {
+    29124C4527613369001832A0 /* Build configuration list for PBXProject "{{app_name}}" */ = {
       isa = XCConfigurationList;
       buildConfigurations = (
         29124C772761336B001832A0 /* Debug */,
@@ -846,7 +846,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
       defaultConfigurationIsVisible = 0;
       defaultConfigurationName = Release;
     };
-    29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget "app_name" */ = {
+    29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget "{{app_name}}" */ = {
       isa = XCConfigurationList;
       buildConfigurations = (
         29124C7A2761336B001832A0 /* Debug */,
@@ -1066,7 +1066,7 @@ dependencies {
 // Android top level `settings.gradle` in Groovy Syntax
 //
 constexpr auto gGradleSettings = R"GROOVY(
-rootProject.name = "app_name"
+rootProject.name = "{{app_name}}"
 include ':app'
 )GROOVY";
 
@@ -1237,7 +1237,7 @@ constexpr auto gAndroidLayoutWebviewActivity = R"XML(
 
 constexpr auto gAndroidValuesStrings = R"XML(
 <resources>
-  <string name="app_name">app_name</string>
+  <string name="app_name">{{app_name}}</string>
 </resources>
 )XML";
 
@@ -1261,9 +1261,9 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "29124C4927613369001832A0"
-               BuildableName = "app_name.app"
-               BlueprintName = "app_name"
-               ReferencedContainer = "container:app_name.xcodeproj">
+               BuildableName = "{{app_name}}.app"
+               BlueprintName = "{{app_name}}"
+               ReferencedContainer = "container:{{app_name}}.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -1291,9 +1291,9 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "29124C4927613369001832A0"
-            BuildableName = "app_name.app"
-            BlueprintName = "app_name"
-            ReferencedContainer = "container:app_name.xcodeproj">
+            BuildableName = "{{app_name}}.app"
+            BlueprintName = "{{app_name}}"
+            ReferencedContainer = "container:{{app_name}}.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
@@ -1308,9 +1308,9 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "29124C4927613369001832A0"
-            BuildableName = "app_name.app"
-            BlueprintName = "app_name"
-            ReferencedContainer = "container:app_name.xcodeproj">
+            BuildableName = "{{app_name}}.app"
+            BlueprintName = "{{app_name}}"
+            ReferencedContainer = "container:{{app_name}}.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>
@@ -1319,7 +1319,7 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"
-      customArchiveName = "app_name"
+      customArchiveName = "{{app_name}}"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>)XML";
@@ -1364,7 +1364,6 @@ constexpr auto gDefaultConfig = R"INI(
 ; do all the heavy lifting and should handle 99.9% of your use cases for moving
 ; files into place or tweaking platform-specific build artifacts. If you don't
 ; specify it, ssc will just copy everything in your project to the build target.
-; Only app_name 
 
 ; The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
 app_name = "beepboop"

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -123,7 +123,7 @@ constexpr auto gPListInfo = R"XML(<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
   <key>CFBundleName</key>
-  <string>{{name}}</string>
+  <string>app_name</string>
   <key>DTSDKName</key>
   <string>macosx10.13</string>
   <key>DTXcode</key>
@@ -193,7 +193,7 @@ constexpr auto gPListInfo = R"XML(<?xml version="1.0" encoding="UTF-8"?>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleExecutable</key>
-  <string>{{executable}}</string>
+  <string>{{app_name}}</string>
   <key>DTCompiler</key>
   <string>com.apple.compilers.llvm.clang.1_0</string>
   <key>NSPrincipalClass</key>
@@ -209,7 +209,7 @@ constexpr auto gPListInfo = R"XML(<?xml version="1.0" encoding="UTF-8"?>
   <key>LSMinimumSystemVersion</key>
   <string>10.10.0</string>
   <key>CFBundleDisplayName</key>
-  <string>{{name}}</string>
+  <string>app_name</string>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
   <key>SoftResourceLimits</key>
@@ -254,7 +254,7 @@ constexpr auto gAndroidManifest = R"XML(
     -->
   <application
     android:allowBackup="true"
-    android:label="{{title}}"
+    android:label="{{app_title}}"
     android:theme="@style/Theme.AppCompat.Light"
     android:supportsRtl="true"
     {{android_allow_cleartext}}
@@ -278,12 +278,12 @@ constexpr auto gDestkopManifest = R"INI(
 [Desktop Entry]
 Encoding=UTF-8
 Version=v{{version}}
-Name={{name}}
+Name=app_name
 Terminal=false
 Type=Application
 Exec={{linux_executable_path}}
 Icon={{linux_icon_path}}
-StartupWMClass={{executable}}
+StartupWMClass={{app_name}}
 Comment={{description}}
 Categories={{linux_categories}};
 )INI";
@@ -292,7 +292,7 @@ constexpr auto gDebianManifest = R"DEB(Package: {{deb_name}}
 Version: {{version}}
 Architecture: amd64
 Maintainer: {{maintainer}}
-Description: {{title}}
+Description: {{app_title}}
  {{description}}
 )DEB";
 
@@ -313,11 +313,11 @@ constexpr auto gWindowsAppManifest = R"XML(<?xml version="1.0" encoding="utf-8"?
     ProcessorArchitecture="neutral"
     Publisher="{{win_publisher}}"
     Version="{{win_version}}"
-    ResourceId="{{executable}}"
+    ResourceId="{{app_name}}"
   />
 
   <Properties>
-    <DisplayName>{{title}}</DisplayName>
+    <DisplayName>{{app_title}}</DisplayName>
     <Description>{{description}}</Description>
     <Logo>{{win_logo}}</Logo>
     <PublisherDisplayName>{{maintainer}}</PublisherDisplayName>
@@ -340,11 +340,11 @@ constexpr auto gWindowsAppManifest = R"XML(<?xml version="1.0" encoding="utf-8"?
   </Capabilities>
   <Applications>
     <Application
-      Id="{{executable}}"
+      Id="{{app_name}}"
       EntryPoint="Windows.FullTrustApplication"
       Executable="{{exe}}"
     >
-      <uap:VisualElements DisplayName="{{title}}"
+      <uap:VisualElements DisplayName="{{app_title}}"
         Square150x150Logo="{{win_logo}}"
         Square44x44Logo="{{win_logo}}"
         Description="{{description}}"
@@ -444,7 +444,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 		17E73FDA28FCC9320087604F /* common.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = common.hh; sourceTree = "<group>"; };
 		17E73FEE28FCD3360087604F /* libuv-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libuv-ios.a"; path = "lib/libuv-ios.a"; sourceTree = "<group>"; };
 		290F7F86276BC2B000486988 /* lib */ = {isa = PBXFileReference; lastKnownFileType = folder; path = lib; sourceTree = "<group>"; };
-		29124C4A27613369001832A0 /* {{name}}.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "{{name}}.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		29124C4A27613369001832A0 /* app_name.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "app_name.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		29124C5C2761336B001832A0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		29124C5E2761336B001832A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		294A3C792763E9C6007B5B9A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -511,7 +511,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 		29124C4B27613369001832A0 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				29124C4A27613369001832A0 /* {{name}}.app */,
+				29124C4A27613369001832A0 /* app_name.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -535,9 +535,9 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		29124C4927613369001832A0 /* {{name}} */ = {
+		29124C4927613369001832A0 /* app_name */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget "{{name}}" */;
+			buildConfigurationList = 29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget "app_name" */;
 			buildPhases = (
 				29124C4627613369001832A0 /* Sources */,
 				29124C4727613369001832A0 /* Frameworks */,
@@ -547,9 +547,9 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 			);
 			dependencies = (
 			);
-			name = "{{name}}";
-			productName = "{{name}}";
-			productReference = 29124C4A27613369001832A0 /* {{name}}.app */;
+			name = "app_name";
+			productName = "app_name";
+			productReference = 29124C4A27613369001832A0 /* app_name.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -566,7 +566,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 					};
 				};
 			};
-			buildConfigurationList = 29124C4527613369001832A0 /* Build configuration list for PBXProject "{{name}}" */;
+			buildConfigurationList = 29124C4527613369001832A0 /* Build configuration list for PBXProject "app_name" */;
 			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -579,7 +579,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				29124C4927613369001832A0 /* {{name}} */,
+				29124C4927613369001832A0 /* app_name */,
 			);
 		};
 /* End PBXProject section */
@@ -752,7 +752,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
         GENERATE_INFOPLIST_FILE = YES;
         HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/include";
         INFOPLIST_FILE = Info.plist;
-        INFOPLIST_KEY_CFBundleDisplayName = "{{name}}";
+        INFOPLIST_KEY_CFBundleDisplayName = "app_name";
         INFOPLIST_KEY_LSApplicationCategoryType = Developer;
         INFOPLIST_KEY_NSCameraUsageDescription = "This app needs access to the camera";
         INFOPLIST_KEY_NSHumanReadableCopyright = "{{copyright}}";
@@ -803,7 +803,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
         GENERATE_INFOPLIST_FILE = YES;
         HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/include";
         INFOPLIST_FILE = Info.plist;
-        INFOPLIST_KEY_CFBundleDisplayName = "{{name}}";
+        INFOPLIST_KEY_CFBundleDisplayName = "app_name";
         INFOPLIST_KEY_LSApplicationCategoryType = Developer;
         INFOPLIST_KEY_NSCameraUsageDescription = "This app needs access to the camera";
         INFOPLIST_KEY_NSHumanReadableCopyright = "{{copyright}}";
@@ -837,7 +837,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-    29124C4527613369001832A0 /* Build configuration list for PBXProject "{{name}}" */ = {
+    29124C4527613369001832A0 /* Build configuration list for PBXProject "app_name" */ = {
       isa = XCConfigurationList;
       buildConfigurations = (
         29124C772761336B001832A0 /* Debug */,
@@ -846,7 +846,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
       defaultConfigurationIsVisible = 0;
       defaultConfigurationName = Release;
     };
-    29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget "{{name}}" */ = {
+    29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget "app_name" */ = {
       isa = XCConfigurationList;
       buildConfigurations = (
         29124C7A2761336B001832A0 /* Debug */,
@@ -1066,7 +1066,7 @@ dependencies {
 // Android top level `settings.gradle` in Groovy Syntax
 //
 constexpr auto gGradleSettings = R"GROOVY(
-rootProject.name = "{{name}}"
+rootProject.name = "app_name"
 include ':app'
 )GROOVY";
 
@@ -1237,7 +1237,7 @@ constexpr auto gAndroidLayoutWebviewActivity = R"XML(
 
 constexpr auto gAndroidValuesStrings = R"XML(
 <resources>
-  <string name="app_name">{{name}}</string>
+  <string name="app_name">app_name</string>
 </resources>
 )XML";
 
@@ -1261,9 +1261,9 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "29124C4927613369001832A0"
-               BuildableName = "{{name}}.app"
-               BlueprintName = "{{name}}"
-               ReferencedContainer = "container:{{name}}.xcodeproj">
+               BuildableName = "app_name.app"
+               BlueprintName = "app_name"
+               ReferencedContainer = "container:app_name.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -1291,9 +1291,9 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "29124C4927613369001832A0"
-            BuildableName = "{{name}}.app"
-            BlueprintName = "{{name}}"
-            ReferencedContainer = "container:{{name}}.xcodeproj">
+            BuildableName = "app_name.app"
+            BlueprintName = "app_name"
+            ReferencedContainer = "container:app_name.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
@@ -1308,9 +1308,9 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "29124C4927613369001832A0"
-            BuildableName = "{{name}}.app"
-            BlueprintName = "{{name}}"
-            ReferencedContainer = "container:{{name}}.xcodeproj">
+            BuildableName = "app_name.app"
+            BlueprintName = "app_name"
+            ReferencedContainer = "container:app_name.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>
@@ -1319,7 +1319,7 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"
-      customArchiveName = "{{name}}"
+      customArchiveName = "app_name"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>)XML";
@@ -1364,6 +1364,13 @@ constexpr auto gDefaultConfig = R"INI(
 ; do all the heavy lifting and should handle 99.9% of your use cases for moving
 ; files into place or tweaking platform-specific build artifacts. If you don't
 ; specify it, ssc will just copy everything in your project to the build target.
+; Only app_name 
+
+; The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
+app_name = "beepboop"
+
+; The title of the app, which will be displayed in the title bar. Can contain spaces and special characters. Defaults to app_name.
+app_title = "Beep Boop"
 
 ; build = "node build-script.js"
 
@@ -1378,9 +1385,6 @@ description = "A UI for the beep boop network"
 
 ; An list of environment variables, separated by commas.
 env = USER, TMPDIR, PWD
-
-; The name of the file to be output.
-executable = "boop"
 
 ; If false, the window will never be displayed.
 headless = false
@@ -1400,17 +1404,14 @@ lang = "en-us"
 ; A String used in the about dialog and meta info.
 maintainer = "Beep Boop Corp."
 
-; The name of the program
-name = "beepboop"
-
 ; The binary output path. It's recommended to add this path to .gitignore.
 output = "dist"
 
 ; TODO: maybe the user doesn't need to know about this? 
 revision = 123
 
-; A string that indicates the version of the application. It should be a semver triple like 1.0.0
-version = 0.0.1
+; A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
+version = 1.0.0
 
 [debug]
 

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -123,17 +123,17 @@ constexpr auto gPListInfo = R"XML(<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
   <key>CFBundleName</key>
-  <string>{{app_name}}</string>
+  <string>{{build_name}}</string>
   <key>DTSDKName</key>
   <string>macosx10.13</string>
   <key>DTXcode</key>
   <string>0941</string>
   <key>NSHumanReadableCopyright</key>
-  <string>{{copyright}}</string>
+  <string>{{meta_copyright}}</string>
   <key>DTSDKBuild</key>
   <string>10.13</string>
   <key>CFBundleVersion</key>
-  <string>v{{version}}</string>
+  <string>v{{meta_version}}</string>
   <key>BuildMachineOSBuild</key>
   <string>17D102</string>
   <key>NSCameraUsageDescription</key>
@@ -149,7 +149,7 @@ constexpr auto gPListInfo = R"XML(<?xml version="1.0" encoding="UTF-8"?>
   <key>CFBundleIconFile</key>
   <string>icon.icns</string>
   <key>CFBundleShortVersionString</key>
-  <string>{{version} Build {{revision}}</string>
+  <string>{{meta_version}}</string>
   <key>NSHighResolutionCapable</key>
   <true/>
   <key>NSMicrophoneUsageDescription</key>
@@ -193,7 +193,7 @@ constexpr auto gPListInfo = R"XML(<?xml version="1.0" encoding="UTF-8"?>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleExecutable</key>
-  <string>{{app_name}}</string>
+  <string>{{build_name}}</string>
   <key>DTCompiler</key>
   <string>com.apple.compilers.llvm.clang.1_0</string>
   <key>NSPrincipalClass</key>
@@ -201,7 +201,7 @@ constexpr auto gPListInfo = R"XML(<?xml version="1.0" encoding="UTF-8"?>
   <key>NSRequiresAquaSystemAppearance</key>
   <false/>
   <key>CFBundleIdentifier</key>
-  <string>{{bundle_identifier}}</string>
+  <string>{{meta_bundle_identifier}}</string>
   <key>LSApplicationCategoryType</key>
   <string>{{mac_category}}</string>
   <key>DTXcodeBuild</key>
@@ -209,13 +209,13 @@ constexpr auto gPListInfo = R"XML(<?xml version="1.0" encoding="UTF-8"?>
   <key>LSMinimumSystemVersion</key>
   <string>10.10.0</string>
   <key>CFBundleDisplayName</key>
-  <string>{{app_name}}</string>
+  <string>{{build_name}}</string>
   <key>NSSupportsAutomaticGraphicsSwitching</key>
   <true/>
   <key>SoftResourceLimits</key>
   <dict>
       <key>NumberOfFiles</key>
-      <integer>{{file_limit}}</integer>
+      <integer>{{meta_file_limit}}</integer>
   </dict>
   <key>WKAppBoundDomains</key>
   <array>
@@ -254,7 +254,7 @@ constexpr auto gAndroidManifest = R"XML(
     -->
   <application
     android:allowBackup="true"
-    android:label="{{app_title}}"
+    android:label="{{meta_title}}"
     android:theme="@style/Theme.AppCompat.Light"
     android:supportsRtl="true"
     {{android_allow_cleartext}}
@@ -277,23 +277,23 @@ constexpr auto gAndroidManifest = R"XML(
 constexpr auto gDestkopManifest = R"INI(
 [Desktop Entry]
 Encoding=UTF-8
-Version=v{{version}}
-Name={{app_name}}
+Version=v{{meta_version}}
+Name={{build_name}}
 Terminal=false
 Type=Application
 Exec={{linux_executable_path}}
 Icon={{linux_icon_path}}
-StartupWMClass={{app_name}}
-Comment={{description}}
+StartupWMClass={{build_name}}
+Comment={{meta_description}}
 Categories={{linux_categories}};
 )INI";
 
 constexpr auto gDebianManifest = R"DEB(Package: {{deb_name}}
-Version: {{version}}
+Version: {{meta_version}}
 Architecture: amd64
-Maintainer: {{maintainer}}
-Description: {{app_title}}
- {{description}}
+Maintainer: {{meta_maintainer}}
+Description: {{meta_title}}
+ {{meta_description}}
 )DEB";
 
 //
@@ -313,18 +313,18 @@ constexpr auto gWindowsAppManifest = R"XML(<?xml version="1.0" encoding="utf-8"?
     ProcessorArchitecture="neutral"
     Publisher="{{win_publisher}}"
     Version="{{win_version}}"
-    ResourceId="{{app_name}}"
+    ResourceId="{{build_name}}"
   />
 
   <Properties>
-    <DisplayName>{{app_title}}</DisplayName>
-    <Description>{{description}}</Description>
+    <DisplayName>{{meta_title}}</DisplayName>
+    <Description>{{meta_description}}</Description>
     <Logo>{{win_logo}}</Logo>
-    <PublisherDisplayName>{{maintainer}}</PublisherDisplayName>
+    <PublisherDisplayName>{{meta_maintainer}}</PublisherDisplayName>
   </Properties>
 
   <Resources>
-    <Resource Language="{{lang}}"/>
+    <Resource Language="{{meta_lang}}"/>
   </Resources>
 
   <Dependencies>
@@ -340,14 +340,14 @@ constexpr auto gWindowsAppManifest = R"XML(<?xml version="1.0" encoding="utf-8"?
   </Capabilities>
   <Applications>
     <Application
-      Id="{{app_name}}"
+      Id="{{build_name}}"
       EntryPoint="Windows.FullTrustApplication"
       Executable="{{exe}}"
     >
-      <uap:VisualElements DisplayName="{{app_title}}"
+      <uap:VisualElements DisplayName="{{meta_title}}"
         Square150x150Logo="{{win_logo}}"
         Square44x44Logo="{{win_logo}}"
-        Description="{{description}}"
+        Description="{{meta_description}}"
         BackgroundColor="#20123A"
       >
         <uap:DefaultTile Wide310x150Logo="{{win_logo}}" />
@@ -444,7 +444,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 		17E73FDA28FCC9320087604F /* common.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = common.hh; sourceTree = "<group>"; };
 		17E73FEE28FCD3360087604F /* libuv-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libuv-ios.a"; path = "lib/libuv-ios.a"; sourceTree = "<group>"; };
 		290F7F86276BC2B000486988 /* lib */ = {isa = PBXFileReference; lastKnownFileType = folder; path = lib; sourceTree = "<group>"; };
-		29124C4A27613369001832A0 /* {{app_name}}.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "{{app_name}}.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		29124C4A27613369001832A0 /* {{build_name}}.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "{{build_name}}.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		29124C5C2761336B001832A0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		29124C5E2761336B001832A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		294A3C792763E9C6007B5B9A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -511,7 +511,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 		29124C4B27613369001832A0 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				29124C4A27613369001832A0 /* {{app_name}}.app */,
+				29124C4A27613369001832A0 /* {{build_name}}.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -535,9 +535,9 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		29124C4927613369001832A0 /* {{app_name}} */ = {
+		29124C4927613369001832A0 /* {{build_name}} */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget "app_name" */;
+			buildConfigurationList = 29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget {{build_name}} */;
 			buildPhases = (
 				29124C4627613369001832A0 /* Sources */,
 				29124C4727613369001832A0 /* Frameworks */,
@@ -547,9 +547,9 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 			);
 			dependencies = (
 			);
-			name = "{{app_name}}";
-			productName = "{{app_name}}";
-			productReference = 29124C4A27613369001832A0 /* {{app_name}}.app */;
+			name = "{{build_name}}";
+			productName = "{{build_name}}";
+			productReference = 29124C4A27613369001832A0 /* {{build_name}}.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -566,7 +566,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 					};
 				};
 			};
-			buildConfigurationList = 29124C4527613369001832A0 /* Build configuration list for PBXProject "{{app_name}}" */;
+			buildConfigurationList = 29124C4527613369001832A0 /* Build configuration list for PBXProject "{{build_name}}" */;
 			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -579,7 +579,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				29124C4927613369001832A0 /* {{app_name}} */,
+				29124C4927613369001832A0 /* {{build_name}} */,
 			);
 		};
 /* End PBXProject section */
@@ -752,10 +752,10 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
         GENERATE_INFOPLIST_FILE = YES;
         HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/include";
         INFOPLIST_FILE = Info.plist;
-        INFOPLIST_KEY_CFBundleDisplayName = "{{app_name}}";
+        INFOPLIST_KEY_CFBundleDisplayName = "{{build_name}}";
         INFOPLIST_KEY_LSApplicationCategoryType = Developer;
         INFOPLIST_KEY_NSCameraUsageDescription = "This app needs access to the camera";
-        INFOPLIST_KEY_NSHumanReadableCopyright = "{{copyright}}";
+        INFOPLIST_KEY_NSHumanReadableCopyright = "{{meta_copyright}}";
         INFOPLIST_KEY_NSMicrophoneUsageDescription = "This app needs access to the microphone";
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
         INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -774,7 +774,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
           "-DHOST={{host}}",
           "-DPORT={{port}}",
         );
-        PRODUCT_BUNDLE_IDENTIFIER = "{{bundle_identifier}}";
+        PRODUCT_BUNDLE_IDENTIFIER = "{{meta_bundle_identifier}}";
         PRODUCT_NAME = "$(TARGET_NAME)";
         PROVISIONING_PROFILE_SPECIFIER = "{{ios_provisioning_specifier}}";
         SWIFT_EMIT_LOC_STRINGS = YES;
@@ -803,10 +803,10 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
         GENERATE_INFOPLIST_FILE = YES;
         HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/include";
         INFOPLIST_FILE = Info.plist;
-        INFOPLIST_KEY_CFBundleDisplayName = "{{app_name}}";
+        INFOPLIST_KEY_CFBundleDisplayName = "{{build_name}}";
         INFOPLIST_KEY_LSApplicationCategoryType = Developer;
         INFOPLIST_KEY_NSCameraUsageDescription = "This app needs access to the camera";
-        INFOPLIST_KEY_NSHumanReadableCopyright = "{{copyright}}";
+        INFOPLIST_KEY_NSHumanReadableCopyright = "{{meta_copyright}}";
         INFOPLIST_KEY_NSMicrophoneUsageDescription = "This app needs access to the microphone";
         INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
         INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -822,7 +822,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
         LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/lib";
         MARKETING_VERSION = 1.0;
         ONLY_ACTIVE_ARCH = YES;
-        PRODUCT_BUNDLE_IDENTIFIER = "{{bundle_identifier}}";
+        PRODUCT_BUNDLE_IDENTIFIER = "{{meta_bundle_identifier}}";
         PRODUCT_NAME = "$(TARGET_NAME)";
         PROVISIONING_PROFILE_SPECIFIER = "{{ios_provisioning_specifier}}";
         SWIFT_EMIT_LOC_STRINGS = YES;
@@ -837,7 +837,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-    29124C4527613369001832A0 /* Build configuration list for PBXProject "{{app_name}}" */ = {
+    29124C4527613369001832A0 /* Build configuration list for PBXProject "{{build_name}}" */ = {
       isa = XCConfigurationList;
       buildConfigurations = (
         29124C772761336B001832A0 /* Debug */,
@@ -846,7 +846,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
       defaultConfigurationIsVisible = 0;
       defaultConfigurationName = Release;
     };
-    29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget "{{app_name}}" */ = {
+    29124C792761336B001832A0 /* Build configuration list for PBXNativeTarget "{{build_name}}" */ = {
       isa = XCConfigurationList;
       buildConfigurations = (
         29124C7A2761336B001832A0 /* Debug */,
@@ -884,7 +884,7 @@ constexpr auto gXCodeExportOptions = R"XML(<?xml version="1.0" encoding="UTF-8"?
   <string>{{ios_codesign_identity}}</string>
   <key>provisioningProfiles</key>
   <dict>
-    <key>{{bundle_identifier}}</key>
+    <key>{{meta_bundle_identifier}}</key>
     <string>{{ios_provisioning_profile}}</string>
   </dict>
 </dict>
@@ -895,7 +895,7 @@ constexpr auto gXCodePlist = R"XML(<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
   <key>CFBundleIdentifier</key>
-  <string>{{bundle_identifier}}</string>
+  <string>{{meta_bundle_identifier}}</string>
   <key>CFBundleIconFile</key>
   <string>ui/icon.png</string>
   <key>NSAppTransportSecurity</key>
@@ -995,14 +995,14 @@ android {
   compileSdkVersion 33
   ndkVersion "25.0.8775105"
   flavorDimensions "default"
-  namespace '{{bundle_identifier}}'
+  namespace '{{meta_bundle_identifier}}'
 
   defaultConfig {
-    applicationId "{{bundle_identifier}}"
+    applicationId "{{meta_bundle_identifier}}"
     minSdkVersion 26
     targetSdkVersion 33
-    versionCode {{revision}}
-    versionName "{{version}}"
+    versionCode {{meta_revision}}
+    versionName "{{meta_version}}"
 
     ndk {
       abiFilters {{android_ndk_abi_filters}}
@@ -1066,7 +1066,7 @@ dependencies {
 // Android top level `settings.gradle` in Groovy Syntax
 //
 constexpr auto gGradleSettings = R"GROOVY(
-rootProject.name = "{{app_name}}"
+rootProject.name = "{{build_name}}"
 include ':app'
 )GROOVY";
 
@@ -1237,7 +1237,7 @@ constexpr auto gAndroidLayoutWebviewActivity = R"XML(
 
 constexpr auto gAndroidValuesStrings = R"XML(
 <resources>
-  <string name="app_name">{{app_name}}</string>
+  <string name="app_name">{{build_name}}</string>
 </resources>
 )XML";
 
@@ -1261,9 +1261,9 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "29124C4927613369001832A0"
-               BuildableName = "{{app_name}}.app"
-               BlueprintName = "{{app_name}}"
-               ReferencedContainer = "container:{{app_name}}.xcodeproj">
+               BuildableName = "{{build_name}}.app"
+               BlueprintName = "{{build_name}}"
+               ReferencedContainer = "container:{{build_name}}.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -1291,9 +1291,9 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "29124C4927613369001832A0"
-            BuildableName = "{{app_name}}.app"
-            BlueprintName = "{{app_name}}"
-            ReferencedContainer = "container:{{app_name}}.xcodeproj">
+            BuildableName = "{{build_name}}.app"
+            BlueprintName = "{{build_name}}"
+            ReferencedContainer = "container:{{build_name}}.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
@@ -1308,9 +1308,9 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "29124C4927613369001832A0"
-            BuildableName = "{{app_name}}.app"
-            BlueprintName = "{{app_name}}"
-            ReferencedContainer = "container:{{app_name}}.xcodeproj">
+            BuildableName = "{{build_name}}.app"
+            BlueprintName = "{{build_name}}"
+            ReferencedContainer = "container:{{build_name}}.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>
@@ -1319,7 +1319,7 @@ constexpr auto gXCodeScheme = R"XML(<?xml version="1.0" encoding="UTF-8"?>
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"
-      customArchiveName = "{{app_name}}"
+      customArchiveName = "{{build_name}}"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>)XML";
@@ -1359,19 +1359,40 @@ constexpr auto gDefaultConfig = R"INI(
 ; Socket ⚡︎ Runtime · A modern runtime for Web Apps · v{{ssc_version}}
 ;
 
-; The value of the "build" property will be interpreted as a shell command when
+; The value of the "script" property in a build section will be interpreted as a shell command when
 ; you run "ssc build". This is the most important command in this file. It will
 ; do all the heavy lifting and should handle 99.9% of your use cases for moving
 ; files into place or tweaking platform-specific build artifacts. If you don't
 ; specify it, ssc will just copy everything in your project to the build target.
 
+[build]
+
+; Advanced Compiler Settings for debug purposes (ie C++ compiler -g, etc).
+debug_flags = "-g"
+
+; An list of environment variables, separated by commas.
+env = USER, TMPDIR, PWD
+
+; Advanced Compiler Settings (ie C++ compiler -02, -03, etc).
+flags = -O3
+
+; If false, the window will never be displayed.
+headless = false
+
+; A directory is where your application's code is located.
+input = "src"
+
 ; The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
-app_name = "beepboop"
+name = "beepboop"
 
-; The title of the app used in metadata files. This is NOT a window title. Can contain spaces and special characters. Defaults to app_name.
-app_title = "Beep Boop"
+; The binary output path. It's recommended to add this path to .gitignore.
+output = "dist"
 
-; build = "node build-script.js"
+; The build script
+; script = "node build-script.js"
+
+
+[meta]
 
 ; A unique ID that identifies the bundle (used by all app stores).
 bundle_identifier = "com.beepboop"
@@ -1382,20 +1403,8 @@ copyright = "(c) Beep Boop Corp. 1985"
 ; A short description of the app.
 description = "A UI for the beep boop network"
 
-; An list of environment variables, separated by commas.
-env = USER, TMPDIR, PWD
-
-; If false, the window will never be displayed.
-headless = false
-
-; Advanced Compiler Settings (ie C++ compiler -02, -03, etc).
-flags = -O3
-
 ; Set the limit of files that can be opened by your process.
 file_limit = 1024
-
-; A directory is where your application's code is located.
-input = "src"
 
 ; Localization
 lang = "en-us"
@@ -1403,19 +1412,11 @@ lang = "en-us"
 ; A String used in the about dialog and meta info.
 maintainer = "Beep Boop Corp."
 
-; The binary output path. It's recommended to add this path to .gitignore.
-output = "dist"
-
-; TODO: maybe the user doesn't need to know about this? 
-revision = 123
+; The title of the app used in metadata files. This is NOT a window title. Can contain spaces and special characters. Defaults to name in a [build] section.
+title = "Beep Boop"
 
 ; A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
 version = 1.0.0
-
-[debug]
-
-; Advanced Compiler Settings for debug purposes (ie C++ compiler -g, etc).
-flags = "-g"
 
 
 [android]

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1391,7 +1391,7 @@ output = "dist"
 
 [debug]
 ; Advanced Compiler Settings for debug purposes (ie C++ compiler -g, etc).
-debug_flags = "-g"
+flags = "-g"
 
 
 [meta]

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -166,13 +166,13 @@ MAIN {
   }
 
   if (isDebugEnabled()) {
-    app.appData["name"] += "-dev";
+    app.appData["app_name"] += "-dev";
   }
 
-  app.appData["name"] += suffix;
+  app.appData["app_name"] += suffix;
 
   argvForward << " --version=v" << app.appData["version"];
-  argvForward << " --name=" << app.appData["name"];
+  argvForward << " --name=" << app.appData["app_name"];
 
   if (isDebugEnabled()) {
     argvForward << " --debug=1";

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -171,7 +171,7 @@ MAIN {
 
   app.appData["build_name"] += suffix;
 
-  argvForward << " --version=v" << app.appData["version"];
+  argvForward << " --version=v" << app.appData["meta_version"];
   argvForward << " --name=" << app.appData["build_name"];
 
   if (isDebugEnabled()) {

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -166,20 +166,20 @@ MAIN {
   }
 
   if (isDebugEnabled()) {
-    app.appData["app_name"] += "-dev";
+    app.appData["build_name"] += "-dev";
   }
 
-  app.appData["app_name"] += suffix;
+  app.appData["build_name"] += suffix;
 
   argvForward << " --version=v" << app.appData["version"];
-  argvForward << " --name=" << app.appData["app_name"];
+  argvForward << " --name=" << app.appData["build_name"];
 
   if (isDebugEnabled()) {
     argvForward << " --debug=1";
   }
 
   SSC::StringStream env;
-  for (auto const &envKey : split(app.appData["env"], ',')) {
+  for (auto const &envKey : split(app.appData["build_env"], ',')) {
     auto cleanKey = trim(envKey);
     auto envValue = getEnv(cleanKey.c_str());
 

--- a/src/mobile/ios.mm
+++ b/src/mobile/ios.mm
@@ -187,7 +187,7 @@ static dispatch_queue_t queue = dispatch_queue_create(
 
   StringStream env;
 
-  for (auto const &envKey : split(appData["env"], ',')) {
+  for (auto const &envKey : split(appData["build_env"], ',')) {
     auto cleanKey = trim(envKey);
     auto envValue = getEnv(cleanKey.c_str());
 

--- a/src/window/linux.cc
+++ b/src/window/linux.cc
@@ -723,7 +723,7 @@ namespace SSC {
 
     gtk_box_pack_start(GTK_BOX(content), img, false, false, 0);
 
-    String title_value(app.appData["name"] + " v" + app.appData["version"]);
+    String title_value(app.appData["app_name"] + " v" + app.appData["version"]);
     String version_value("Built with ssc v" + SSC::VERSION_FULL_STRING);
 
     GtkWidget *label_title = gtk_label_new("");

--- a/src/window/linux.cc
+++ b/src/window/linux.cc
@@ -723,7 +723,7 @@ namespace SSC {
 
     gtk_box_pack_start(GTK_BOX(content), img, false, false, 0);
 
-    String title_value(app.appData["build_name"] + " v" + app.appData["version"]);
+    String title_value(app.appData["build_name"] + " v" + app.appData["meta_version"]);
     String version_value("Built with ssc v" + SSC::VERSION_FULL_STRING);
 
     GtkWidget *label_title = gtk_label_new("");

--- a/src/window/linux.cc
+++ b/src/window/linux.cc
@@ -706,7 +706,7 @@ namespace SSC {
     GtkContainer *content = GTK_CONTAINER(body);
 
     String imgPath = "/usr/share/icons/hicolor/256x256/apps/" +
-      app.appData["executable"] +
+      app.appData["build_name"] +
       ".png";
 
     GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file_at_scale(
@@ -723,7 +723,7 @@ namespace SSC {
 
     gtk_box_pack_start(GTK_BOX(content), img, false, false, 0);
 
-    String title_value(app.appData["app_name"] + " v" + app.appData["version"]);
+    String title_value(app.appData["build_name"] + " v" + app.appData["version"]);
     String version_value("Built with ssc v" + SSC::VERSION_FULL_STRING);
 
     GtkWidget *label_title = gtk_label_new("");
@@ -735,7 +735,7 @@ namespace SSC {
     gtk_container_add(content, label_op_version);
 
     GtkWidget *label_copyright = gtk_label_new("");
-    gtk_label_set_markup(GTK_LABEL(label_copyright), app.appData["copyright"].c_str());
+    gtk_label_set_markup(GTK_LABEL(label_copyright), app.appData["meta_copyright"].c_str());
     gtk_container_add(content, label_copyright);
 
     g_signal_connect(

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -978,10 +978,10 @@ namespace SSC {
 
   void Window::about () {
     auto text = SSC::String(
-      app.appData["app_name"] + " " +
+      app.appData["build_name"] + " " +
       "v" + app.appData["version"] + "\n" +
       "Built with ssc v" + SSC::VERSION_FULL_STRING + "\n" +
-      app.appData["copyright"]
+      app.appData["meta_copyright"]
     );
 
     MSGBOXPARAMS mbp;
@@ -989,7 +989,7 @@ namespace SSC {
     mbp.hwndOwner = window;
     mbp.hInstance = app.hInstance;
     mbp.lpszText = text.c_str();
-    mbp.lpszCaption = app.appData["app_name"].c_str();
+    mbp.lpszCaption = app.appData["build_name"].c_str();
     mbp.dwStyle = MB_USERICON;
     mbp.dwLanguageId = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);
     mbp.lpfnMsgBoxCallback = NULL;

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -979,7 +979,7 @@ namespace SSC {
   void Window::about () {
     auto text = SSC::String(
       app.appData["build_name"] + " " +
-      "v" + app.appData["version"] + "\n" +
+      "v" + app.appData["meta_version"] + "\n" +
       "Built with ssc v" + SSC::VERSION_FULL_STRING + "\n" +
       app.appData["meta_copyright"]
     );

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -978,7 +978,7 @@ namespace SSC {
 
   void Window::about () {
     auto text = SSC::String(
-      app.appData["name"] + " " +
+      app.appData["app_name"] + " " +
       "v" + app.appData["version"] + "\n" +
       "Built with ssc v" + SSC::VERSION_FULL_STRING + "\n" +
       app.appData["copyright"]
@@ -989,7 +989,7 @@ namespace SSC {
     mbp.hwndOwner = window;
     mbp.hInstance = app.hInstance;
     mbp.lpszText = text.c_str();
-    mbp.lpszCaption = app.appData["name"].c_str();
+    mbp.lpszCaption = app.appData["app_name"].c_str();
     mbp.dwStyle = MB_USERICON;
     mbp.dwLanguageId = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);
     mbp.lpfnMsgBoxCallback = NULL;

--- a/src/window/window.hh
+++ b/src/window/window.hh
@@ -418,7 +418,7 @@ namespace SSC {
         }
 
         if (opts.appData.size() > 0) {
-          for (auto const &envKey : split(opts.appData["env"], ',')) {
+          for (auto const &envKey : split(opts.appData["build_env"], ',')) {
             auto cleanKey = trim(envKey);
             auto envValue = getEnv(cleanKey.c_str());
 
@@ -427,7 +427,7 @@ namespace SSC {
             );
           }
         } else {
-          for (auto const &envKey : split(this->options.appData["env"], ',')) {
+          for (auto const &envKey : split(this->options.appData["build_env"], ',')) {
             auto cleanKey = trim(envKey);
             auto envValue = getEnv(cleanKey.c_str());
 
@@ -454,7 +454,7 @@ namespace SSC {
           .index = opts.index,
           .debug = isDebugEnabled() || opts.debug,
           .isTest = this->options.isTest,
-          .headless = this->options.headless || opts.headless || opts.appData["headless"] == "true",
+          .headless = this->options.headless || opts.headless || opts.appData["build_headless"] == "true",
 
           .cwd = this->options.cwd,
           .title = opts.title.size() > 0 ? opts.title : "",

--- a/test/socket.ini
+++ b/test/socket.ini
@@ -1,5 +1,5 @@
 [build]
-name = "socketsupply-socket-tests"
+name = "socket-runtime-javascript-tests"
 input = src
 build = node build.js
 output = build
@@ -11,8 +11,8 @@ env = "TMPDIR, TMP, TEMP, HOME, PWD"
 
 ; Package Metadata
 [meta]
+title = "Socket API Tests"
 version = "1.0.0"
-name = "socket-runtime-javascript-tests"
 description = "Socket Runtime JavaScript Tests"
 lang = en-US
 copyright = "Socket Supply Co. © 2021-2022"

--- a/test/socket.ini
+++ b/test/socket.ini
@@ -8,7 +8,7 @@ executable = socket-tests
 flags = "-O3 -g"
 
 ; Package Metadata
-version = "1.1110.0"
+version = "1.0.0"
 revision = 1
 name = "socket-runtime-javascript-tests"
 description = "Socket Runtime JavaScript Tests"

--- a/test/socket.ini
+++ b/test/socket.ini
@@ -1,7 +1,7 @@
 [build]
 name = "socket-runtime-javascript-tests"
 input = src
-build = node build.js
+script = node build.js
 output = build
 ; Compiler Settings
 flags = "-O3 -g"

--- a/test/socket.ini
+++ b/test/socket.ini
@@ -1,4 +1,5 @@
 [build]
+name = "socketsupply-socket-tests"
 input = src
 build = node build.js
 output = build

--- a/test/socket.ini
+++ b/test/socket.ini
@@ -5,7 +5,6 @@ script = node build.js
 output = build
 ; Compiler Settings
 flags = "-O3 -g"
-debug_flags = -g
 headless = true
 env = "TMPDIR, TMP, TEMP, HOME, PWD"
 
@@ -18,6 +17,9 @@ lang = en-US
 copyright = "Socket Supply Co. © 2021-2022"
 maintainer = "Socket Supply Co."
 bundle_identifier = co.socketsupply.socket.tests
+
+[debug]
+flags = -g
 
 [window]
 width = 80%

--- a/test/socket.ini
+++ b/test/socket.ini
@@ -8,7 +8,7 @@ executable = socket-tests
 flags = "-O3 -g"
 
 ; Package Metadata
-version = "1.0.0"
+version = "1.1110.0"
 revision = 1
 name = "socket-runtime-javascript-tests"
 description = "Socket Runtime JavaScript Tests"

--- a/test/socket.ini
+++ b/test/socket.ini
@@ -1,15 +1,16 @@
-; Build Settings
+[build]
 input = src
 build = node build.js
 output = build
-executable = socket-tests
-
 ; Compiler Settings
 flags = "-O3 -g"
+debug_flags = -g
+headless = true
+env = "TMPDIR, TMP, TEMP, HOME, PWD"
 
 ; Package Metadata
+[meta]
 version = "1.0.0"
-revision = 1
 name = "socket-runtime-javascript-tests"
 description = "Socket Runtime JavaScript Tests"
 lang = en-US
@@ -17,16 +18,10 @@ copyright = "Socket Supply Co. © 2021-2022"
 maintainer = "Socket Supply Co."
 bundle_identifier = co.socketsupply.socket.tests
 
-headless = true
-
-env = "TMPDIR, TMP, TEMP, HOME, PWD"
-
 [window]
 width = 80%
 height = 80%
 
-[debug]
-flags = -g
 [mac]
 cmd = "node backend.js"
 [linux]

--- a/test/src/runtime.js
+++ b/test/src/runtime.js
@@ -52,7 +52,7 @@ if (window.__args.os !== 'android' && window.__args.os !== 'ios') {
       value = value.trim().replace(/"/g, '')
       config.push([prefix.length === 0 ? key : prefix + '_' + key, value])
     }
-    config.filter(([key]) => key !== 'headless' && key !== 'app_name').forEach(([key, value]) => {
+    config.filter(([key]) => key !== 'headless' && key !== 'build_name').forEach(([key, value]) => {
       t.equal(runtime.config[key], value, `runtime.config.${key} is correct`)
       t.throws(
         () => { runtime.config[key] = 0 },
@@ -68,12 +68,12 @@ if (window.__args.os !== 'android' && window.__args.os !== 'ios') {
       RegExp('Attempting to define property on object that is not extensible.'),
       'runtime.config.headless is read-only'
     )
-    t.ok(runtime.config.app_name.startsWith(config.find(([key]) => key === 'app_name')[1]), 'runtime.config.app_name is correct')
+    t.ok(runtime.config.build_name.startsWith(config.find(([key]) => key === 'build_name')[1]), 'runtime.config.build_name is correct')
     t.throws(
-      () => { runtime.config.app_name = 0 },
+      () => { runtime.config.build_name = 0 },
       // eslint-disable-next-line prefer-regex-literals
       RegExp('Attempted to assign to readonly property.'),
-      'runtime.config.app_name is read-only'
+      'runtime.config.build_name is read-only'
     )
   })
 

--- a/test/src/runtime.js
+++ b/test/src/runtime.js
@@ -65,7 +65,7 @@ if (window.__args.os !== 'android' && window.__args.os !== 'ios') {
     t.throws(
       () => { runtime.config.build_headless = 0 },
       // eslint-disable-next-line prefer-regex-literals
-      RegExp('Attempting to define property on object that is not extensible.'),
+      RegExp('Attempted to assign to readonly property.'),
       'runtime.config.build_headless is read-only'
     )
     t.ok(runtime.config.build_name.startsWith(config.find(([key]) => key === 'build_name')[1]), 'runtime.config.build_name is correct')

--- a/test/src/runtime.js
+++ b/test/src/runtime.js
@@ -52,7 +52,7 @@ if (window.__args.os !== 'android' && window.__args.os !== 'ios') {
       value = value.trim().replace(/"/g, '')
       config.push([prefix.length === 0 ? key : prefix + '_' + key, value])
     }
-    config.filter(([key]) => key !== 'headless' && key !== 'build_name').forEach(([key, value]) => {
+    config.filter(([key]) => key !== 'build_headless' && key !== 'build_name').forEach(([key, value]) => {
       t.equal(runtime.config[key], value, `runtime.config.${key} is correct`)
       t.throws(
         () => { runtime.config[key] = 0 },
@@ -61,12 +61,12 @@ if (window.__args.os !== 'android' && window.__args.os !== 'ios') {
         `runtime.config.${key} is read-only`
       )
     })
-    t.equal(runtime.config.headless, true, 'runtime.config.headless is correct')
+    t.equal(runtime.config.build_headless, true, 'runtime.config.build_headless is correct')
     t.throws(
-      () => { runtime.config.hedless = 0 },
+      () => { runtime.config.build_headless = 0 },
       // eslint-disable-next-line prefer-regex-literals
       RegExp('Attempting to define property on object that is not extensible.'),
-      'runtime.config.headless is read-only'
+      'runtime.config.build_headless is read-only'
     )
     t.ok(runtime.config.build_name.startsWith(config.find(([key]) => key === 'build_name')[1]), 'runtime.config.build_name is correct')
     t.throws(

--- a/test/src/runtime.js
+++ b/test/src/runtime.js
@@ -52,7 +52,7 @@ if (window.__args.os !== 'android' && window.__args.os !== 'ios') {
       value = value.trim().replace(/"/g, '')
       config.push([prefix.length === 0 ? key : prefix + '_' + key, value])
     }
-    config.filter(([key]) => key !== 'headless' && key !== 'name').forEach(([key, value]) => {
+    config.filter(([key]) => key !== 'headless' && key !== 'app_name').forEach(([key, value]) => {
       t.equal(runtime.config[key], value, `runtime.config.${key} is correct`)
       t.throws(
         () => { runtime.config[key] = 0 },
@@ -68,12 +68,12 @@ if (window.__args.os !== 'android' && window.__args.os !== 'ios') {
       RegExp('Attempting to define property on object that is not extensible.'),
       'runtime.config.headless is read-only'
     )
-    t.ok(runtime.config.name.startsWith(config.find(([key]) => key === 'name')[1]), 'runtime.config.name is correct')
+    t.ok(runtime.config.app_name.startsWith(config.find(([key]) => key === 'app_name')[1]), 'runtime.config.app_name is correct')
     t.throws(
-      () => { runtime.config.name = 0 },
+      () => { runtime.config.app_name = 0 },
       // eslint-disable-next-line prefer-regex-literals
       RegExp('Attempted to assign to readonly property.'),
-      'runtime.config.name is read-only'
+      'runtime.config.app_name is read-only'
     )
   })
 


### PR DESCRIPTION
It's confusing to have all three: `name`, `title` and `executable`

Changes in this PR:
- previously ungrouped fields are in either `[build]` or `[meta]` section now
- new field ~~`app_name`~~ `[debug] name` — string without spaces and special symbols; instead of `name` and `executable`
- new field ~~`app_title`~~ `[meta] title` — any string; instead of `title`
- only ~~`app_name`~~ `[debug] name` is required now; default value for `version` is `1.0.0`
- ~~`app_name`~~ `[debug] name` validation; supports alphanumerical characters, dash and underscore
- ~~`version`~~ `[meta] version` validation; supports semver triple 
- hides `revision` field from the user
- `build` is `[build] script` now

also see https://github.com/socketsupply/socket/pull/124#issuecomment-1408740946

fixes #83