### PR TITLE
linux: free resources created by gtk

### DIFF
--- a/src/ipc/bridge.cc
+++ b/src/ipc/bridge.cc
@@ -1164,6 +1164,7 @@ static void registerSchemeHandler (Router *router) {
       webkit_uri_scheme_response_set_content_type(response, IPC_CONTENT_TYPE);
       webkit_uri_scheme_request_finish_with_response(request, response);
       g_object_unref(stream);
+      g_object_unref(response);
     });
 
     if (!invoked) {
@@ -1186,6 +1187,7 @@ static void registerSchemeHandler (Router *router) {
       webkit_uri_scheme_response_set_content_type(response, IPC_CONTENT_TYPE);
       webkit_uri_scheme_request_finish_with_response(request, response);
       g_object_unref(stream);
+      g_object_unref(response);
     }
   },
   router,

--- a/src/window/linux.cc
+++ b/src/window/linux.cc
@@ -141,7 +141,10 @@ namespace SSC {
       ) {
         auto window = static_cast<Window*>(ptr);
         auto value = webkit_javascript_result_get_js_value(result);
-        auto str = String(jsc_value_to_string(value));
+        gchar* str_val = jsc_value_to_string(value);
+        auto str = String(str_val);
+
+        g_free(str_val);
 
         char *buf = nullptr;
         size_t bufsize = 0;
@@ -168,6 +171,9 @@ namespace SSC {
             delete [] index;
             delete [] seq;
           }
+
+          g_free(data);
+          g_free(bytes);
         }
 
         if (!window->bridge->route(str, buf, bufsize)) {
@@ -175,6 +181,8 @@ namespace SSC {
             window->onMessage(str);
           }
         }
+
+        delete[] buf;
       }),
       this
     );
@@ -292,6 +300,8 @@ namespace SSC {
 
             w->draggablePayload = split(str_value, ';');
             exception = jsc_context_get_exception(jsc_value_get_context(value));
+
+            g_free(str_value);
           },
           w
         );


### PR DESCRIPTION
The gtk library allocates resources when called. They need to be manually free'd or they'll leak all over like an over excited chihuahua.

The call to g_object_unref() is another way to free an allocation of a GObject. Since GTK has an internal reference counter (see https://discourse.gnome.org/t/when-should-i-use-g-object-unref/3834/2)

valgrind output for fs tests before fix:

    definitely lost: 1,004,645,382 bytes in 19,428 blocks
    indirectly lost: 941,726,112 bytes in 59,030 blocks
      possibly lost: 493,737,863 bytes in 1,977 blocks
    still reachable: 6,775,064 bytes in 36,079 blocks

and after tests:

    definitely lost: 2,825 bytes in 38 blocks
    indirectly lost: 11,461 bytes in 426 blocks
      possibly lost: 67,146 bytes in 393 blocks
    still reachable: 3,957,412 bytes in 36,028 blocks