### PR TITLE
Fix 'Window::getScreenSize()' on Linux

### DIFF
--- a/src/window/linux.cc
+++ b/src/window/linux.cc
@@ -631,6 +631,16 @@ namespace SSC {
       g_list_free(list);
     }
 
+    if (!height || !width) {
+      auto geometry = GdkRectangle {};
+      auto display = gdk_display_get_default();
+      auto monitor = gdk_display_get_primary_monitor(display);
+
+      gdk_monitor_get_workarea(monitor, &geometry);
+      width = (int) geometry.width;
+      height = (int) geometry.height;
+    }
+
     return ScreenSize { height, width };
   }
 


### PR DESCRIPTION
There is a case when `Window::getScreenSize()` returns `ScreenSize { 0, 0 }` when `Window#0` hasn't been created yet. 