### PR TITLE
Various fixes

### DIFF
--- a/api/events.js
+++ b/api/events.js
@@ -469,6 +469,21 @@ function eventTargetAgnosticAddListener (emitter, name, listener, flags) {
 EventEmitter.EventEmitter = EventEmitter
 EventEmitter.once = once
 
+export const CustomEvent = globalThis.CustomEvent || class CustomEvent extends globalThis.Event {
+  #detail = null
+
+  constructor (type, options) {
+    super(type, options)
+    if (options?.detail) {
+      this.#detail = options.detail
+    }
+  }
+
+  get detail () {
+    return this.#detail
+  }
+}
+
 export {
   EventEmitter,
   once

--- a/api/external/libsodium/index.js
+++ b/api/external/libsodium/index.js
@@ -47,4 +47,4 @@ define('libsodium', async (module, exports, require) => {
 })
 
 modules.libsodium.exports.inspect = () => '[object libsodium]'
-export default modules.libsodium.exports
+export default modules.libsodium.exports.libsodium

--- a/api/util.js
+++ b/api/util.js
@@ -97,14 +97,16 @@ export function toString (object) {
   return Object.prototype.toString(object)
 }
 
-export function toBuffer (object) {
+export function toBuffer (object, encoding) {
   if (Buffer.isBuffer(object)) {
     return object
   } else if (isTypedArray(object)) {
     return Buffer.from(object.buffer)
+  } else if (typeof object?.toBuffer === 'function') {
+    return toBuffer(object.toBuffer(), encoding)
   }
 
-  return Buffer.from(object)
+  return Buffer.from(object, encoding)
 }
 
 export function toProperCase (string) {
@@ -295,7 +297,8 @@ export function inspect (value, options) {
           value?.[kSocketCustomInspect] !== inspect
         )
       ) {
-        const formatted = (value[kNodeCustomInspect] || value[kSocketCustomInspect])(
+        const formatted = (value[kNodeCustomInspect] || value[kSocketCustomInspect]).call(
+          value,
           depth,
           ctx,
           ctx.options,
@@ -740,6 +743,10 @@ const percentageRegex = /^(100(\.0+)?|[1-9]?\d(\.\d+)?)%$/
 
 export function isValidPercentageValue (input) {
   return percentageRegex.test(input)
+}
+
+export function compareBuffers (a, b) {
+  return toBuffer(a).compare(toBuffer(b))
 }
 
 export default exports


### PR DESCRIPTION
- Assigns `libsodium` export to `crypto.sodium` export 
- Falls back to `sodium.randombytes_buf` in `crypto.getRandomValues`
- Exports `CustomEvent` in `socket:events` for usage in platforms that do not support it globally (node)
- Allow `encoding` to be given in `util.toBuffer()` where `Buffer.from()` is used
- Use `value` as `this` value when calling custom inspect (`Symbol.for('socket.util.inspect.custom')`)
- Introduce `compareBuffers()` for comparing `all `TypedArray` types, including `Buffer`
- Support `--link` for `publish-npm-modules.sh` which globally links the built node modules, instead of publishing  them (this makes it easier to develop against: `npm link @socketsupply/socket` just works)