### PR TITLE
Windows console fix

### DIFF
--- a/src/app/app.cc
+++ b/src/app/app.cc
@@ -87,8 +87,10 @@ namespace SSC {
     }
 #elif defined(_WIN32)
     if (isDebugEnabled()) {
-      fclose(console);
-      FreeConsole();
+      std::cout << "PostQuitMessage(0)" << std::endl;
+      if (w32ShowConsole) {
+        HideConsole();
+      }
     }
     PostQuitMessage(0);
 #endif
@@ -203,13 +205,21 @@ namespace SSC {
     MessageBoxA(nullptr, s, _TEXT("Alert"), MB_OK | MB_ICONSTOP);
   }
 
-  App::App (void* h) : App() {
-    this->hInstance = (HINSTANCE) h;
+  
+  void App::ShowConsole() {
+    std::cout << "Showing console" << std::endl;
+    AllocConsole();
+    freopen_s(&console, "CONOUT$", "w", stdout);
+  }
 
-    if (isDebugEnabled()) {
-      AllocConsole();
-      freopen_s(&console, "CONOUT$", "w", stdout);
-    }
+  void App::HideConsole() {
+    std::cout << "Hiding console" << std::endl;
+    fclose(console);
+    FreeConsole();
+  }
+
+  App::App (void* h) : App() {
+    this->hInstance = (HINSTANCE) h;  
 
     // this fixes bad default quality DPI.
     SetProcessDPIAware();

--- a/src/app/app.cc
+++ b/src/app/app.cc
@@ -87,7 +87,6 @@ namespace SSC {
     }
 #elif defined(_WIN32)
     if (isDebugEnabled()) {
-      std::cout << "PostQuitMessage(0)" << std::endl;
       if (w32ShowConsole) {
         HideConsole();
       }
@@ -207,13 +206,17 @@ namespace SSC {
 
   
   void App::ShowConsole() {
-    std::cout << "Showing console" << std::endl;
+    if (consoleVisible)
+      return;
+    consoleVisible = true;
     AllocConsole();
     freopen_s(&console, "CONOUT$", "w", stdout);
   }
 
   void App::HideConsole() {
-    std::cout << "Hiding console" << std::endl;
+    if (!consoleVisible)
+      return;
+    consoleVisible = false;
     fclose(console);
     FreeConsole();
   }

--- a/src/app/app.hh
+++ b/src/app/app.hh
@@ -33,6 +33,7 @@ namespace SSC {
       App (void *);
       void ShowConsole();
       void HideConsole();
+      bool consoleVisible = false;
 #endif
 
       App (int);

--- a/src/app/app.hh
+++ b/src/app/app.hh
@@ -25,11 +25,14 @@ namespace SSC {
       ExitCallback onExit = nullptr;
       bool shouldExit = false;
       bool fromSSC = false;
+      bool w32ShowConsole = false;
       Map appData;
       Core *core;
 
 #ifdef _WIN32
       App (void *);
+      void ShowConsole();
+      void HideConsole();
 #endif
 
       App (int);

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -139,11 +139,11 @@ int runApp (const fs::path& path, const String& args, bool headless) {
 
   auto runner = trim(String(STR_VALUE(CMD_RUNNER)));
   auto prefix = runner.size() > 0 ? runner + String(" ") : runner;
+  String headlessCommand = "";
 
   if (headless) {
     auto headlessRunner = settings["headless_runner"];
     auto headlessRunnerFlags = settings["headless_runner_flags"];
-    String headlessCommand = "";
 
     if (headlessRunner.size() == 0) {
       headlessRunner = settings["headless_" + platform.os + "_runner"];
@@ -172,20 +172,28 @@ int runApp (const fs::path& path, const String& args, bool headless) {
     }
 
     if (headlessRunner != "false") {
-      headlessCommand = headlessRunner + " " + headlessRunnerFlags + " ";
+      headlessCommand = headlessRunner + headlessRunnerFlags;
     }
-
-    status = std::system((headlessCommand + prefix + cmd + " " + args + " --from-ssc").c_str());
+    
   // TODO: this branch exits the CLI process
   // } else if (platform.mac) {
   //   auto s = prefix + cmd;
   //   auto part = s.substr(0, s.find(".app/") + 4);
   //   status = std::system(("open -n " + part + " --args " + args + " --from-ssc").c_str());
-  } else {
-    status = std::system((prefix + cmd + " " + args + " --from-ssc").c_str());
   }
+  std::cout << "Running app: " << prefix << cmd << args + " --from-ssc --w32" << std::endl;
+  auto process = new SSC::Process(
+    headlessCommand + prefix + cmd,
+    args + " --from-ssc",
+    fs::current_path().string(),
+    [](SSC::String const &out) { std::cout << out << std::endl; },
+    [](SSC::String const &out) { std::cerr << out << std::endl; }
+  );
 
-  return WEXITSTATUS(status);
+  process->open();
+  process->wait();
+
+  return WEXITSTATUS(process->status);
 }
 
 int runApp (const fs::path& path, const String& args) {

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1776,18 +1776,17 @@ int main (const int argc, const char* argv[]) {
         buildArgs.str(),
         fs::current_path().string(),
         [](SSC::String const &out) { stdWrite(out, false); },
-        [](SSC::String const &out) { stdWrite(out, true); },
-        [](SSC::String const &code) {
-          if (std::stoul(code) != 0) {
-            log("build failed, exiting with code " + code);
-            // TODO(trevnorris): Force non-windows to exit the process.
-            exit(std::stoul(code));
-          }
-        }
+        [](SSC::String const &out) { stdWrite(out, true); }
       );
 
       process->open();
       process->wait();
+      if (process->status != 0)
+      {
+        // TODO(trevnorris): Force non-windows to exit the process.
+        log("build failed, exiting with code " + std::to_string(process->status));
+        exit(process->status);
+      }
 
       log("ran user build command");
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1778,10 +1778,10 @@ int main (const int argc, const char* argv[]) {
         [](SSC::String const &out) { stdWrite(out, false); },
         [](SSC::String const &out) { stdWrite(out, true); },
         [](SSC::String const &code) {
-          if (std::stoi(code) != 0) {
+          if (std::stoul(code) != 0) {
             log("build failed, exiting with code " + code);
             // TODO(trevnorris): Force non-windows to exit the process.
-            exit(std::stoi(code));
+            exit(std::stoul(code));
           }
         }
       );

--- a/src/common.hh
+++ b/src/common.hh
@@ -547,16 +547,7 @@ namespace SSC {
   }
 
   inline void stdWrite (const String &str, bool isError) {
-    #ifdef _WIN32
-      StringStream ss;
-      ss << str << std::endl;
-      auto lineStr = ss.str();
-
-      auto handle = isError ? STD_ERROR_HANDLE : STD_OUTPUT_HANDLE;
-      WriteConsoleA(GetStdHandle(handle), lineStr.c_str(), lineStr.size(), NULL, NULL);
-    #else
-      (isError ? std::cerr : std::cout) << str << std::endl;
-    #endif
+    (isError ? std::cerr : std::cout) << str << std::endl;
   }
 
   #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -142,11 +142,9 @@ MAIN {
     // launched from the `ssc` cli
     app.fromSSC = s.find("--from-ssc") == 0 ? true : false;
 
-    if (!app.w32ShowConsole) {
-      app.w32ShowConsole = s.find("--w32-console") == 0 ? true : false;
-      if (app.w32ShowConsole) {
-        app.ShowConsole();
-      }
+    if (!app.w32ShowConsole && s.find("--w32-console") == 0) {
+      app.w32ShowConsole = true;
+      app.ShowConsole();
     }
 
     if (s.find("--test") == 0) {

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -142,6 +142,13 @@ MAIN {
     // launched from the `ssc` cli
     app.fromSSC = s.find("--from-ssc") == 0 ? true : false;
 
+    if (!app.w32ShowConsole) {
+      app.w32ShowConsole = s.find("--w32-console") == 0 ? true : false;
+      if (app.w32ShowConsole) {
+        app.ShowConsole();
+      }
+    }
+
     if (s.find("--test") == 0) {
       suffix = "-test";
       isTest = true;

--- a/src/process/process.hh
+++ b/src/process/process.hh
@@ -182,10 +182,12 @@ namespace SSC {
     // force=true is only supported on Unix-like systems.
     void kill(id_type id) noexcept;
 
-    void wait () {
+    int wait () {
       do {
         std::this_thread::yield();
       } while (this->closed == false);
+
+      return this->status;
     }
 
   private:

--- a/src/process/win.cc
+++ b/src/process/win.cc
@@ -210,7 +210,7 @@ Process::id_type Process::open(const SSC::String &command, const SSC::String &pa
       exitCode = -1;
     }
 
-    this->status = (int) exitCode;
+    this->status = WEXITSTATUS(exitCode);
     this->closed = true;
     on_exit(std::to_string(exitCode));
   });

--- a/src/process/win.cc
+++ b/src/process/win.cc
@@ -7,8 +7,7 @@
 
 namespace SSC {
 
-SSC::String FormatError(DWORD error, SSC::String source)
-{
+SSC::String FormatError(DWORD error, SSC::String source) {
   SSC::StringStream message;
   LPVOID lpMsgBuf;
   LPVOID lpDisplayBuf;

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -993,6 +993,14 @@ namespace SSC {
                           return S_OK;
                         }
 
+                        if (msg.name == "stdout") {
+                          std::cout << decodeURIComponent(msg.get("value")) << std::endl;
+                        }
+
+                        if (msg.name == "stderr") {
+                          std::cerr << decodeURIComponent(msg.get("value")) << std::endl;
+                        }
+
                         if (!w->bridge->route(message, nullptr, 0)) {
                           onMessage(message);
                         }

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -993,14 +993,6 @@ namespace SSC {
                           return S_OK;
                         }
 
-                        if (msg.name == "stdout") {
-                          std::cout << decodeURIComponent(msg.get("value")) << std::endl;
-                        }
-
-                        if (msg.name == "stderr") {
-                          std::cerr << decodeURIComponent(msg.get("value")) << std::endl;
-                        }
-
                         if (!w->bridge->route(message, nullptr, 0)) {
                           onMessage(message);
                         }


### PR DESCRIPTION
windows: disable extra console

1. Added additional code to win.cc to get tests to write to console
(These are probably in the wrong place, let me know if this can be improved)
3. modified cli to use SSC::Process when launching app, so std pipes can be captured and output
4. console can be reenabled using --w32-console

