### PR TITLE
cli: fix path

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -487,10 +487,10 @@ int main (const int argc, const char* argv[]) {
   if (argc == 2 || lastOption[0] == '-') {
     numberOfOptions = argc - 2;
     targetPath = fs::current_path();
-  } else if (lastOption[0] == '.') {
-    targetPath = fs::absolute(lastOption).lexically_normal();
   } else {
-    targetPath = fs::path(lastOption);
+    targetPath = fs::absolute(lastOption).lexically_normal();
+  // } else {
+    // targetPath = fs::absolute(lastOption);
   }
 
   struct Paths {

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -489,8 +489,6 @@ int main (const int argc, const char* argv[]) {
     targetPath = fs::current_path();
   } else {
     targetPath = fs::absolute(lastOption).lexically_normal();
-  // } else {
-    // targetPath = fs::absolute(lastOption);
   }
 
   struct Paths {


### PR DESCRIPTION
this makes `ssc build -r dir` work (currently only `ssc build -r ./dir` works)
absolute paths still work after this change