### PR TITLE
windows ipc: scheme support

### DIFF
--- a/api/dgram.js
+++ b/api/dgram.js
@@ -11,6 +11,7 @@ import { EventEmitter } from './events.js'
 import { Buffer } from './buffer.js'
 import { rand64 } from './crypto.js'
 import { isIPv4 } from './net.js'
+import process from './process.js'
 import * as ipc from './ipc.js'
 import console from './console.js'
 import dns from './dns.js'
@@ -160,7 +161,8 @@ function getDefaultAddress (socket, local) {
     if (socket.type === 'udp4') return '127.0.0.1'
     if (socket.type === 'udp6') return '::1'
   } else {
-    if (socket.type === 'udp4') return '0.0.0.0'
+    const IP = process.platform === 'win32' ? '127.0.0.1' : '0.0.0.0'
+    if (socket.type === 'udp4') return IP
     if (socket.type === 'udp6') return '::'
   }
 

--- a/api/ipc.js
+++ b/api/ipc.js
@@ -79,9 +79,45 @@ function initializeXHRIntercept () {
           typeof body !== 'undefined' &&
           typeof seq !== 'undefined'
         ) {
+          if (typeof body === 'string') {
+            body = encoder.encode(body)
+          }
+
           if (/android/i.test(window.__args.os)) {
             await postMessage(`ipc://buffer.map?seq=${seq}`, body)
             body = null
+          }
+
+          if (/win32/i.test(window.__args.os) && body) {
+            // 1. send `ipc://buffer.create`
+            //   - The native side should create a shared buffer for `index` and `seq` pair of `size` bytes
+            //   - `index` is the target window
+            //   - `seq` is the sequence is used to know how to return the value to the sender
+            // 2. wait for 'sharedbufferreceived' event
+            //   - The webview will wait for this event on `window`
+            //   - The event should include "additional data" that is JSON and includes the `index` and `seq` values
+            // 3. filter on `index` and `seq` for this request
+            //   - The webview will filter on the `index` and `seq` values before calling `getBuffer()`
+            // 4. write `body` to _shared_ `buffer`
+            //   - The webview should write all bytes to the buffer
+            // 5. resolve promise
+            //   - After promise resolution, the XHR request will continue
+            //   - The native side should look up the shared buffer for the `index` and `seq` values and use it
+            //     as the bytes for the request when routing the IPC request through the bridge router
+            //   - The native side should release the shared buffer
+            // size here assumes latin1 encoding.
+            await postMessage(`ipc://buffer.create?index=${index}&seq=${seq}&size=${body.length}`)
+            await new Promise((resolve) => {
+              window.chrome.webview.addEventListener('sharedbufferreceived', function onSharedBufferReceived (event) {
+                const { additionalData } = event
+                if (additionalData.index === index && additionalData.seq === seq) {
+                  const buffer = new Uint8Array(event.getBuffer())
+                  buffer.set(body)
+                  window.chrome.webview.removeEventListener('sharedbufferreceived', onSharedBufferReceived)
+                  resolve()
+                }
+              })
+            })
           }
 
           if (/linux/i.test(window.__args.os)) {

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -1,4 +1,4 @@
-param([Switch]$debug, [Switch]$skipwebview, $webview = "1.0.1369-prerelease", $uv = "v1.44.2")
+param([Switch]$debug, [Switch]$skipwebview, $webview = "1.0.1619-prerelease", $uv = "v1.44.2")
 
 $OLD_CWD = (Get-Location).Path
 
@@ -134,7 +134,7 @@ Function Install-WebView2 {
 
   # download and extract
   Write-Output "# downloading WebView2 ${WEBVIEW2_VERSION} header and library files..."
-  Invoke-WebRequest "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/1.0.1369-prerelease" -O "$tmpdir\webview2.zip"
+  Invoke-WebRequest "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${WEBVIEW2_VERSION}" -O "$tmpdir\webview2.zip"
   Expand-Archive -Path $tmpdir\WebView2.zip -DestinationPath $tmpdir\WebView2
 
   # install files into project `lib\` dir

--- a/src/core/core.cc
+++ b/src/core/core.cc
@@ -143,9 +143,8 @@ namespace SSC {
       "  });                                                         \n"
       "};                                                            \n"
       "                                                              \n"
-      "const protocol = __args.os === 'win32' ? 'http:' : 'ipc:';    \n"
-      "xhr.open('GET', `${protocol}//post?id=" + sid + "`);          \n"
-      "xhr.setRequestHeader('x-ipc-request', 'post');                \n"
+      "xhr.open('GET', `ipc://post?id=" + sid + "`);                 \n"
+      "xhr.setRequestHeader('Access-Control-Allow-Origin', '*');     \n"
       "xhr.send();                                                   \n"
     );
 

--- a/src/ipc/bridge.cc
+++ b/src/ipc/bridge.cc
@@ -174,13 +174,7 @@ void initFunctionsTable (Router *router) {
    * `message.buffer` with already an mapped buffer.
    */
   router->map("buffer.map", false, [](auto message, auto router, auto reply) {
-    router->setMappedBuffer(
-      message.index,
-      message.seq,
-      message.buffer.bytes,
-      message.buffer.size
-    );
-
+    router->setMappedBuffer(message.index, message.seq, message.buffer);
     reply(Result { message.seq, message });
   });
 
@@ -1489,15 +1483,12 @@ namespace SSC::IPC {
     return MessageBuffer {};
   }
 
-  void Router::setMappedBuffer (
-    int index,
-    const Message::Seq seq,
-    char* bytes,
-    size_t size
-  ) {
+  void Router::setMappedBuffer(int index,
+                               const Message::Seq seq,
+                               MessageBuffer msg_buf) {
     Lock lock(this->mutex);
     auto key = std::to_string(index) + seq;
-    this->buffers.insert_or_assign(key, MessageBuffer { bytes, size });
+    this->buffers.insert_or_assign(key, msg_buf);
   }
 
   void Router::removeMappedBuffer (int index, const Message::Seq seq) {

--- a/test/build.js
+++ b/test/build.js
@@ -48,7 +48,7 @@ async function main () {
         build.onResolve({ filter: /^socket:.*$/ }, (args) => {
           const basename = args.path.replace('socket:', '').replace(/.js$/, '') + '.js'
           const filename = path.resolve(path.dirname(dirname), 'api', basename)
-          return { path: filename }
+          return { path: filename, external: true }
         })
       }
     })

--- a/test/src/ipc.js
+++ b/test/src/ipc.js
@@ -54,39 +54,41 @@ test('ipc.Message', (t) => {
   t.ok(ipc.Message.prototype instanceof URL, 'is a URL')
   // pass a Buffer
   let msg = ipc.Message.from(Buffer.from('test'), { foo: 'bar' })
-  t.equal(msg.protocol, ipc.Message.PROTOCOL)
+  t.equal(msg.protocol, 'ipc:')
   t.equal(msg.command, 'test')
   t.deepEqual(msg.params, { foo: 'bar' })
   // pass an ipc.Message
   msg = ipc.Message.from(msg)
-  t.equal(msg.protocol, ipc.Message.PROTOCOL)
+  t.equal(msg.protocol, 'ipc:')
   t.equal(msg.command, 'test')
   t.deepEqual(msg.params, { foo: 'bar' })
   // pass an object
-  msg = ipc.Message.from({ protocol: ipc.Message.PROTOCOL, command: 'test' }, { foo: 'bar' })
-  t.equal(msg.protocol, ipc.Message.PROTOCOL)
+  msg = ipc.Message.from({ protocol: 'ipc:', command: 'test' }, { foo: 'bar' })
+  t.equal(msg.protocol, 'ipc:')
   t.equal(msg.command, 'test')
   t.deepEqual(msg.params, { foo: 'bar' })
   // pass a string
   msg = ipc.Message.from('test', { foo: 'bar' })
-  t.equal(msg.protocol, ipc.Message.PROTOCOL)
+  t.equal(msg.protocol, 'ipc:')
   t.equal(msg.command, 'test')
   t.deepEqual(msg.params, { foo: 'bar' })
-  t.ok(ipc.Message.isValidInput(`${ipc.Message.PROTOCOL}//test`), 'is valid input')
+  t.ok(ipc.Message.isValidInput('ipc://test'), 'is valid input')
   t.ok(!ipc.Message.isValidInput('test'), 'is valid input')
   t.ok(!ipc.Message.isValidInput('foo://test'), 'is valid input')
 })
 
-test('ipc.sendSync not found', (t) => {
-  const response = ipc.sendSync('test', { foo: 'bar' })
-  t.ok(response instanceof ipc.Result)
-  const { err } = response
-  t.equal(err?.toString(), 'NotFoundError: Not found')
-  t.equal(err?.name, 'NotFoundError')
-  t.equal(err?.message, 'Not found')
-  t.ok(err?.url.startsWith(`${ipc.Message.PROTOCOL}//test?foo=bar&index=0&seq=R`))
-  t.equal(err?.code, 'NOT_FOUND_ERR')
-})
+if (window.__args.os !== 'ios' && window.__args.os !== 'android') {
+  test('ipc.sendSync not found', (t) => {
+    const response = ipc.sendSync('test', { foo: 'bar' })
+    t.ok(response instanceof ipc.Result)
+    const { err } = response
+    t.equal(err?.toString(), 'NotFoundError: Not found')
+    t.equal(err?.name, 'NotFoundError')
+    t.equal(err?.message, 'Not found')
+    t.ok(err?.url.startsWith('ipc://test?foo=bar&index=0&seq=R'))
+    t.equal(err?.code, 'NOT_FOUND_ERR')
+  })
+}
 
 test('ipc.sendSync success', (t) => {
   const response = ipc.sendSync('os.arch')


### PR DESCRIPTION
All the necessary changes to get `ipc:` schemes working on Windows. The test runner now runs to completion. Still has errors, but at least runs successfully without hanging.