### PR TITLE
Diagnostics API

### DIFF
--- a/api/dgram.js
+++ b/api/dgram.js
@@ -33,6 +33,7 @@ const RECV_BUFFER = 1
 const SEND_BUFFER = 0
 
 const dc = diagnostics.channels.group('udp', [
+  'send',
   'send.start',
   'send.end',
   'message',
@@ -571,14 +572,21 @@ async function send (socket, options, callback) {
   } catch (err) {
     callback(err)
     return { err }
-  } finally {
-    dc.channel('send.end').publish({
-      socket,
-      port: options.port,
-      buffer: options.buffer,
-      address: options.address
-    })
   }
+
+  dc.channel('send.end').publish({
+    socket,
+    port: options.port,
+    buffer: options.buffer,
+    address: options.address
+  })
+
+  dc.channel('send').publish({
+    socket,
+    port: options.port,
+    buffer: options.buffer,
+    address: options.address
+  })
 
   return result
 }

--- a/api/diagnostics.js
+++ b/api/diagnostics.js
@@ -1,0 +1,8 @@
+/**
+ * @notice This is a rexports of `diagnostics/index.js` so consumers will
+ * need to only `import * as diagnostics from 'socket:diagnostics'`
+ */
+import * as exports from './diagnostics.js'
+
+export * from './diagnostics/index.js'
+export default exports

--- a/api/diagnostics/channels.js
+++ b/api/diagnostics/channels.js
@@ -1,0 +1,528 @@
+import { toString, IllegalConstructor } from '../util.js'
+import process from '../process.js'
+
+export const MIN_CHANNEL_SUBSCRIBER_SIZE = 64
+
+/**
+ * Normalizes a channel name to lower case replacing white space,
+ * hyphens (-), underscores (_), with dots (.).
+ * @ignore
+ */
+export function normalizeName (group, name) {
+  if (group && !name) {
+    name = group.name || group || ''
+  } else if (group && name) {
+    const groupName = normalizeName(group.name || group || '')
+    if (!name.startsWith(groupName)) {
+      name = [groupName, name].filter(Boolean).join('.')
+    }
+  }
+
+  if (typeof name !== 'string') {
+    throw new TypeError(`Expecting 'name' to be a string. Got: ${typeof name}`)
+  }
+
+  const normalized = name
+    .toLowerCase()
+    .replace(/\s+/g, '.')
+    .replace(/(-|_)/g, '.')
+
+  return normalized
+}
+
+/**
+ * TODO(@jwerle): documentation
+ * @ignore
+ */
+export class Channel {
+  subscribers = new Array(MIN_CHANNEL_SUBSCRIBER_SIZE)
+  #subscribed = 0
+
+  constructor (name) {
+    this.name = name
+    this.group = null
+  }
+
+  get hasSubscribers () {
+    return false
+  }
+
+  get length () {
+    return this.#subscribed || 0
+  }
+
+  get [Symbol.iterator] () {
+    return this.subscribers
+  }
+
+  channel (name) {
+    name = normalizeName(this, name)
+    return registry.channel(name)
+  }
+
+  /**
+   * Adds an `onMessage` subscription callback to the channel.
+   * @return {boolean}
+   */
+  subscribe (onMessage) {
+    if (typeof onMessage !== 'function') {
+      throw new TypeError(
+        `Expecting 'onMessage' to be a function. Got: ${typeof onMessage}`
+      )
+    }
+
+    if (this.#subscribed >= this.subscribers.length) {
+      this.subscribers.push(onMessage)
+      this.#subscribed = this.subscribers.length
+    } else {
+      const i = this.#subscribed
+      this.subscribers[i] = onMessage
+      this.#subscribed++
+    }
+
+    Object.setPrototypeOf(this, ActiveChannel.prototype)
+
+    return true
+  }
+
+  /**
+   * Removes an `onMessage` subscription callback from the channel.
+   * @param {function} onMessage
+   * @return {boolean}
+   */
+  unsubscribe (onMessage) {
+    if (typeof onMessage !== 'function') {
+      throw new TypeError(
+        `Expecting 'onMessage' to be a function. Got: ${typeof onMessage}`
+      )
+    }
+
+    const index = this.subscribers.indexOf(onMessage)
+
+    if (index === -1) {
+      return false
+    }
+
+    if (index >= MIN_CHANNEL_SUBSCRIBER_SIZE) {
+      this.subscribers.splice(index, 1)
+    } else {
+      this.subscribers[index] = undefined
+    }
+
+    this.#subscribed--
+
+    return true
+  }
+
+  /**
+   * A no-op for `Channel` instances. This function always returns `false`.
+   * @return {boolean}
+   */
+  async publish () {
+    return false
+  }
+
+  /**
+   * GC finalizer callback
+   * @ignore
+   */
+  [Symbol.for('gc.finalizer')] (options) {
+    return {
+      args: [this.name, this.subscribers],
+      handle (name, subscribers) {
+        if (registry.has(name)) {
+          registry.remove(name)
+        }
+
+        subscribers.splice(0, subscribers.length)
+      }
+    }
+  }
+
+  /**
+   * @ignore
+   */
+  [Symbol.toStringTag] () {
+    return 'DiagnosticChannel'
+  }
+
+  /**
+   * @ignore
+   */
+  toString () {
+    return toString(this)
+  }
+}
+
+/**
+ * TODO(@jwerle): documentation
+ * @ignore
+ */
+export class ActiveChannel extends Channel {
+  get hasSubscribers () {
+    return true
+  }
+
+  unsubscribe (onMessage) {
+    if (!super.unsubscribe(onMessage)) {
+      return false
+    }
+
+    if (this.length === 0) {
+      Object.setPrototypeOf(this, Channel.prototype)
+    }
+  }
+
+  async publish (message) {
+    if (!this.hasSubscribers) return false
+
+    let published = false
+
+    for (const onMessage of this.subscribers) {
+      if (typeof onMessage === 'function') {
+        try {
+          await onMessage(message, this.name, this)
+          published = true
+        } catch (err) {
+          process.nextTick(() => { throw err })
+          return false
+        }
+      }
+    }
+
+    return published
+  }
+}
+
+/**
+ * TODO(@jwerle): documentation
+ * @ignore
+ */
+export class ChannelGroup extends Channel {
+  /**
+   * @param {Array<Channel>} channels
+   * @param {string} name
+   */
+  constructor (name, channels) {
+    super(name)
+
+    this.channels = Array.isArray(channels) ? channels : []
+
+    for (const channel of this.channels) {
+      channel.group = this
+    }
+  }
+
+  /**
+   * Computed subscribers for all channels in this group.
+   */
+  get subscribers () {
+    return this.channels
+      .map((channel) => channel.subscribers)
+      .reduce((a, b) => a.concat(b), [])
+  }
+
+  /**
+   * Number of channels in this group
+   */
+  get length () {
+    return this.channels.length
+  }
+
+  /**
+   * `true` if any channel in this group has a subscriber, otherwise `false`.
+   */
+  get hasSubscribers () {
+    return this.channels.some((channel) => channel.hasSubscribers)
+  }
+
+  /**
+   * @ignore
+   */
+  get [Symbol.iterator] () {
+    return this.channels
+  }
+
+  /**
+   * TODO
+   * @ignore
+   */
+  subscribe (name, onMessage) {
+    if (typeof name === 'function') {
+      onMessage = name
+      name = null
+    }
+
+    const selection = name ? this.select(name) : this.select('*')
+
+    for (const { channel } of selection) {
+      if (!channel.subscribe(onMessage)) {
+        return false
+      }
+    }
+
+    return selection.length > 0
+  }
+
+  /**
+   * TODO
+   * @ignore
+   */
+  unsubscribe (name, onMessage) {
+    const selection = this.select(name)
+
+    for (const { channel } of selection) {
+      if (!channel.unsubscribe(onMessage)) {
+        return false
+      }
+    }
+
+    return selection.length > 0
+  }
+
+  /**
+   * Gets or creates a channel for this group.
+   * @param {string} name
+   * @return {Channel}
+   */
+  channel (name) {
+    name = normalizeName(this, name)
+    const selection = this.select([name])
+
+    if (!selection.length) {
+      const channel = registry.channel(name)
+      channel.group = this
+      this.channels.push(channel)
+      return channel
+    }
+
+    if (selection.length > 1) {
+      throw new RangeError(
+        `Expecting 1 selection in 'group.channel()' for name '${name}'`
+      )
+    }
+
+    return selection[0].channel
+  }
+
+  /**
+   * TODO
+   * @ignore
+   */
+  select (keys, hasSubscribers = false) {
+    const selection = []
+
+    if (!keys || !keys.length) {
+      return selection
+    }
+
+    if (typeof keys === 'string') {
+      keys = [keys]
+    }
+
+    for (const key of keys) {
+      const name = normalizeName(this, key)
+      const filtered = this.channels.filter(filter(name))
+      for (const channel of filtered) {
+        selection.push({ name, channel })
+      }
+    }
+
+    return selection
+
+    function filter (name) {
+      const regexSafeName = name.replace(/:/g, '\\:').replace(/\*/g, '.*')
+      const regex = new RegExp(`^${regexSafeName}$`, 'g')
+      return (channel) => {
+        regex.lastIndex = 0 // `RegExp` instances are stateful
+
+        if (channel.name === name || regex.test(channel.name)) {
+          return !hasSubscribers || channel.hasSubscribers
+        }
+
+        return false
+      }
+    }
+  }
+
+  /**
+   * Publish a message to named subscribers in this group where `targets` is an
+   * object mapping channel names to messages.
+   * @param {string} name
+   * @param {object} message
+   * @return {boolean}
+   */
+  async publish (name, message) {
+    const pending = []
+    const targets = name && message ? { [name]: message } : name
+    const entries = Object.entries(targets).map((e) => normalizeEntry(this, e))
+    const messages = Object.fromEntries(entries)
+    const selection = this.select(Object.keys(messages), true)
+
+    for (const { name, channel } of selection) {
+      const message = messages[name]
+      if (message && channel.hasSubscribers) {
+        pending.push(channel.publish(message))
+      }
+    }
+
+    const results = await Promise.all(pending)
+    return results.length > 0 && results.every((result) => result === true)
+
+    function normalizeEntry (group, entry) {
+      return [normalizeName(group, entry[0]), entry[1]]
+    }
+  }
+}
+
+Object.freeze(Channel.prototype)
+Object.freeze(ChannelGroup.prototype)
+Object.freeze(ActiveChannel.prototype)
+
+/**
+ * An object mapping of named channels to `WeakRef<Channel>` instances.
+ */
+// eslint-disable-next-line new-parens
+export const registry = new class ChannelRegistry {
+  /**
+   * Subscribes callback `onMessage` to channel of `name`.
+   * @param {string} name
+   * @param {function} onMessage
+   * @return {boolean}
+   */
+  subscribe (name, onMessage) {
+    return this.channel(name)?.subscribe(onMessage) ?? false
+  }
+
+  /**
+   * Unsubscribes callback `onMessage` from channel of `name`.
+   * @param {string} name
+   * @param {function} onMessage
+   * @return {boolean}
+   */
+  unsubscribe (name, onMessage) {
+    return this.channel(name)?.unsubscribe(onMessage) ?? false
+  }
+
+  /**
+   * Predicate to determine if a named channel has subscribers.
+   * @param {string} name
+   */
+  hasSubscribers (name) {
+    return this.get(name)?.hasSubscribers ?? false
+  }
+
+  /**
+   * Get or set a channel by `name`.
+   * @param {string} name
+   * @return {Channel}
+   */
+  channel (name) {
+    return this.has(name)
+      ? this.get(name)
+      : this.set(name, new Channel(name))
+  }
+
+  /**
+   * Creates a `ChannelGroup` for a set of channels
+   * @param {string} name
+   * @param {Array<string>} [channels]
+   * @return {ChannelGroup}
+   */
+  group (name, channels) {
+    if (channels && !Array.isArray(channels)) {
+      channels = [channels]
+    }
+
+    channels = (channels || [])
+      .map((channel) => channel instanceof Channel
+        ? channel
+        : this.channel(normalizeName(name, channel))
+      )
+
+    return new ChannelGroup(name, channels)
+  }
+
+  /**
+   * Get a channel by name. The name is normalized.
+   * @param {string} name
+   * @return {Channel?}
+   */
+  get (name) {
+    return this[normalizeName(name)]?.deref?.() ?? null
+  }
+
+  /**
+   * Checks if a channel is known by  name. The name is normalized.
+   * @param {string} name
+   * @return {boolean}
+   */
+  has (name) {
+    return normalizeName(name) in this
+  }
+
+  /**
+   * Set a channel by name. The name is normalized.
+   * @param {string} name
+   * @param {Channel} channel
+   * @return {Channel?}
+   */
+  set (name, channel) {
+    if (channel instanceof Channel === false) {
+      const tag = String(channel?.[Symbol.toStringTag]?.() ?? channel)
+      throw new TypeError(
+        `Expecting 'channel' to be an instance of 'Channel'. Got ${tag}`
+      )
+    }
+
+    this[normalizeName(name)] = new WeakRef(channel)
+
+    return channel
+  }
+
+  /**
+   * Removes a channel by `name`
+   * @return {boolean}
+   */
+  remove (name) {
+    name = normalizeName(name)
+    return name in this && delete this[name]
+  }
+
+  /**
+   * @ignore
+   */
+  [Symbol.toStringTag] () {
+    return 'DiagnosticChannels'
+  }
+
+  /**
+   * @ignore
+   */
+  toString () {
+    return toString(this)
+  }
+
+  /**
+   * @ignore
+   */
+  toJSON () {
+    const json = {}
+
+    for (const name in this) {
+      const channel = this.get(name)
+      if (channel) {
+        json[name] = channel.toJSON()
+      }
+    }
+
+    return json
+  }
+}
+
+// make construction illegal
+Object.assign(Object.getPrototypeOf(registry), {
+  constructor: IllegalConstructor
+})
+
+export default registry

--- a/api/diagnostics/index.js
+++ b/api/diagnostics/index.js
@@ -1,0 +1,15 @@
+import channels from './channels.js'
+import window from './window.js'
+
+import * as exports from './index.js'
+
+export default exports
+export { channels, window }
+
+/**
+ * @param {string} name
+ * @return {import('./channels.js').Channel}
+ */
+export function channel (name) {
+  return channels.channel(name)
+}

--- a/api/diagnostics/metric.js
+++ b/api/diagnostics/metric.js
@@ -1,0 +1,30 @@
+import { format } from '../util.js'
+
+export class Metric {
+  init () {}
+  update () {}
+  destroy () {}
+
+  toJSON () {
+    return {}
+  }
+
+  toString () {
+    return format(this)
+  }
+
+  [Symbol.iterator] () {
+    if (isArrayLike(this)) {
+      return Array.from(this)
+    }
+
+    return [this]
+  }
+
+  [Symbol.toStringTag] () {
+    const name = this.constructor.name.replace('Metric', '')
+    return `DiagnosticMetric(${name})`
+  }
+}
+
+export default Metric

--- a/api/diagnostics/metric.js
+++ b/api/diagnostics/metric.js
@@ -1,4 +1,4 @@
-import { format } from '../util.js'
+import { isArrayLike, format } from '../util.js'
 
 export class Metric {
   init () {}

--- a/api/diagnostics/window.js
+++ b/api/diagnostics/window.js
@@ -1,0 +1,225 @@
+import { format, isArrayLike, IllegalConstructor } from '../util.js'
+import registry from './channels.js'
+import process from '../process.js'
+
+const dc = registry.group('window', [
+  'XMLHttpRequest',
+  'XMLHttpRequest.open',
+  'XMLHttpRequest.send',
+  'worker',
+  'fetch',
+  'fetch.start',
+  'fetch.end',
+  'requestAnimationFrame'
+])
+
+export class Metric {
+  init () {}
+  update () {}
+  destroy () {}
+
+  toJSON () {
+    return {}
+  }
+
+  toString () {
+    return format(this)
+  }
+
+  [Symbol.iterator] () {
+    if (isArrayLike(this)) {
+      return Array.from(this)
+    }
+
+    return [this]
+  }
+
+  [Symbol.toStringTag] () {
+    const name = this.constructor.name.replace('Metric', '')
+    return `DiagnosticMetric(${name})`
+  }
+}
+
+export class AnimationFrameMetric extends Metric {
+  constructor (options) {
+    super()
+    this.originalRequestAnimationFrame = null
+    this.requestAnimationFrame = this.requestAnimationFrame.bind(this)
+    this.sampleSize = options?.sampleSize || 60
+    this.channel = dc.channel('requestAnimationFrame')
+    this.frame = null
+    this.tick = 0 // max(0, sampleSize)
+    this.now = 0
+  }
+
+  requestAnimationFrame (callback) {
+    return this.originalRequestAnimationFrame.call(globalThis, (...args) => {
+      this.update(...args)
+      // eslint-disable-next-line n/no-callback-literal
+      callback(...args)
+    })
+  }
+
+  init () {
+    if (this.frame === null) {
+      this.samples = new Uint8Array(this.sampleSize)
+      this.originalRequestAnimationFrame = globalThis.requestAnimationFrame
+      globalThis.requestAnimationFrame = this.requestAnimationFrame
+
+      process.once('exit', () => {
+        this.destroy()
+      })
+    }
+  }
+
+  update (value) {
+    const then = this.now
+    const now = globalThis?.performance.now()
+
+    if (then > 0) {
+      const computed = 1 / (0.001 * (now - then))
+      const sample = Math.floor(computed)
+
+      if (this.samples) {
+        this.samples[this.tick] = sample
+      }
+
+      this.tick = (this.tick + 1) % this.sampleSize
+
+      const sum = this.samples?.slice(0, this.tick).reduce((a, b) => a + b, 0)
+      const average = sum / (this.tick)
+      const rate = Math.round(average)
+      const metric = { rate, samples: this.tick - 1 }
+
+      this.channel?.publish(metric)
+    }
+
+    this.now = now
+  }
+
+  destroy () {
+    globalThis.cancelAnimationFrame(this.frame)
+
+    if (typeof this.originalRequestAnimationFrame === 'function') {
+      globalThis.requestAnimationFrame = this.originalRequestAnimationFrame
+    }
+
+    this.originalRequestAnimationFrame = null
+    this.samples = null
+    this.channel = null
+    this.frame = null
+  }
+}
+
+export class FetchMetric extends Metric {
+  constructor (options) {
+    super()
+    this.originalFetch = null
+    this.channel = dc.channel('fetch')
+    this.fetch = this.fetch.bind(this)
+  }
+
+  async fetch (resource, options, extra) {
+    const metric = { resource, options, extra }
+    this.channel.channel('start').publish(metric)
+
+    const args = [resource, options, extra]
+    const response = await this.originalFetch.apply(globalThis, args)
+
+    this.channel.channel('end').publish(metric)
+    this.channel.publish(metric)
+    return response
+  }
+
+  init () {
+    if (!this.originalFetch) {
+      this.originalFetch = globalThis.fetch
+      globalThis.fetch = this.fetch
+    }
+  }
+
+  destroy () {
+    if (typeof this.originalFetch === 'function') {
+      globalThis.fetch = this.originalFetch
+      this.originalFetch = null
+    }
+  }
+}
+
+export class XMLHttpRequestMetric extends Metric {
+  constructor (options) {
+    super()
+    const self = this
+    this.channel = dc.channel('xmlhttprequest')
+    this.OrigialXMLHttpRequest = null
+
+    this.XMLHttpRequest = class XMLHttpRequest extends globalThis.XMLHttpRequest {
+      constructor () {
+        super()
+        self.channel.publish({ request: this })
+      }
+
+      send (body = null, ...args) {
+        self.channel.channel('send').publish({ request: this, body })
+        return self.OrigialXMLHttpRequest.prototype.send.call(this, body, ...args)
+      }
+
+      open (method, url, async, ...args) {
+        self.channel.channel('open').publish({ request: this, method, url, async })
+        return self.OrigialXMLHttpRequest.prototype.open.call(this, method, url, ...args)
+      }
+    }
+  }
+
+  init () {
+    if (!this.OrigialXMLHttpRequest) {
+      this.OrigialXMLHttpRequest = globalThis.XMLHttpRequest
+      globalThis.XMLHttpRequest = this.XMLHttpRequest
+    }
+  }
+
+  destroy () {
+    if (typeof this.OrigialXMLHttpRequest === 'function') {
+      globalThis.XMLHttpRequest = this.OrigialXMLHttpRequest
+      this.OrigialXMLHttpRequest = null
+    }
+  }
+}
+
+// eslint-disable-next-line new-parens
+export const metrics = new class Metrics {
+  animationFrame = new AnimationFrameMetric()
+  XMLHttpRequest = new XMLHttpRequestMetric()
+  fetch = new FetchMetric()
+
+  channel = dc
+
+  subscribe (...args) {
+    return dc.subscribe(...args)
+  }
+
+  unsubscribe (...args) {
+    return dc.unsubscribe(...args)
+  }
+
+  init (which) {
+    if (Array.isArray(which)) {
+      for (const key of which) {
+        if (typeof this[key]?.init === 'function') {
+          this[key].init()
+        }
+      }
+    } else {
+      this.animationFrame.init()
+      this.XMLHttpRequest.init()
+      this.fetch.init()
+    }
+  }
+}
+
+// make construction illegal
+Object.assign(Object.getPrototypeOf(metrics), {
+  constructor: IllegalConstructor
+})
+
+export default { metrics }

--- a/api/diagnostics/window.js
+++ b/api/diagnostics/window.js
@@ -1,4 +1,4 @@
-import { isArrayLike, IllegalConstructor } from '../util.js'
+import { IllegalConstructor } from '../util.js'
 import { Metric } from './metric.js'
 import registry from './channels.js'
 import process from '../process.js'
@@ -188,7 +188,7 @@ export const metrics = new class Metrics {
     return dc.unsubscribe(...args)
   }
 
-  init (which) {
+  start (which) {
     if (Array.isArray(which)) {
       for (const key of which) {
         if (typeof this[key]?.init === 'function') {
@@ -204,7 +204,7 @@ export const metrics = new class Metrics {
     }
   }
 
-  destroy (which) {
+  stop (which) {
     if (Array.isArray(which)) {
       for (const key of which) {
         if (typeof this[key]?.destroy === 'function') {

--- a/api/dns/index.js
+++ b/api/dns/index.js
@@ -19,7 +19,8 @@ import * as exports from './index.js'
 
 const dc = diagnostics.channels.group('dns', [
   'lookup.start',
-  'lookup.end'
+  'lookup.end',
+  'lookup'
 ])
 
 /**
@@ -78,7 +79,6 @@ export function lookup (hostname, opts, cb) {
 
   dc.channel('lookup.start').publish({ hostname, family: opts.family, sync: true })
   const { err, data } = ipc.sendSync('dns.lookup', { ...opts, id: rand64(), hostname })
-  dc.channel('lookup.end').publish({ hostname, family: opts.family, sync: true })
 
   if (err) {
     const e = new Error(`getaddrinfo EAI_AGAIN ${hostname}`)
@@ -91,6 +91,8 @@ export function lookup (hostname, opts, cb) {
     return
   }
 
+  dc.channel('lookup.end').publish({ hostname, family: opts.family, sync: true })
+  dc.channel('lookup').publish({ hostname, family: opts.family, sync: true })
   cb(null, data?.address ?? null, data?.family ?? null)
 }
 

--- a/api/dns/promises.js
+++ b/api/dns/promises.js
@@ -17,7 +17,8 @@ import * as exports from './promises.js'
 
 const dc = diagnostics.channels.group('dns', [
   'lookup.start',
-  'lookup.end'
+  'lookup.end',
+  'lookup'
 ])
 
 /**
@@ -49,7 +50,6 @@ export async function lookup (hostname, opts) {
 
   dc.channel('lookup.start').publish({ hostname, family: opts.family })
   const { err, data } = await ipc.send('dns.lookup', { ...opts, id: rand64(), hostname })
-  dc.channel('lookup.end').publish({ hostname, family: opts.family })
 
   if (err) {
     const e = new Error(`getaddrinfo EAI_AGAIN ${hostname}`)
@@ -60,6 +60,9 @@ export async function lookup (hostname, opts) {
     // e.errno = -3008, // lib_uv constant?
     throw e
   }
+
+  dc.channel('lookup.end').publish({ hostname, family: opts.family })
+  dc.channel('lookup').publish({ hostname, family: opts.family })
 
   return data
 }

--- a/api/errors.js
+++ b/api/errors.js
@@ -150,6 +150,38 @@ export class FinalizationRegistryCallbackError extends Error {
 }
 
 /**
+ * An `IllegalConstructorError` is an error type thrown when a constructor is
+ * called for a class constructor when it shouldn't be.
+ */
+export class IllegalConstructorError extends TypeError {
+  /**
+   * The default code given to an `IllegalConstructorError`
+   */
+  static get code () { return 0 }
+
+  /**
+   * `IllegalConstructorError` class constructor.
+   * @param {string} message
+   * @param {number} [code]
+   */
+  constructor (message, ...args) {
+    super(message, ...args)
+
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, IllegalConstructorError)
+    }
+  }
+
+  get name () {
+    return 'IllegalConstructorError'
+  }
+
+  get code () {
+    return 'ILLEGAL_CONSTRUCTOR_ERR'
+  }
+}
+
+/**
  * An `IndexSizeError` is an error type thrown when an internal exception
  * has occurred, such as in the native IPC layer.
  */

--- a/api/gc.js
+++ b/api/gc.js
@@ -1,4 +1,5 @@
 import { FinalizationRegistryCallbackError } from './errors.js'
+import diagnostics from './diagnostics.js'
 import { noop } from './util.js'
 import console from './console.js'
 
@@ -8,6 +9,13 @@ if (typeof FinalizationRegistry === 'undefined') {
     'gc.ref() will have no effect.'
   )
 }
+
+const dc = diagnostics.channels.group('gc', [
+  'finalizer.start',
+  'finalizer.end',
+  'unref',
+  'ref'
+])
 
 export const finalizers = new WeakMap()
 export const kFinalizer = Symbol.for('gc.finalizer')
@@ -50,6 +58,8 @@ export default gc
  * @param {Finalizer} finalizer
  */
 async function finalizationRegistryCallback (finalizer) {
+  dc.channel('finalizer.start').publish({ finalizer })
+
   if (typeof finalizer.handle === 'function') {
     try {
       await finalizer.handle(...finalizer.args)
@@ -77,6 +87,7 @@ async function finalizationRegistryCallback (finalizer) {
     pool.delete(weakRef)
   }
 
+  dc.channel('finalizer.end').publish({ finalizer })
   finalizer = undefined
 }
 
@@ -134,6 +145,8 @@ export async function ref (object, ...args) {
     pool.add(weakRef)
 
     registry.register(object, finalizer, object)
+
+    dc.channel('ref').publish({ object, finalizer: weakRef })
   }
 
   return finalizers.has(object)
@@ -159,6 +172,7 @@ export function unref (object) {
 
     finalizers.delete(object)
     registry.unregister(object)
+    dc.channel('unref').publish({ object, finalizer: weakRef })
     return true
   }
 

--- a/api/ipc.js
+++ b/api/ipc.js
@@ -1218,6 +1218,7 @@ export async function request (command, params, options) {
       if (options?.timeout) {
         clearTimeout(timeout)
       }
+
       resolve(Result.from(null, new AbortError(signal), command))
     }
 

--- a/api/os.js
+++ b/api/os.js
@@ -18,6 +18,16 @@ export function arch () {
   return primordials.arch
 }
 
+export function cpus () {
+  if (!cache.cpus) {
+    const { err, data } = ipc.sendSync('os.cpus')
+    if (err) throw err
+    cache.cpus = data
+  }
+
+  return cache.cpus
+}
+
 export function networkInterfaces () {
   const now = Date.now()
 

--- a/api/os.js
+++ b/api/os.js
@@ -212,6 +212,28 @@ export const EOL = (() => {
   return '\n'
 })()
 
+export function rusage () {
+  const { err, data } = ipc.sendSync('os.rusage')
+  if (err) throw err
+  return data
+}
+
+export function uptime () {
+  const { err, data } = ipc.sendSync('os.uptime')
+  if (err) throw err
+  return data
+}
+
+export function uname () {
+  if (!cache.uname) {
+    const { err, data } = ipc.sendSync('os.uname')
+    if (err) throw err
+    cache.uname = data
+  }
+
+  return cache.uname
+}
+
 // eslint-disable-next-line
 import * as exports from './os.js'
 export default exports

--- a/api/process.js
+++ b/api/process.js
@@ -29,6 +29,26 @@ if (!isNode) {
 
 export default process
 
+export function nextTick (callback) {
+  if (typeof process.nextTick === 'function' && process.nextTick !== nextTick) {
+    process.nextTick(callback)
+  } else if (typeof globalThis.setImmediate === 'function') {
+    globalThis.setImmediate(callback)
+  } else if (typeof globalThis.queueMicrotask === 'function') {
+    globalThis.queueMicrotask(callback)
+  } else if (typeof globalThis.setTimeout === 'function') {
+    globalThis.setTimeout(callback)
+  } else if (typeof globalThis.requestAnimationFrame === 'function') {
+    globalThis.requestAnimationFrame(callback)
+  } else {
+    throw new TypeError('\'process.nextTick\' is not supported in environment.')
+  }
+}
+
+if (typeof process.nextTick !== 'function') {
+  process.nextTick = nextTick
+}
+
 /**
  * @returns {string} The home directory of the current user.
  */

--- a/src/app/app.cc
+++ b/src/app/app.cc
@@ -36,12 +36,12 @@ namespace SSC {
 #if defined(__linux__)
     gtk_init_check(0, nullptr);
 #endif
+
+    auto cwd = getCwd();
+    uv_chdir(cwd.c_str());
   }
 
   int App::run () {
-    auto cwd = getCwd();
-    uv_chdir(cwd.c_str());
-
 #if defined(__linux__)
     gtk_main();
 #elif defined(__APPLE__) && !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR

--- a/src/core/core.hh
+++ b/src/core/core.hh
@@ -563,6 +563,18 @@ namespace SSC {
             Module::Callback cb
           );
           void networkInterfaces (const String seq, Module::Callback cb) const;
+          void rusage (
+            const String seq,
+            Module::Callback cb
+          );
+          void uname (
+            const String seq,
+            Module::Callback cb
+          );
+          void uptime (
+            const String seq,
+            Module::Callback cb
+          );
       };
 
       class Platform : public Module {

--- a/src/core/core.hh
+++ b/src/core/core.hh
@@ -357,6 +357,11 @@ namespace SSC {
           }
       };
 
+      class Diagnostics : public Module {
+        public:
+          Diagnostics (auto core) : Module(core) {}
+      };
+
       class DNS : public Module {
         public:
           DNS (auto core) : Module(core) {}
@@ -553,6 +558,10 @@ namespace SSC {
             int buffer,
             Module::Callback cb
           );
+          void cpus  (
+            const String seq,
+            Module::Callback cb
+          );
           void networkInterfaces (const String seq, Module::Callback cb) const;
       };
 
@@ -628,6 +637,7 @@ namespace SSC {
           );
       };
 
+      Diagnostics diagnostics;
       DNS dns;
       FS fs;
       OS os;
@@ -668,6 +678,7 @@ namespace SSC {
 #endif
 
       Core () :
+        diagnostics(this),
         dns(this),
         fs(this),
         os(this),

--- a/src/core/diagnostics.cc
+++ b/src/core/diagnostics.cc
@@ -1,0 +1,5 @@
+#include "core.hh"
+#include "json.hh"
+
+namespace SSC {
+}

--- a/src/ipc/bridge.cc
+++ b/src/ipc/bridge.cc
@@ -782,6 +782,18 @@ void initFunctionsTable (Router *router) {
     router->core->os.cpus(message.seq, RESULT_CALLBACK_FROM_CORE_CALLBACK(message, reply));
   });
 
+  router->map("os.rusage", [=](auto message, auto router, auto reply) {
+    router->core->os.rusage(message.seq, RESULT_CALLBACK_FROM_CORE_CALLBACK(message, reply));
+  });
+
+  router->map("os.uptime", [=](auto message, auto router, auto reply) {
+    router->core->os.uptime(message.seq, RESULT_CALLBACK_FROM_CORE_CALLBACK(message, reply));
+  });
+
+  router->map("os.uname", [=](auto message, auto router, auto reply) {
+    router->core->os.uname(message.seq, RESULT_CALLBACK_FROM_CORE_CALLBACK(message, reply));
+  });
+
   /**
    * Simply returns `pong`.
    */

--- a/src/ipc/bridge.cc
+++ b/src/ipc/bridge.cc
@@ -776,6 +776,13 @@ void initFunctionsTable (Router *router) {
   });
 
   /**
+   * Returns an array of CPUs available to the process.
+   */
+  router->map("os.cpus", [=](auto message, auto router, auto reply) {
+    router->core->os.cpus(message.seq, RESULT_CALLBACK_FROM_CORE_CALLBACK(message, reply));
+  });
+
+  /**
    * Simply returns `pong`.
    */
   router->map("ping", [](auto message, auto router, auto reply) {

--- a/test/src/diagnostics.js
+++ b/test/src/diagnostics.js
@@ -1,0 +1,2 @@
+// import './diagnostics/channels.js'
+import './diagnostics/window.js'

--- a/test/src/diagnostics/channels.js
+++ b/test/src/diagnostics/channels.js
@@ -1,0 +1,219 @@
+import diagnostics from 'socket:diagnostics'
+import { Buffer } from 'socket:buffer'
+import dgram from 'socket:dgram'
+import path from 'socket:path'
+import test from 'socket:test'
+import dns from 'socket:dns/promises'
+import fs from 'socket:fs/promises'
+import os from 'socket:os'
+
+const TMPDIR = `${os.tmpdir()}${path.sep}`
+const FIXTURES = /android/i.test(os.platform())
+  ? '/data/local/tmp/ssc-socket-test-fixtures/'
+  : `${TMPDIR}ssc-socket-test-fixtures${path.sep}`
+
+test('diagnostics - channels - simple', async (t) => {
+  const channel = diagnostics.channel('simple')
+  t.equal(channel.hasSubscribers, false, 'channel.hasSubscribers === false')
+
+  await new Promise((resolve) => {
+    channel.subscribe(function onMessage (message, name, chan) {
+      t.equal(typeof message, 'object', 'typeof message === \'object\'')
+      t.equal(message.key, 'value', 'message.key === \'value\'')
+      t.equal(name, 'simple', 'name === \'simple\'')
+      t.equal(chan, channel, 'chan === channel')
+      channel.unsubscribe(onMessage)
+      t.equal(channel.hasSubscribers, false, 'channel.hasSubscribers === false')
+      resolve()
+    })
+
+    t.equal(channel.hasSubscribers, true, 'channel.hasSubscribers === true')
+    const promise = channel.publish({ key: 'value' })
+    t.ok(promise instanceof Promise, 'channel.publish() -> Promise')
+    promise.then((status) => {
+      t.equal(status, true, '(await channel.publish()) === true')
+    })
+  })
+})
+
+test('diagnostics - channel groups - simple', async (t) => {
+  const group = diagnostics.channels.group('diagnostics group')
+  const channels = [
+    group.channel('b:2'),
+    group.channel('b:1'),
+    group.channel('a:2'),
+    group.channel('a:1')
+  ]
+
+  t.equal(group.hasSubscribers, false, 'group.hasSubscribers === false')
+
+  await new Promise((resolve) => {
+    let pending = 2
+    group.subscribe('a:*', (message, name, chan) => {
+      let channelIndex = -1
+
+      if (name.endsWith('a:1')) {
+        pending -= 1
+        channelIndex = 3
+      } else if (name.endsWith('a:2')) {
+        pending -= 1
+        channelIndex = 2
+      }
+
+      t.equal(chan, channels[channelIndex], `${name} channel seen`)
+      t.equal(chan.group, group, `${group.name} group set for ${chan.name}`)
+      t.equal(message?.hello, 'world', 'message.hello == \'world\'')
+
+      if (pending === 0) {
+        resolve()
+      }
+    })
+
+    group.publish('a:*', { hello: 'world' })
+  })
+})
+
+test('diagnostics - channels - builtin - udp', async (t) => {
+  const pending = []
+  const group = diagnostics.channels.group('udp')
+
+  pending.push(new Promise((resolve) => {
+    group.channel('socket').subscribe((message, name, chan) => {
+      t.equal(name, 'udp.socket', '\'udp.socket\' message called')
+      t.ok(message.socket, 'message.socket')
+      resolve()
+    })
+  }))
+
+  pending.push(new Promise((resolve) => {
+    group.channel('bind').subscribe((message, name, chan) => {
+      t.equal(name, 'udp.bind', 'udp.bind message')
+      resolve()
+    })
+  }))
+
+  pending.push(new Promise((resolve) => {
+    group.channel('message').subscribe((message, name, chan) => {
+      t.equal(name, 'udp.message', 'udp.message message')
+      resolve()
+    })
+  }))
+
+  pending.push(new Promise((resolve) => {
+    group.channel('send.start').subscribe((message, name, chan) => {
+      t.equal(name, 'udp.send.start', 'udp.send.start message')
+      resolve()
+    })
+  }))
+
+  pending.push(new Promise((resolve) => {
+    group.channel('send.end').subscribe((message, name, chan) => {
+      t.equal(name, 'udp.send.end', 'udp.send.start message')
+      resolve()
+    })
+  }))
+
+  pending.push(new Promise((resolve) => {
+    let pending = 2
+    group.channel('close').subscribe((message, name, chan) => {
+      t.equal(name, 'udp.close', 'udp.close message')
+      if (--pending === 0) {
+        resolve()
+      }
+    })
+  }))
+
+  let socket = dgram.createSocket('udp4')
+  socket.bind(8888, () => {
+    const { address, port } = socket.address()
+    const buffer = Buffer.from('hello')
+    let sender = dgram.createSocket('udp4')
+    sender.send(buffer, 0, buffer.length, port, address, () => {
+      sender.close()
+      socket.close()
+      sender = undefined
+      socket = undefined
+    })
+  })
+
+  await Promise.all(pending)
+})
+
+test('diagnostics - channels - builtin - fs', async (t) => {
+  const pending = []
+  const group = diagnostics.channels.group('fs')
+
+  pending.push(new Promise((resolve) => {
+    group.channel('handle').subscribe((message, name, chan) => {
+      t.equal(name, 'fs.handle', 'fs.handle message')
+      t.ok(message.handle, 'message.handle')
+      resolve()
+    })
+  }))
+
+  pending.push(new Promise((resolve) => {
+    group.channel('handle.open').subscribe((message, name, chan) => {
+      t.equal(name, 'fs.handle.open', 'fs.handle.open message')
+      t.ok(message.handle, 'message.handle')
+      resolve()
+    })
+  }))
+
+  pending.push(new Promise((resolve) => {
+    group.channel('handle.close').subscribe((message, name, chan) => {
+      t.equal(name, 'fs.handle.close', 'fs.handle.close message')
+      t.ok(message.handle, 'message.handle')
+      resolve()
+    })
+  }))
+
+  pending.push(new Promise((resolve) => {
+    group.channel('handle.read').subscribe((message, name, chan) => {
+      t.equal(name, 'fs.handle.read', 'fs.handle.read message')
+      t.equal(message.bytesRead, 4, 'message.bytesRead === 4')
+      t.ok(message.handle, 'message.handle')
+      resolve()
+    })
+  }))
+
+  pending.push(new Promise((resolve) => {
+    group.channel('handle.write').subscribe((message, name, chan) => {
+      t.equal(name, 'fs.handle.write', 'fs.handle.write message')
+      t.equal(message.bytesWritten, 4, 'message.bytesWritten === 4')
+      t.ok(message.handle, 'message.handle')
+      resolve()
+    })
+  }))
+
+  const handle = await fs.open(FIXTURES + 'file.txt', 'r+')
+  const buffer = Buffer.alloc(4)
+
+  await handle.read(buffer, 0, buffer.length, 0)
+  await handle.write(buffer, 0, buffer.length, 0)
+  await handle.close()
+  await Promise.all(pending)
+})
+
+test('diagnostics - channels - builtin - dns', async (t) => {
+  const pending = []
+  const group = diagnostics.channels.group('dns')
+
+  pending.push(new Promise((resolve) => {
+    group.channel('lookup.start').subscribe((message, name, chan) => {
+      t.equal(typeof message.hostname, 'string', 'message.host is string')
+      t.equal(typeof message.family, 'number', 'message.port is number')
+      resolve()
+    })
+  }))
+
+  pending.push(new Promise((resolve) => {
+    group.channel('lookup.end').subscribe((message, name, chan) => {
+      t.equal(typeof message.hostname, 'string', 'message.host is string')
+      t.equal(typeof message.family, 'number', 'message.port is number')
+      resolve()
+    })
+  }))
+
+  await dns.lookup('google.com')
+  await Promise.all(pending)
+})

--- a/test/src/diagnostics/window.js
+++ b/test/src/diagnostics/window.js
@@ -2,7 +2,7 @@ import diagnostics from 'socket:diagnostics'
 import test from 'socket:test'
 
 test('diagnostics - window - metrics', async (t) => {
-  diagnostics.window.metrics.init()
+  diagnostics.window.metrics.start()
 
   /**
    * This test requires the browser window to be focused as
@@ -70,5 +70,5 @@ test('diagnostics - window - metrics', async (t) => {
     Promise.all(pending).then(resolve)
   })
 
-  diagnostics.window.metrics.destroy()
+  diagnostics.window.metrics.stop()
 })

--- a/test/src/diagnostics/window.js
+++ b/test/src/diagnostics/window.js
@@ -1,0 +1,78 @@
+import diagnostics from 'socket:diagnostics'
+import test from 'socket:test'
+
+test('diagnostics - window - metrics', async (t) => {
+  diagnostics.window.metrics.init()
+
+  /**
+   * This test requires the browser window to be focused as
+   * requestAnimationFrame` is used internally.
+   * Uncomment it to verify manually
+   */
+  /*
+  await new Promise((resolve) => {
+    let iterations = 0
+    diagnostics.window.metrics.subscribe('requestAnimationFrame', (message) => {
+      if (message.rate > 0 && iterations === 30) {
+        t.equal(typeof message.fps, 'number', 'message.fps is number')
+        t.equal(typeof message.samples, 'number', 'message.samples is number')
+      }
+
+      resolve()
+    })
+
+    globalThis.requestAnimationFrame(function onAnimationFrame () {
+      if (++iterations < 30) {
+        globalThis.requestAnimationFrame(onAnimationFrame)
+      }
+    })
+  })
+  */
+
+  await new Promise((resolve) => {
+    const uri = 'ipc://platform.primordials'
+    const options = { method: 'GET' }
+    let diagnosticsReceived = false
+    diagnostics.window.metrics.subscribe('fetch', (message) => {
+      t.equal(message.resource, uri, 'message.resource === uri')
+      t.equal(message.options, options, 'message.options === options')
+      diagnosticsReceived = true
+    })
+
+    fetch(uri, options)
+      .then((response) => response.json())
+      .then((json) => t.ok(json?.data, 'response json.data'))
+      .then(() => t.ok(diagnosticsReceived, 'fetch diagnostics received'))
+      .then(resolve)
+  })
+
+  await new Promise((resolve) => {
+    const pending = []
+    const uri = 'ipc://platform.primordials'
+    const method = 'GET'
+
+    pending.push(new Promise((resolve) => {
+      diagnostics.window.metrics.subscribe('XMLHttpRequest', (message) => {
+        resolve()
+      })
+    }))
+
+    pending.push(new Promise((resolve) => {
+      diagnostics.window.metrics.subscribe('XMLHttpRequest.open', (message) => {
+        resolve()
+      })
+    }))
+
+    pending.push(new Promise((resolve) => {
+      diagnostics.window.metrics.subscribe('XMLHttpRequest.send', (message) => {
+        resolve()
+      })
+    }))
+
+    const request = new globalThis.XMLHttpRequest()
+    request.open(method, uri, true)
+    request.send()
+
+    Promise.all(pending).then(resolve)
+  })
+})

--- a/test/src/diagnostics/window.js
+++ b/test/src/diagnostics/window.js
@@ -52,12 +52,6 @@ test('diagnostics - window - metrics', async (t) => {
     const method = 'GET'
 
     pending.push(new Promise((resolve) => {
-      diagnostics.window.metrics.subscribe('XMLHttpRequest', (message) => {
-        resolve()
-      })
-    }))
-
-    pending.push(new Promise((resolve) => {
       diagnostics.window.metrics.subscribe('XMLHttpRequest.open', (message) => {
         resolve()
       })
@@ -75,4 +69,6 @@ test('diagnostics - window - metrics', async (t) => {
 
     Promise.all(pending).then(resolve)
   })
+
+  diagnostics.window.metrics.destroy()
 })

--- a/test/src/frontend/index.html
+++ b/test/src/frontend/index.html
@@ -2,6 +2,14 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        connect-src http://* https://* ipc://* file://*;
+        child-src 'none';
+        img-src https: data: file:;
+      "
+    >
     <title>Socket Runtime JavaScript Tests</title>
     <script charset="utf-8" src="index.js" type="module"></script>
   </head>

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -4,6 +4,7 @@ import './test-context.js' // this should be first
 // expect the total pass count
 
 import './webview.js'
+import './diagnostics.js'
 import './ipc.js'
 import './os.js'
 import './process.js'

--- a/test/src/os.js
+++ b/test/src/os.js
@@ -10,6 +10,20 @@ test('os.arch()', (t) => {
   t.ok(archs.includes(os.arch()), 'os.arch() value is valid')
 })
 
+test('os.cpus()', (t) => {
+  const cpus = os.cpus()
+  t.ok(Array.isArray(cpus), 'Array.isArray(cpus)')
+  t.ok(cpus.length > 0, 'cpus.length > 0')
+  t.equal(typeof cpus[0].model, 'string', 'cpus[0].model is string')
+  t.equal(typeof cpus[0].speed, 'number', 'cpus[0].numberl is number')
+  t.equal(cpus[0].times !== null && typeof cpus[0].times, 'object', 'cpus[0].times is object')
+  t.equal(typeof cpus[0].times.user, 'number', 'cpus[0].times.user is number')
+  t.equal(typeof cpus[0].times.nice, 'number', 'cpus[0].times.nice is number')
+  t.equal(typeof cpus[0].times.sys, 'number', 'cpus[0].times.sys is number')
+  t.equal(typeof cpus[0].times.idle, 'number', 'cpus[0].times.idle is number')
+  t.equal(typeof cpus[0].times.irq, 'number', 'cpus[0].times.irq is number')
+})
+
 test('os.platform()', (t) => {
   t.ok(platforms.includes(os.platform()), 'os.platform() value is valid')
   t.equal(os.platform(), primordials.platform, 'os.platform() equals primordials.platform')

--- a/test/src/os.js
+++ b/test/src/os.js
@@ -10,18 +10,35 @@ test('os.arch()', (t) => {
   t.ok(archs.includes(os.arch()), 'os.arch() value is valid')
 })
 
-test('os.cpus()', (t) => {
-  const cpus = os.cpus()
-  t.ok(Array.isArray(cpus), 'Array.isArray(cpus)')
-  t.ok(cpus.length > 0, 'cpus.length > 0')
-  t.equal(typeof cpus[0].model, 'string', 'cpus[0].model is string')
-  t.equal(typeof cpus[0].speed, 'number', 'cpus[0].numberl is number')
-  t.equal(cpus[0].times !== null && typeof cpus[0].times, 'object', 'cpus[0].times is object')
-  t.equal(typeof cpus[0].times.user, 'number', 'cpus[0].times.user is number')
-  t.equal(typeof cpus[0].times.nice, 'number', 'cpus[0].times.nice is number')
-  t.equal(typeof cpus[0].times.sys, 'number', 'cpus[0].times.sys is number')
-  t.equal(typeof cpus[0].times.idle, 'number', 'cpus[0].times.idle is number')
-  t.equal(typeof cpus[0].times.irq, 'number', 'cpus[0].times.irq is number')
+if (!['android', 'ios'].includes(os.platform())) {
+  test('os.cpus()', (t) => {
+    const cpus = os.cpus()
+    t.ok(Array.isArray(cpus), 'Array.isArray(cpus)')
+    t.ok(cpus.length > 0, 'cpus.length > 0')
+    t.equal(typeof cpus[0].model, 'string', 'cpus[0].model is string')
+    t.equal(typeof cpus[0].speed, 'number', 'cpus[0].numberl is number')
+    t.equal(cpus[0].times !== null && typeof cpus[0].times, 'object', 'cpus[0].times is object')
+    t.equal(typeof cpus[0].times.user, 'number', 'cpus[0].times.user is number')
+    t.equal(typeof cpus[0].times.nice, 'number', 'cpus[0].times.nice is number')
+    t.equal(typeof cpus[0].times.sys, 'number', 'cpus[0].times.sys is number')
+    t.equal(typeof cpus[0].times.idle, 'number', 'cpus[0].times.idle is number')
+    t.equal(typeof cpus[0].times.irq, 'number', 'cpus[0].times.irq is number')
+  })
+}
+
+test('os.rusage()', (t) => {
+  const rusage = os.rusage()
+  t.equal(typeof rusage, 'object', 'rusage is object')
+  t.equal(
+    !Number.isNaN(rusage.ru_maxrss) && typeof rusage.ru_maxrss,
+    'number',
+    'rusage.ru_maxrss is object'
+  )
+})
+
+test('os.uptime()', (t) => {
+  const uptime = os.uptime()
+  t.equal(!Number.isNaN(uptime) && typeof uptime, 'number', 'uptime is object')
 })
 
 test('os.platform()', (t) => {

--- a/test/src/test-context.js
+++ b/test/src/test-context.js
@@ -14,13 +14,23 @@ if (typeof globalThis?.addEventListener === 'function') {
   globalThis.addEventListener('unhandledrejection', onerror)
 }
 
+let finishing = false
 GLOBAL_TEST_RUNNER.onFinish(({ fail }) => {
-  setTimeout(() => {
-    process.exit(fail > 0 ? 1 : 0)
-  }, 1024) // give app time to print TAP output
+  if (!finishing) {
+    finishing = true
+    if (!process.env.DEBUG) {
+      setTimeout(() => {
+        process.exit(fail > 0 ? 1 : 0)
+      }, 1024) // give app time to print TAP output
+    }
+  }
 })
 
 function onerror (err) {
   console.error(err.stack || err.reason || err.message || err)
-  process.exit(1)
+  if (!finishing && !process.env.DEBUG) {
+    process.nextTick(() => {
+      process.exit(1)
+    })
+  }
 }


### PR DESCRIPTION
This pull request introduces an initial _Diagnostics API_ for usable in user space and also suitable for retrieving real time information about the usage of various API modules.

**listening for UDP sockets created and counting bytes of sent/received network traffic:**

```js
import diagnostics from 'socket:diagnostics'

const group = diagnostics.channels.group('udp')

group.subscribe('socket', (message) => {
  const { socket } = message // `socket` is an instance of `dgram.Socket`
})

let bytesReceived = 0
group.subscribe('message', (message) => {
  const { buffer } = message
  bytesReceived += buffer.length
})

let bytesWritten = 0
group.subscribe('send', (message) => {
  const { buffer } = message
  bytesWritten += buffer.length
})
```

**tracking requestAnimationFrame rate:**

```js
import diagnostics from 'socket:diagnostics'

diagnostics.window.metrics.start(['requestAnimationFrame'])
diagnostics.window.metrics.subscribe('requestAnimationFrame', (message) => {
  console.log(message.rate) // current rate of usage for `requestAnimationFrame()`
})

// start loop and sample 64 frames
let iterations = 0
requestAnimationFrame(function loop () {
  if (iterations++ < 64) {
    requestAnimationFrame(loop)
  }
})

diagnostics.window.metrics.stop(['requestAnimationFrame'])
```

**tracking `fetch()` calls and `XMLHttpRequest` usage:**

```js
import diagnostics from 'socket:diagnostics'

diagnostics.window.metrics.start(['fetch', 'XMLHttpRequest'])

diagnostics.window.metrics.subscribe('fetch', (message) => {
  console.log(message.resource) // the first argument to `fetch()` 
})

diagnostics.window.metrics.subscribe('XMLHttpRequest.*', (message, metric) => {
  if (metric.name === 'window.XMLHttpRequest.send') {
    const { body } = message
  }

  if (metric.name === 'window.XMLHttpRequest.open') {
    const { method, url } = message
  }
})

diagnostics.window.metrics.stop(['fetch', 'XMLHttpRequest'])
``` 