### PR TITLE
Adds a symmetrical API for user-space IPC

### DIFF
--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -65,6 +65,8 @@ MAIN {
   // their instantiation and destruction.
   static App app(instanceId);
   static WindowManager windowManager(app);
+  static Mutex mutexStdout;
+  static Mutex mutexStdin;
 
   // TODO(trevnorris): Since App is a singleton, follow the CppCoreGuidelines
   // better in how it's handled in the future.
@@ -301,6 +303,8 @@ MAIN {
   // Launch the backend process and connect callbacks to the stdio and stderr pipes.
   //
   auto onStdOut = [&](SSC::String const &out) {
+    Lock lock(mutexStdout);
+
     //
     // ## Dispatch
     // Messages from the backend process may be sent to the render process. If they
@@ -414,6 +418,8 @@ MAIN {
   // main thread.
   //
   auto onMessage = [&](auto out) {
+    Lock lock(mutexStdin);
+
     // debug("onMessage %s", out.c_str());
     IPC::Message message(out);
 


### PR DESCRIPTION
On the node.js or deno side...

```js
import { IPC } from '@socketsupply/socket/ipc.js'
const ipc = new IPC()

const value = { foo: true }

// send to window 0, expect a response
const result = await ipc.request({ window: 0, value })

// send to all windows, (assume window 0) expect a response
const res = await ipc.request({ value })

// send to window 1, don't expect a response
const ipc.send({ window: 1, value })

// send to window 0, don't expect a response
const ipc.send({ value })

// a request to respond to an ipc message ("req" includes the index and seq)
ipc.on('request', (req, value) => {
  ipc.respond(req, value)
})
```

on the Socket side...

```js
import { IPC } from 'socket:ipc'
const ipc = new IPC()

const value = { foo: true }

// send to window 0, expect a response
const res = await ipc.request({ value })

// send to the backend
const ipc.send({ value })

// send to window 2
const ipc.send({ window: 2, value })

// a request to respond to an ipc message ("req" includes the index and seq)
ipc.on('request', (req, value) => {
  ipc.respond(req, value)
})
```