### PR TITLE
``./scripts-desktop.sh`` invalid syntax on win32.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "scripts": {
-    "pretest": "standard .",
+    "pretest": "npx standard .",
     "readme": "node ./bin/generate-docs.js",
     "test": "cd test && npm install --silent --no-audit && npm test",
     "test:node": "node ./test/node/index.js",

--- a/test/package.json
+++ b/test/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "scripts": {
     "test": "npm run test:desktop",
-    "test:desktop": "./scripts/test-desktop.sh",
-    "test:android": "./scripts/test-android.sh",
-    "test:ios-simulator": "./scripts/test-ios-simulator.sh",
-    "test:android-emulator": "./scripts/test-android-emulator.sh",
+    "test:desktop": "sh ./scripts/test-desktop.sh",
+    "test:android": "sh ./scripts/test-android.sh",
+    "test:ios-simulator": "sh ./scripts/test-ios-simulator.sh",
+    "test:android-emulator": "sh ./scripts/test-android-emulator.sh",
     "start": "npm test"
   },
   "dependencies": {


### PR DESCRIPTION
```
'.' is not recognized as an internal or external command,
```

We have 3 options:
1. Tell user to run ``npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"``, not great
2. Prefix all scripts with ``bash`` eg ``"test:desktop": "bash ./scripts/test-desktop.sh"`` - This doesn't work, ``PATH`` seems to be lost and ``ssc.exe`` can't be found
3. Prefix all scripts with ``sh`` eg ``"test:desktop": "sh ./scripts/test-desktop.sh",`` - This works on mac and windows

I have elected to go with 3.

Also updated ``standard`` call so that global install isn't required, user will now be prompted to install by ``npx``:
```
> npx standard .

Need to install the following packages:
  standard@17.0.0
Ok to proceed? (y)
```