### PR TITLE
Fix Windows tests

### DIFF
--- a/api/fs/handle.js
+++ b/api/fs/handle.js
@@ -62,6 +62,9 @@ export class FileHandle extends EventEmitter {
     return new this({ fd, id })
   }
 
+  // TODO(trevnorris): The way the comment says to use mode doesn't match
+  // how it's currently being used in tests. Instead we're passing values
+  // from fs.constants.
   /**
    * Determines if access to `path` for `mode` is possible.
    * @param {string} path
@@ -85,7 +88,8 @@ export class FileHandle extends EventEmitter {
       throw result.err
     }
 
-    return result.data?.mode === mode
+    // F_OK means access in any way
+    return mode === F_OK ? true : (result.data?.mode && mode) > 0
   }
 
   /**

--- a/src/core/runtime-preload.hh
+++ b/src/core/runtime-preload.hh
@@ -6,7 +6,22 @@
 namespace SSC {
   inline SSC::String createPreload (WindowOptions opts) {
     SSC::String cleanCwd = SSC::String(opts.cwd);
+
+#ifndef _WIN32
     std::replace(cleanCwd.begin(), cleanCwd.end(), '\\', '/');
+#else
+    // Escape backslashes in paths.
+    size_t last_pos = 0;
+    while ((last_pos = opts.argv.find('\\', last_pos)) != std::string::npos) {
+      opts.argv.replace(last_pos, 1, "\\\\");
+      last_pos += 2;
+    }
+    last_pos = 0;
+    while ((last_pos = cleanCwd.find('\\', last_pos)) != std::string::npos) {
+      cleanCwd.replace(last_pos, 1, "\\\\");
+      last_pos += 2;
+    }
+#endif
 
     auto preload = SSC::String(
       "\n;(() => {                                                           \n"

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -437,6 +437,13 @@ MAIN {
           createProcess(force);
           process->open();
         }
+#ifdef _WIN32
+        size_t last_pos = 0;
+        while ((last_pos = process->path.find('\\', last_pos)) != std::string::npos) {
+          process->path.replace(last_pos, 1, "\\\\\\\\");
+          last_pos += 4;
+        }
+#endif
         const JSON::Object json = JSON::Object::Entries {
           { "cmd", cmd },
           { "argv", process->argv },

--- a/test/scripts/test-desktop.js
+++ b/test/scripts/test-desktop.js
@@ -3,7 +3,7 @@ import { execSync as exec } from 'node:child_process'
 import path from 'node:path'
 import os from 'node:os'
 
-const dirname = path.dirname(import.meta.url.replace('file://', ''))
+const dirname = path.dirname(import.meta.url.replace('file://', '').replace(/^\/[A-Za-z]:/, ''))
 const root = path.dirname(dirname)
 
 const SOCKET_HOME_API = path.join(root, '..', 'api')

--- a/test/src/fs/flags.js
+++ b/test/src/fs/flags.js
@@ -1,145 +1,141 @@
 import { normalizeFlags } from 'socket:fs/flags'
 import { test } from 'socket:test'
 import * as fs from 'socket:fs'
-import process from 'socket:process'
 
-// TODO(@jwerle): FIXME
-if (process.platform !== 'win32') {
-  test('flags', (t) => {
-    t.ok(
-      normalizeFlags() === fs.constants.O_RDONLY,
-      'undefined === fs.constants.O_RDONLY'
-    )
+test('flags', (t) => {
+  t.ok(
+    normalizeFlags() === fs.constants.O_RDONLY,
+    'undefined === fs.constants.O_RDONLY'
+  )
 
-    t.ok(
-      normalizeFlags(fs.constants.O_WRONLY) === fs.constants.O_WRONLY,
-      'fs.constants.O_WRONLY=== fs.constants.O_WRONLY'
-    )
+  t.ok(
+    normalizeFlags(fs.constants.O_WRONLY) === fs.constants.O_WRONLY,
+    'fs.constants.O_WRONLY=== fs.constants.O_WRONLY'
+  )
 
-    t.throws(
-      () => normalizeFlags(null),
-      // eslint-disable-next-line prefer-regex-literals
-      RegExp('Expecting flags to be a string or number: Got object'),
-      'normalizeFlags() throws on null'
-    )
-
-    t.throws(() =>
-      normalizeFlags({}),
+  t.throws(
+    () => normalizeFlags(null),
     // eslint-disable-next-line prefer-regex-literals
     RegExp('Expecting flags to be a string or number: Got object'),
-    'normalizeFlags() throws on object'
-    )
+    'normalizeFlags() throws on null'
+  )
 
-    t.throws(
-      () => normalizeFlags(true),
-      // eslint-disable-next-line prefer-regex-literals
-      RegExp('Expecting flags to be a string or number: Got boolean'),
-      'normalizeFlags() throws on boolean'
-    )
+  t.throws(() =>
+    normalizeFlags({}),
+  // eslint-disable-next-line prefer-regex-literals
+  RegExp('Expecting flags to be a string or number: Got object'),
+  'normalizeFlags() throws on object'
+  )
 
-    t.ok(
-      normalizeFlags('r') === fs.constants.O_RDONLY,
-      'r === fs.constants.O_RDONLY'
-    )
+  t.throws(
+    () => normalizeFlags(true),
+    // eslint-disable-next-line prefer-regex-literals
+    RegExp('Expecting flags to be a string or number: Got boolean'),
+    'normalizeFlags() throws on boolean'
+  )
 
-    t.ok(
-      normalizeFlags('rs') === fs.constants.O_RDONLY | fs.constants.O_SYNC,
-      'rs === fs.constants.O_RDONLY | fs.constants.O_SYNC'
-    )
+  t.ok(
+    normalizeFlags('r') === fs.constants.O_RDONLY,
+    'r === fs.constants.O_RDONLY'
+  )
 
-    t.ok(
-      normalizeFlags('sr') === fs.constants.O_RDONLY | fs.constants.O_SYNC, 'sr === fs.constants.O_RDONLY | fs.constants.O_SYNC')
+  t.ok(
+    normalizeFlags('rs') === fs.constants.O_RDONLY | fs.constants.O_SYNC,
+    'rs === fs.constants.O_RDONLY | fs.constants.O_SYNC'
+  )
 
-    t.ok(
-      normalizeFlags('r+') === fs.constants.O_RDWR,
-      'r+ === fs.constants.O_RDWR'
-    )
+  t.ok(
+    normalizeFlags('sr') === fs.constants.O_RDONLY | fs.constants.O_SYNC, 'sr === fs.constants.O_RDONLY | fs.constants.O_SYNC')
 
-    t.ok(
-      normalizeFlags('rs+') === fs.constants.O_RDWR | fs.constants.O_SYNC,
-      'rs+ === fs.constants.O_RDWR | fs.constants.O_SYNC'
-    )
+  t.ok(
+    normalizeFlags('r+') === fs.constants.O_RDWR,
+    'r+ === fs.constants.O_RDWR'
+  )
 
-    t.ok(
-      normalizeFlags('sr+') === fs.constants.O_RDWR | fs.constants.O_SYNC,
-      'sr+ === fs.constants.O_RDWR | fs.constants.O_SYNC'
-    )
+  t.ok(
+    normalizeFlags('rs+') === fs.constants.O_RDWR | fs.constants.O_SYNC,
+    'rs+ === fs.constants.O_RDWR | fs.constants.O_SYNC'
+  )
 
-    t.ok(
-      normalizeFlags('w') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY,
-      'w === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY'
-    )
+  t.ok(
+    normalizeFlags('sr+') === fs.constants.O_RDWR | fs.constants.O_SYNC,
+    'sr+ === fs.constants.O_RDWR | fs.constants.O_SYNC'
+  )
 
-    t.ok(
-      normalizeFlags('wx') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL,
-      'wx === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL'
-    )
+  t.ok(
+    normalizeFlags('w') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY,
+    'w === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY'
+  )
 
-    t.ok(
-      normalizeFlags('xw') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL,
-      'xw === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL'
-    )
+  t.ok(
+    normalizeFlags('wx') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL,
+    'wx === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL'
+  )
 
-    t.ok(
-      normalizeFlags('w+') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR,
-      'w+ === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR'
-    )
+  t.ok(
+    normalizeFlags('xw') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL,
+    'xw === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL'
+  )
 
-    t.ok(
-      normalizeFlags('wx+') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL,
-      'wx+ === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL'
-    )
-    t.ok(
-      normalizeFlags('xw+') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL, 'xw+ === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL')
+  t.ok(
+    normalizeFlags('w+') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR,
+    'w+ === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR'
+  )
 
-    t.ok(
-      normalizeFlags('a') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY,
-      'a === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY'
-    )
+  t.ok(
+    normalizeFlags('wx+') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL,
+    'wx+ === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL'
+  )
+  t.ok(
+    normalizeFlags('xw+') === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL, 'xw+ === fs.constants.O_TRUNC | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL')
 
-    t.ok(
-      normalizeFlags('ax') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL,
-      'ax === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL'
-    )
+  t.ok(
+    normalizeFlags('a') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY,
+    'a === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY'
+  )
 
-    t.ok(
-      normalizeFlags('xa') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL,
-      'xa === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL'
-    )
+  t.ok(
+    normalizeFlags('ax') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL,
+    'ax === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL'
+  )
 
-    t.ok(
-      normalizeFlags('as') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_SYNC,
-      'as === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_SYNC'
-    )
+  t.ok(
+    normalizeFlags('xa') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL,
+    'xa === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_EXCL'
+  )
 
-    t.ok(
-      normalizeFlags('sa') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_SYNC,
-      'sa === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_SYNC'
-    )
+  t.ok(
+    normalizeFlags('as') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_SYNC,
+    'as === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_SYNC'
+  )
 
-    t.ok(
-      normalizeFlags('a+') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR,
-      'a+ === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR'
-    )
+  t.ok(
+    normalizeFlags('sa') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_SYNC,
+    'sa === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_SYNC'
+  )
 
-    t.ok(
-      normalizeFlags('ax+') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL,
-      'ax+ === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL'
-    )
+  t.ok(
+    normalizeFlags('a+') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR,
+    'a+ === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR'
+  )
 
-    t.ok(
-      normalizeFlags('xa+') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL,
-      'xa+ === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL'
-    )
+  t.ok(
+    normalizeFlags('ax+') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL,
+    'ax+ === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL'
+  )
 
-    t.ok(
-      normalizeFlags('as+') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_SYNC,
-      'as+ === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_SYNC'
-    )
+  t.ok(
+    normalizeFlags('xa+') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL,
+    'xa+ === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_EXCL'
+  )
 
-    t.ok(
-      normalizeFlags('sa+') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_SYNC,
-      'sa+ === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_SYNC'
-    )
-  })
-}
+  t.ok(
+    normalizeFlags('as+') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_SYNC,
+    'as+ === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_SYNC'
+  )
+
+  t.ok(
+    normalizeFlags('sa+') === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_SYNC,
+    'sa+ === fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_RDWR | fs.constants.O_SYNC'
+  )
+})

--- a/test/src/fs/index.js
+++ b/test/src/fs/index.js
@@ -1,280 +1,280 @@
 import { Buffer } from 'socket:buffer'
 import deepEqual from 'socket:test/fast-deep-equal'
 import { test } from 'socket:test'
-// import console from 'socket:console'
 import crypto from 'socket:crypto'
 import path from 'socket:path'
 import fs from 'socket:fs'
 import os from 'socket:os'
-import process from 'socket:process'
 
-// TODO(@jwerle): FIXME
-if (process.platform !== 'win32') {
-  const TMPDIR = `${os.tmpdir()}${path.sep}`
-  const FIXTURES = /android/i.test(os.platform())
-    ? '/data/local/tmp/ssc-socket-test-fixtures/'
-    : `${TMPDIR}ssc-socket-test-fixtures${path.sep}`
+// node compat
+/*
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+*/
 
-  // node compat
-  /*
-  import crypto from 'node:crypto'
-  import fs from 'node:fs'
-  import os from 'node:os'
-  */
-  test('fs.access', async (t) => {
-    await new Promise((resolve, reject) => {
-      fs.access(FIXTURES, fs.constants.F_OK, (err) => {
-        if (err) t.fail(err, '(F_OK) fixtures/ is not accessible')
-        else t.ok(true, '(F_OK) fixtures/ directory is accessible')
-        resolve()
-      })
-    })
+const TMPDIR = `${os.tmpdir()}${path.sep}`
+const FIXTURES = /android/i.test(os.platform())
+  ? '/data/local/tmp/ssc-socket-test-fixtures/'
+  : `${TMPDIR}ssc-socket-test-fixtures${path.sep}`
 
-    await new Promise((resolve, reject) => {
-      fs.access(FIXTURES, fs.constants.F_OK | fs.constants.R_OK, (err) => {
-        if (err) t.fail(err, '(F_OK | R_OK) fixtures/ directory is not readable')
-        else t.ok(true, '(F_OK | R_OK) fixtures/ directory is readable')
-        resolve()
-      })
-    })
+test('fs.access', async (t) => {
+  const { F_OK, R_OK, W_OK, X_OK } = fs.constants
 
-    await new Promise((resolve, reject) => {
-      fs.access('.', fs.constants.W_OK, (err) => {
-        if (err) t.fail(err, '(W_OK) ./ directory is not writable')
-        else t.ok(true, '(W_OK) ./ directory is writable')
-        resolve()
-      })
-    })
-
-    await new Promise((resolve, reject) => {
-      fs.access(FIXTURES, fs.constants.X_OK, (err) => {
-        if (err) t.fail(err, '(X_OK) fixtures/ directory is not "executable" - cannot list items')
-        else t.ok(true, '(X_OK) fixtures/ directory is "executable" - can list items')
-        resolve()
-      })
+  await new Promise((resolve, reject) => {
+    fs.access(FIXTURES, F_OK, (err, access) => {
+      if (err) t.fail(err, '(F_OK) fixtures/ is not accessible')
+      else t.ok(access, '(F_OK) fixtures/ directory is accessible')
+      resolve()
     })
   })
 
-  test('fs.appendFile', async (t) => {})
-
-  if (os.platform() !== 'android' && os.platform() !== 'win32') {
-    test('fs.chmod', async (t) => {
-      await new Promise((resolve, reject) => {
-        fs.chmod(FIXTURES + 'file.txt', 0o777, (err) => {
-          if (err) t.fail(err)
-          fs.stat(FIXTURES + 'file.txt', (err, stats) => {
-            if (err) t.fail(err)
-            t.equal(stats.mode & 0o777, 0o777, 'file.txt mode is 777')
-            resolve()
-          })
-        })
-      })
-    })
-  }
-
-  test('fs.chown', async (t) => {})
-  test('fs.close', async (t) => {
-    await new Promise((resolve, reject) => {
-      fs.open(FIXTURES + 'file.txt', (err, fd) => {
-        if (err) {
-          t.fail(err)
-          return resolve()
-        }
-
-        t.ok(Number.isFinite(fd), 'isFinite(fd)')
-        fs.close(fd, (err) => {
-          if (err) t.fail(err)
-
-          t.ok(!err, 'fd closed')
-          resolve()
-        })
-      })
+  await new Promise((resolve, reject) => {
+    fs.access(FIXTURES, R_OK, (err, access) => {
+      if (err) t.fail(err, '(R_OK) fixtures/ directory is not readable')
+      else t.ok(access, '(R_OK) fixtures/ directory is readable')
+      resolve()
     })
   })
 
-  test('fs.copyFile', async (t) => {})
-  test('fs.createReadStream', async (t) => {
-    if (os.platform() === 'android') {
-      t.comment('FIXME for Android')
-      return
-    }
+  await new Promise((resolve, reject) => {
+    fs.access('.', W_OK, (err, access) => {
+      if (err) t.fail(err, '(W_OK) ./ directory is not writable')
+      else t.ok(access, '(W_OK) ./ directory is writable')
+      resolve()
+    })
+  })
 
-    const buffers = []
+  await new Promise((resolve, reject) => {
+    fs.access(FIXTURES, X_OK, (err, access) => {
+      if (err) t.fail(err, '(X_OK) fixtures/ directory is not "executable" - cannot list items')
+      else t.ok(access, '(X_OK) fixtures/ directory is "executable" - can list items')
+      resolve()
+    })
+  })
+})
+
+test('fs.appendFile', async (t) => {})
+
+if (os.platform() !== 'android' && os.platform() !== 'win32') {
+  test('fs.chmod', async (t) => {
     await new Promise((resolve, reject) => {
-      const stream = fs.createReadStream(FIXTURES + 'file.txt')
-      const expected = Buffer.from('test 123')
-
-      stream.on('close', resolve)
-      stream.on('data', (buffer) => {
-        buffers.push(buffer)
-      })
-
-      stream.on('error', (err) => {
+      fs.chmod(FIXTURES + 'file.txt', 0o777, (err) => {
         if (err) t.fail(err)
-        resolve()
-      })
-
-      stream.on('end', () => {
-        let actual = Buffer.concat(buffers)
-        if (actual[actual.length - 1] === 0x0A) {
-          actual = actual.slice(0, -1)
-        }
-
-        t.ok(
-          Buffer.compare(expected, actual) === 0,
-          `fixtures/file.txt contents match "${expected}"`
-        )
-      })
-    })
-  })
-
-  test('fs.createWriteStream', async (t) => {
-    if (os.platform() === 'android') return t.comment('TODO')
-    const writer = fs.createWriteStream(TMPDIR + 'new-file.txt')
-    const bytes = crypto.randomBytes(32 * 1024 * 1024)
-    writer.write(bytes.slice(0, 512 * 1024))
-    writer.write(bytes.slice(512 * 1024))
-    writer.end()
-    await new Promise((resolve) => {
-      writer.once('error', (err) => {
-        t.fail(err.message)
-        writer.removeAllListeners()
-        resolve()
-      })
-      writer.once('close', () => {
-        const reader = fs.createReadStream(TMPDIR + 'new-file.txt')
-        const buffers = []
-        reader.on('data', (buffer) => buffers.push(buffer))
-        reader.on('end', () => {
-          t.ok(Buffer.compare(bytes, Buffer.concat(buffers)) === 0, 'bytes match')
+        fs.stat(FIXTURES + 'file.txt', (err, stats) => {
+          if (err) t.fail(err)
+          t.equal(stats.mode & 0o777, 0o777, 'file.txt mode is 777')
           resolve()
         })
       })
     })
   })
+}
 
-  test('fs.fstat', async (t) => {})
-  test('fs.lchmod', async (t) => {})
-  test('fs.lchown', async (t) => {})
-  test('fs.lutimes', async (t) => {})
-  test('fs.link', async (t) => {})
-  test('fs.lstat', async (t) => {})
-  if (os.platform() !== 'android') {
-    test('fs.mkdir', async (t) => {
-      const dirname = FIXTURES + Math.random().toString(16).slice(2)
-      await new Promise((resolve, reject) => {
-        fs.mkdir(dirname, {}, (err) => {
-          if (err) reject(err)
+test('fs.chown', async (t) => {})
 
-          fs.stat(dirname, (err) => {
-            if (err) reject(err)
-            resolve()
-          })
-        })
-      })
-    })
-  }
-  test('fs.open', async (t) => {})
-  test('fs.opendir', async (t) => {})
-  test('fs.read', async (t) => {})
-  test('fs.readdir', async (t) => {})
-  test('fs.readFile', async (t) => {
-    let failed = false
-    const iterations = 16 // generate ~1k _concurrent_ requests
-    const expected = { data: 'test 123' }
-    const promises = Array.from(Array(iterations), (_, i) => new Promise((resolve) => {
-      if (failed) return resolve(false)
-      fs.readFile(FIXTURES + 'file.json', (err, buf) => {
-        if (failed) return resolve(false)
-
-        const message = `fs.readFile('fixtures/file.json') [iteration=${i + 1}]`
-
-        try {
-          if (err) {
-            t.fail(err, message)
-            failed = true
-          } else if (!deepEqual(expected, JSON.parse(buf))) {
-            failed = true
-          }
-        } catch (err) {
-          t.fail(err, message)
-          failed = true
-        }
-
-        resolve(!failed)
-      })
-    }))
-
-    const results = await Promise.all(promises)
-    t.ok(results.every(Boolean), 'fs.readFile(\'fixtures/file.json\')')
-  })
-
-  test('fs.readlink', async (t) => {})
-  test('fs.realpath', async (t) => {})
-  test('fs.rename', async (t) => {})
-  test('fs.rmdir', async (t) => {})
-  test('fs.rm', async (t) => {})
-  test('fs.stat', async (t) => {})
-  test('fs.symlink', async (t) => {})
-  test('fs.truncate', async (t) => {})
-  test('fs.unlink', async (t) => {})
-  test('fs.utimes', async (t) => {})
-  test('fs.watch', async (t) => {})
-  test('fs.write', async (t) => {})
-
-  if (os.platform() !== 'android') {
-    test('fs.writeFile', async (t) => {
-      const alloc = (size) => crypto.randomBytes(size)
-      const small = Array.from({ length: 32 }, (_, i) => i * 2 * 1024).map(alloc)
-      const large = Array.from({ length: 16 }, (_, i) => i * 2 * 1024 * 1024).map(alloc)
-      const buffers = [...small, ...large]
-
-      // const pending = buffers.length
-      let failed = false
-      const writes = []
-
-      // const now = Date.now()
-      while (!failed && buffers.length) {
-        writes.push(testWrite(buffers.length - 1, buffers.pop()))
+test('fs.close', async (t) => {
+  await new Promise((resolve, reject) => {
+    fs.open(FIXTURES + 'file.txt', (err, fd) => {
+      if (err) {
+        t.fail(err)
+        return resolve()
       }
 
-      await Promise.all(writes)
-      /*
-    console.log(
-      '%d writes to %sms to write %s bytes',
-      small.length + large.length,
-      Date.now() - now,
-      [...small, ...large].reduce((n, a) => n + a.length, 0)
-    ) */
+      t.ok(Number.isFinite(fd), 'isFinite(fd)')
+      fs.close(fd, (err) => {
+        if (err) t.fail(err)
 
-      t.ok(!failed, 'all bytes match')
+        t.ok(!err, 'fd closed')
+        resolve()
+      })
+    })
+  })
+})
 
-      async function testWrite (i, buffer) {
-        await new Promise((resolve) => {
-          const filename = TMPDIR + `new-file-${i}.txt`
-          fs.writeFile(filename, buffer, async (err) => {
+test('fs.copyFile', async (t) => {})
+
+test('fs.createReadStream', async (t) => {
+  if (os.platform() === 'android') {
+    t.comment('FIXME for Android')
+    return
+  }
+
+  const buffers = []
+  await new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(FIXTURES + 'file.txt')
+    const expected = Buffer.from('test 123')
+
+    stream.on('close', resolve)
+    stream.on('data', (buffer) => {
+      buffers.push(buffer)
+    })
+
+    stream.on('error', (err) => {
+      if (err) t.fail(err)
+      resolve()
+    })
+
+    stream.on('end', () => {
+      let actual = Buffer.concat(buffers)
+      if (actual[actual.length - 1] === 0x0A) {
+        actual = actual.slice(0, -1)
+      }
+
+      t.ok(
+        Buffer.compare(expected, actual) === 0,
+        `fixtures/file.txt contents match "${expected}"`
+      )
+    })
+  })
+})
+
+test('fs.createWriteStream', async (t) => {
+  if (os.platform() === 'android') return t.comment('TODO')
+  const writer = fs.createWriteStream(TMPDIR + 'new-file.txt')
+  const bytes = crypto.randomBytes(32 * 1024 * 1024)
+  writer.write(bytes.slice(0, 512 * 1024))
+  writer.write(bytes.slice(512 * 1024))
+  writer.end()
+  await new Promise((resolve) => {
+    writer.once('error', (err) => {
+      t.fail(err.message)
+      writer.removeAllListeners()
+      resolve()
+    })
+    writer.once('close', () => {
+      const reader = fs.createReadStream(TMPDIR + 'new-file.txt')
+      const buffers = []
+      reader.on('data', (buffer) => buffers.push(buffer))
+      reader.on('end', () => {
+        t.ok(Buffer.compare(bytes, Buffer.concat(buffers)) === 0, 'bytes match')
+        resolve()
+      })
+    })
+  })
+})
+
+test('fs.fstat', async (t) => {})
+test('fs.lchmod', async (t) => {})
+test('fs.lchown', async (t) => {})
+test('fs.lutimes', async (t) => {})
+test('fs.link', async (t) => {})
+test('fs.lstat', async (t) => {})
+if (os.platform() !== 'android') {
+  test('fs.mkdir', async (t) => {
+    const dirname = FIXTURES + Math.random().toString(16).slice(2)
+    await new Promise((resolve, reject) => {
+      fs.mkdir(dirname, {}, (err) => {
+        if (err) reject(err)
+
+        fs.stat(dirname, (err) => {
+          if (err) reject(err)
+          resolve()
+        })
+      })
+    })
+  })
+}
+test('fs.open', async (t) => {})
+test('fs.opendir', async (t) => {})
+test('fs.read', async (t) => {})
+test('fs.readdir', async (t) => {})
+test('fs.readFile', async (t) => {
+  let failed = false
+  const iterations = 16 // generate ~1k _concurrent_ requests
+  const expected = { data: 'test 123' }
+  const promises = Array.from(Array(iterations), (_, i) => new Promise((resolve) => {
+    if (failed) return resolve(false)
+    fs.readFile(FIXTURES + 'file.json', (err, buf) => {
+      if (failed) return resolve(false)
+
+      const message = `fs.readFile('fixtures/file.json') [iteration=${i + 1}]`
+
+      try {
+        if (err) {
+          t.fail(err, message)
+          failed = true
+        } else if (!deepEqual(expected, JSON.parse(buf))) {
+          failed = true
+        }
+      } catch (err) {
+        t.fail(err, message)
+        failed = true
+      }
+
+      resolve(!failed)
+    })
+  }))
+
+  const results = await Promise.all(promises)
+  t.ok(results.every(Boolean), 'fs.readFile(\'fixtures/file.json\')')
+})
+
+test('fs.readlink', async (t) => {})
+test('fs.realpath', async (t) => {})
+test('fs.rename', async (t) => {})
+test('fs.rmdir', async (t) => {})
+test('fs.rm', async (t) => {})
+test('fs.stat', async (t) => {})
+test('fs.symlink', async (t) => {})
+test('fs.truncate', async (t) => {})
+test('fs.unlink', async (t) => {})
+test('fs.utimes', async (t) => {})
+test('fs.watch', async (t) => {})
+test('fs.write', async (t) => {})
+
+if (os.platform() !== 'android') {
+  test('fs.writeFile', async (t) => {
+    const alloc = (size) => crypto.randomBytes(size)
+    const small = Array.from({ length: 32 }, (_, i) => i * 2 * 1024).map(alloc)
+    const large = Array.from({ length: 16 }, (_, i) => i * 2 * 1024 * 1024).map(alloc)
+    const buffers = [...small, ...large]
+
+    // const pending = buffers.length
+    let failed = false
+    const writes = []
+
+    // const now = Date.now()
+    while (!failed && buffers.length) {
+      writes.push(testWrite(buffers.length - 1, buffers.pop()))
+    }
+
+    await Promise.all(writes)
+    /*
+  console.log(
+    '%d writes to %sms to write %s bytes',
+    small.length + large.length,
+    Date.now() - now,
+    [...small, ...large].reduce((n, a) => n + a.length, 0)
+  ) */
+
+    t.ok(!failed, 'all bytes match')
+
+    async function testWrite (i, buffer) {
+      await new Promise((resolve) => {
+        const filename = TMPDIR + `new-file-${i}.txt`
+        fs.writeFile(filename, buffer, async (err) => {
+          if (err) {
+            failed = true
+            t.fail(err.message)
+            return resolve()
+          }
+
+          fs.readFile(filename, (err, result) => {
             if (err) {
               failed = true
               t.fail(err.message)
-              return resolve()
+            } else if (Buffer.compare(result, buffer) !== 0) {
+              failed = true
+              t.fail('bytes do not match')
             }
 
-            fs.readFile(filename, (err, result) => {
-              if (err) {
-                failed = true
-                t.fail(err.message)
-              } else if (Buffer.compare(result, buffer) !== 0) {
-                failed = true
-                t.fail('bytes do not match')
-              }
-
-              resolve()
-            })
+            resolve()
           })
         })
-      }
-    })
-  }
-
-  test('fs.writev', async (t) => {})
+      })
+    }
+  })
 }
+
+test('fs.writev', async (t) => {})

--- a/test/src/fs/promises.js
+++ b/test/src/fs/promises.js
@@ -2,100 +2,98 @@ import Buffer from 'socket:buffer'
 import path from 'socket:path'
 import fs from 'socket:fs/promises'
 import os from 'socket:os'
-import process from 'socket:process'
 
 import { FileHandle } from 'socket:fs/handle'
 import { test } from 'socket:test'
 import { Dir } from 'socket:fs/dir'
 
-// TODO(@jwerle): FIXME
-if (process.platform !== 'win32') {
-  const TMPDIR = `${os.tmpdir()}${path.sep}`
-  const FIXTURES = /android/i.test(os.platform())
-    ? '/data/local/tmp/ssc-socket-test-fixtures/'
-    : `${TMPDIR}ssc-socket-test-fixtures${path.sep}`
+const TMPDIR = `${os.tmpdir()}${path.sep}`
+const FIXTURES = /android/i.test(os.platform())
+  ? '/data/local/tmp/ssc-socket-test-fixtures/'
+  : `${TMPDIR}ssc-socket-test-fixtures${path.sep}`
 
-  test('fs.promises.access', async (t) => {
-    let access = await fs.access(FIXTURES, fs.constants.F_OK)
-    t.equal(access, true, '(F_OK) fixtures/ directory is accessible')
+test('fs.promises.access', async (t) => {
+  const { F_OK, R_OK, W_OK, X_OK } = fs.constants
 
-    access = await fs.access(FIXTURES, fs.constants.F_OK | fs.constants.R_OK)
-    t.equal(access, true, '(F_OK | R_OK) fixtures/ directory is readable')
+  let access = await fs.access(FIXTURES, F_OK)
+  t.equal(access, true, '(F_OK) fixtures/ directory is accessible')
 
-    access = await fs.access('.', fs.constants.W_OK)
-    t.equal(access, true, '(W_OK) ./ directory is writable')
+  access = await fs.access(FIXTURES, R_OK)
+  t.equal(access, true, '(F_OK | R_OK) fixtures/ directory is readable')
 
-    access = await fs.access(FIXTURES, fs.constants.X_OK)
-    t.equal(access, true, '(X_OK) fixtures/ directory is "executable" - can list items')
+  access = await fs.access('.', W_OK)
+  t.equal(access, true, '(W_OK) ./ directory is writable')
+
+  access = await fs.access(FIXTURES, X_OK)
+  t.equal(access, true, '(X_OK) fixtures/ directory is "executable" - can list items')
+})
+
+test('fs.promises.chmod', async (t) => {
+  const chmod = await fs.chmod(FIXTURES + 'file.txt', 0o777)
+  t.equal(chmod, undefined, 'file.txt is chmod 777')
+})
+
+if (os.platform() !== 'android') {
+  test('fs.promises.mkdir', async (t) => {
+    const dirname = FIXTURES + Math.random().toString(16).slice(2)
+    const { err } = await fs.mkdir(dirname, {})
+    t.equal(err, undefined, 'mkdir does not throw')
   })
+}
 
-  test('fs.promises.chmod', async (t) => {
-    const chmod = await fs.chmod(FIXTURES + 'file.txt', 0o777)
-    t.equal(chmod, undefined, 'file.txt is chmod 777')
+test('fs.promises.open', async (t) => {
+  const fd = await fs.open(FIXTURES + 'file.txt', 'r')
+  t.ok(fd instanceof FileHandle, 'FileHandle is returned')
+  await fd.close()
+})
+
+test('fs.promises.opendir', async (t) => {
+  const dir = await fs.opendir(FIXTURES + 'directory')
+  t.ok(dir instanceof Dir, 'fs.Dir is returned')
+  await dir.close()
+})
+
+test('fs.promises.readdir', async (t) => {
+  const files = await fs.readdir(FIXTURES + 'directory')
+  t.ok(Array.isArray(files), 'array is returned')
+  t.equal(files.length, 6, 'array contains 2 items')
+  t.deepEqual(files.map(file => file.name), ['0', '1', '2', 'a', 'b', 'c'].map(name => `${name}.txt`), 'array contains files')
+})
+
+test('fs.promises.readFile', async (t) => {
+  const data = await fs.readFile(FIXTURES + 'file.txt')
+  t.ok(Buffer.isBuffer(data), 'buffer is returned')
+  t.equal(data.toString(), 'test 123\n', 'buffer contains file contents')
+})
+
+test('fs.promises.stat', async (t) => {
+  let stats = await fs.stat(FIXTURES + 'file.txt')
+  t.ok(stats, 'stats are returned')
+  t.equal(stats.isFile(), true, 'stats are for a file')
+  t.equal(stats.isDirectory(), false, 'stats are not for a directory')
+  t.equal(stats.isSymbolicLink(), false, 'stats are not for a symbolic link')
+  t.equal(stats.isSocket(), false, 'stats are not for a socket')
+  t.equal(stats.isFIFO(), false, 'stats are not for a FIFO')
+  t.equal(stats.isBlockDevice(), false, 'stats are not for a block device')
+  t.equal(stats.isCharacterDevice(), false, 'stats are not for a character device')
+
+  stats = await fs.stat(FIXTURES + 'directory')
+  t.ok(stats, 'stats are returned')
+  t.equal(stats.isFile(), false, 'stats are not for a file')
+  t.equal(stats.isDirectory(), true, 'stats are for a directory')
+  t.equal(stats.isSymbolicLink(), false, 'stats are not for a symbolic link')
+  t.equal(stats.isSocket(), false, 'stats are not for a socket')
+  t.equal(stats.isFIFO(), false, 'stats are not for a FIFO')
+  t.equal(stats.isBlockDevice(), false, 'stats are not for a block device')
+  t.equal(stats.isCharacterDevice(), false, 'stats are not for a character device')
+})
+
+if (os.platform() !== 'android') {
+  test('fs.promises.writeFile', async (t) => {
+    const file = FIXTURES + 'write-file.txt'
+    const data = 'test 123\n'
+    await fs.writeFile(file, data)
+    const contents = await fs.readFile(file)
+    t.equal(contents.toString(), data, 'file contents are correct')
   })
-
-  if (os.platform() !== 'android') {
-    test('fs.promises.mkdir', async (t) => {
-      const dirname = FIXTURES + Math.random().toString(16).slice(2)
-      const { err } = await fs.mkdir(dirname, {})
-      t.equal(err, undefined, 'mkdir does not throw')
-    })
-  }
-
-  test('fs.promises.open', async (t) => {
-    const fd = await fs.open(FIXTURES + 'file.txt', 'r')
-    t.ok(fd instanceof FileHandle, 'FileHandle is returned')
-    await fd.close()
-  })
-
-  test('fs.promises.opendir', async (t) => {
-    const dir = await fs.opendir(FIXTURES + 'directory')
-    t.ok(dir instanceof Dir, 'fs.Dir is returned')
-    await dir.close()
-  })
-
-  test('fs.promises.readdir', async (t) => {
-    const files = await fs.readdir(FIXTURES + 'directory')
-    t.ok(Array.isArray(files), 'array is returned')
-    t.equal(files.length, 6, 'array contains 2 items')
-    t.deepEqual(files.map(file => file.name), ['0', '1', '2', 'a', 'b', 'c'].map(name => `${name}.txt`), 'array contains files')
-  })
-
-  test('fs.promises.readFile', async (t) => {
-    const data = await fs.readFile(FIXTURES + 'file.txt')
-    t.ok(Buffer.isBuffer(data), 'buffer is returned')
-    t.equal(data.toString(), 'test 123\n', 'buffer contains file contents')
-  })
-
-  test('fs.promises.stat', async (t) => {
-    let stats = await fs.stat(FIXTURES + 'file.txt')
-    t.ok(stats, 'stats are returned')
-    t.equal(stats.isFile(), true, 'stats are for a file')
-    t.equal(stats.isDirectory(), false, 'stats are not for a directory')
-    t.equal(stats.isSymbolicLink(), false, 'stats are not for a symbolic link')
-    t.equal(stats.isSocket(), false, 'stats are not for a socket')
-    t.equal(stats.isFIFO(), false, 'stats are not for a FIFO')
-    t.equal(stats.isBlockDevice(), false, 'stats are not for a block device')
-    t.equal(stats.isCharacterDevice(), false, 'stats are not for a character device')
-
-    stats = await fs.stat(FIXTURES + 'directory')
-    t.ok(stats, 'stats are returned')
-    t.equal(stats.isFile(), false, 'stats are not for a file')
-    t.equal(stats.isDirectory(), true, 'stats are for a directory')
-    t.equal(stats.isSymbolicLink(), false, 'stats are not for a symbolic link')
-    t.equal(stats.isSocket(), false, 'stats are not for a socket')
-    t.equal(stats.isFIFO(), false, 'stats are not for a FIFO')
-    t.equal(stats.isBlockDevice(), false, 'stats are not for a block device')
-    t.equal(stats.isCharacterDevice(), false, 'stats are not for a character device')
-  })
-
-  if (os.platform() !== 'android') {
-    test('fs.promises.writeFile', async (t) => {
-      const file = FIXTURES + 'write-file.txt'
-      const data = 'test 123\n'
-      await fs.writeFile(file, data)
-      const contents = await fs.readFile(file)
-      t.equal(contents.toString(), data, 'file contents are correct')
-    })
-  }
 }

--- a/test/src/ipc.js
+++ b/test/src/ipc.js
@@ -82,10 +82,17 @@ if (window.__args.os !== 'ios' && window.__args.os !== 'android') {
     const response = ipc.sendSync('test', { foo: 'bar' })
     t.ok(response instanceof ipc.Result)
     const { err } = response
-    t.equal(err?.toString(), 'NotFoundError: Not found')
+    // Make lower case to adjust for implementation differences.
+    t.equal(err?.toString().toLowerCase(), 'notfounderror: not found')
     t.equal(err?.name, 'NotFoundError')
-    t.equal(err?.message, 'Not found')
-    t.ok(err?.url.startsWith('ipc://test?foo=bar&index=0&seq=R'))
+    // Make lower case to adjust for implementation differences.
+    t.equal(err?.message.toLowerCase(), 'not found')
+    // win32 adds on the trailing slash in the URL.
+    if (window.__args.os === 'win32') {
+      t.ok(err?.url.startsWith('ipc://test/?foo=bar&index=0&seq=R'))
+    } else {
+      t.ok(err?.url.startsWith('ipc://test?foo=bar&index=0&seq=R'))
+    }
     t.equal(err?.code, 'NOT_FOUND_ERR')
   })
 }

--- a/test/src/os.js
+++ b/test/src/os.js
@@ -3,7 +3,7 @@ import * as os from 'socket:os'
 
 const archs = ['arm64', 'ia32', 'x64', 'unknown']
 const platforms = ['android', 'cygwin', 'freebsd', 'linux', 'darwin', 'ios', 'openbsd', 'win32', 'unknown']
-const types = ['CYGWIN_NT', 'Mac', 'Darwin', 'FreeBSD', 'Linux', 'OpenBSD', 'Windows_NT', 'Unknown']
+const types = ['CYGWIN_NT', 'Mac', 'Darwin', 'FreeBSD', 'Linux', 'OpenBSD', 'Windows_NT', 'Win32', 'Unknown']
 
 test('os.arch()', (t) => {
   t.ok(archs.includes(os.arch()), 'os.arch() value is valid')
@@ -23,7 +23,8 @@ test('os.networkInterfaces()', (t) => {
   }
 
   const networkInterfaces = os.networkInterfaces()
-  t.ok(Array.isArray(networkInterfaces.lo) || Array.isArray(networkInterfaces.lo0), 'iterface is "lo"')
+  const lo = os.platform() === 'win32' ? 'Loopback Pseudo-Interface 1' : 'lo'
+  t.ok(Array.isArray(networkInterfaces[lo]) || Array.isArray(networkInterfaces.lo0), 'iterface is "lo"')
   const interfaces = Object.values(networkInterfaces)
   t.ok(interfaces.length >= 2, 'network interfaces has at least two keys, loopback + wifi, was:' + interfaces.length)
   t.ok(interfaces.every(addresses => Array.isArray(addresses)), 'network interface is an array')
@@ -34,7 +35,7 @@ test('os.networkInterfaces()', (t) => {
 })
 
 test('os.EOL', (t) => {
-  if (/windows/i.test(os.type())) {
+  if (os.platform() === 'win32') {
     t.equal(os.EOL, '\r\n')
   } else {
     t.equal(os.EOL, '\n')

--- a/test/src/path.js
+++ b/test/src/path.js
@@ -11,6 +11,5 @@ test('path', (t) => {
   t.equal(path.sep, expectedSep, 'path.sep is correct')
   const expectedDelimiter = isUnix ? ':' : ';'
   t.equal(path.delimiter, expectedDelimiter, 'path.delimiter is correct')
-  const cwd = isUnix ? process.cwd() : process.cwd().replace(/\\/g, '/')
-  t.equal(path.cwd(), cwd, 'path.cwd() returns the current working directory')
+  t.equal(path.cwd(), process.cwd(), 'path.cwd() returns the current working directory')
 })

--- a/test/src/process.js
+++ b/test/src/process.js
@@ -22,8 +22,11 @@ test('process.cwd', async (t) => {
     t.equal(process.cwd(), path.resolve(process.argv0, '../../socket-runtime-javascript-tests'), 'process.cwd() returns a correct value')
   } else if (process.platform === 'android') {
     t.ok(process.cwd(), 'process.cwd() returns a correct value')
+  } else if (process.platform === 'win32') {
+    // TODO(trevnorris): Fix to use path once implemented for Windows
+    t.equal(process.cwd(), process.argv0.slice(0, process.argv0.lastIndexOf('\\') + 1), 'process.cwd() returns a correct value')
   } else {
-    // TODO: iOS, Windows
+    // TODO: iOS
     t.fail(`FIXME: not implemented for platform ${process.platform}`)
   }
 })
@@ -35,7 +38,7 @@ test('process.arch', (t) => {
 
 test('process.platform', (t) => {
   t.ok(typeof process.platform === 'string', 'process.platform returns an string')
-  t.ok(['mac', 'linux', 'android', 'ios', 'win'].includes(process.platform), 'process.platform is correct')
+  t.ok(['mac', 'linux', 'android', 'ios', 'win32'].includes(process.platform), 'process.platform is correct')
   t.equal(process.platform, window.__args.os, 'process.platform equals window.__args.platform')
   t.equal(process.platform, process.os, 'process.platform returns the same value as process.os')
 })


### PR DESCRIPTION
I'm not proud of how backslashes are escaped. All tests, except the runtime tests, are now passing.

I also believe there's a memory leak somewhere. The test runner requires > 900MB memory to execute. That doesn't sound right.