### PR TITLE
windows: fix url file pathing

### DIFF
--- a/test/build.js
+++ b/test/build.js
@@ -5,7 +5,7 @@ import os from 'node:os'
 
 import esbuild from 'esbuild'
 
-const dirname = path.resolve(path.dirname(import.meta.url.replace('file://', '').replace('C:/', '')))
+const dirname = path.resolve(path.dirname(import.meta.url.replace('file://', '').replace(/^\/[A-Za-z]:\//, '/')))
 
 const cp = async (a, b) => fs.cp(
   path.resolve(a),


### PR DESCRIPTION
When altering the file:/// url, in Windows it includes the drive letter. e.g. file:///C:/. Make sure to do a regex match to catch any drive letter.