### PR TITLE
windows ci/test: Resolve process status issues

### DIFF
--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -213,6 +213,7 @@ MAIN {
     if (processToKill != nullptr) {
       auto pid = processToKill->getPID();
       processToKill->kill(pid);
+      processToKill->wait();
 
       if (processToKill == process) {
         process = nullptr;

--- a/src/process/unix.cc
+++ b/src/process/unix.cc
@@ -368,6 +368,7 @@ void Process::kill(id_type id) noexcept {
     return;
   }
 
+  this->closed = true;
   auto r = ::kill(-id, SIGINT);
 
   if (r != 0) {

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -1081,7 +1081,14 @@ namespace SSC {
   }
 
   void Window::exit (int code) {
-    if (this->onExit != nullptr) this->onExit(code);
+    if (this->onExit != nullptr) 
+    {
+      std::cerr << "WARNING: Window#" << index << " exiting with code " << code << std::endl;
+      this->onExit(code);
+    }
+    else {
+      std::cerr << "WARNING: Window#" << index << " window->onExit is null in Window::exit()" << std::endl;
+    }
   }
 
   void Window::close (int code) {


### PR DESCRIPTION
1. Introduce SSC::Process->killed flag to prevent illegal access exception
(object was being deleted before wait thread completed)

2. Resolve exitCode -> int conversion issue:
If exitCode == 1 in previous code, (int)exitCode == 0, not good.

Note that this is basically a cross platform issue, as Win32 `GetProcessExitCode()` sets a DWORD (uint), while POSIX like `wait_pid` sets an int_32_t (currently on macos). 