### PR TITLE
Handle signals in 'ssc(1)' to shutdown child app process

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -154,7 +154,9 @@ void signalHandler (int signal) {
     auto pid = appProcess->getPID();
     appProcess->kill(pid);
   } else if (appPid > 0) {
+  #if !defined(_WIN32)
     kill(appPid, signal);
+  #endif
     appPid = 0;
   } else {
     exit(signal);

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -275,6 +275,7 @@ MAIN {
     #endif
 
     signal(SIGINT, signalHandler);
+    signal(SIGTERM, signalHandler);
 
     return exitCode;
   }
@@ -919,6 +920,7 @@ MAIN {
   #endif
 
   signal(SIGINT, signalHandler);
+  signal(SIGTERM, signalHandler);
 
   if (isReadingStdin) {
     std::string value;

--- a/src/process/process.hh
+++ b/src/process/process.hh
@@ -172,10 +172,11 @@ namespace SSC {
     // Close stdin. If the process takes parameters from stdin, use this to
     // notify that all parameters have been sent.
     void close_stdin() noexcept;
-    void open() noexcept {
-      if (this->command.size() == 0) return;
-      open(this->command + this->argv, this->path);
+    id_type open() noexcept {
+      if (this->command.size() == 0) return 0;
+      auto pid = open(this->command + this->argv, this->path);
       read();
+      return pid;
     }
 
     // Kill a given process id. Use kill(bool force) instead if possible.


### PR DESCRIPTION
We were no longer handling signals with the move to `SSC::Process` from `SSC::exec`. This pull request introduces a signal handler.