### PR TITLE
Fix debug logs on macOS

### DIFF
--- a/bin/publish-npm-modules.sh
+++ b/bin/publish-npm-modules.sh
@@ -81,7 +81,7 @@ if (( !only_platforms || only_top_level )); then
   cp -rf "$root/npm/bin/ssc.js" "$SOCKET_HOME/packages/$package/bin/ssc.js"
   cp -f "$root/LICENSE.txt" "$SOCKET_HOME/packages/$package"
   cp -f "$root/README.md" "$SOCKET_HOME/packages/$package/README-RUNTIME.md"
-  cp -rf "$root/api"/* "$SOCKET_HOME/packages/$package"
+  cp -rf "$SOCKET_HOME/api"/* "$SOCKET_HOME/packages/$package"
 fi
 
 if (( !only_top_level )); then
@@ -126,7 +126,7 @@ if (( !only_top_level )); then
 
     if (( !dry_run )) ; then
       npm publish "${args[@]}" || exit $?
-    else
+    elif (( !do_global_link )); then
       # echo "# npm publish ${args[@]}"
       npm pack "${args[@]}" || exit $?
     fi
@@ -143,7 +143,7 @@ if (( !only_platforms || only_top_level )); then
 
   if (( !dry_run )); then
     npm publish "${args[@]}" || exit $?
-  else
+  elif (( !do_global_link )); then
     # echo "# npm publish ${args[@]}"
     npm pack "${args[@]}" || exit $?
   fi

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -282,12 +282,15 @@ int runApp (const fs::path& path, const String& args, bool headless) {
       //
       // We can build the predicate query string manually, instead.
       auto queryStream = StringStream {};
-      queryStream << "category == 'socket.runtime.desktop' AND ";
-      queryStream << "processIdentifier == ";
-      queryStream << std::to_string(app.processIdentifier);
-      queryStream << " AND ";
-      queryStream << "subsystem == '";
-      queryStream << bundle.bundleIdentifier.UTF8String << "'";
+      auto pid = std::to_string(app.processIdentifier);
+      auto bid = bundle.bundleIdentifier.UTF8String;
+      queryStream
+        << "("
+        << "  category == 'socket.runtime.desktop' OR "
+        << "  category == 'socket.runtime.debug'"
+        << ") AND "
+        << "processIdentifier == " << pid << " AND "
+        << "subsystem == '" << bid << "'";
       // log store query and predicate for filtering logs based on the currently
       // running application that was just launched and those of a subsystem
       // directly related to the application's bundle identifier which allows us

--- a/src/common.hh
+++ b/src/common.hh
@@ -15,12 +15,26 @@
 #endif
 
 #ifndef debug
-static auto SSC_OS_LOG_DEBUG = os_log_create("debug", "socket.runtime");
 #if !defined(SSC_CLI)
+static os_log_t SSC_OS_LOG_DEBUG_BUNDLE = nullptr;
 // wrap `os_log*` functions for global debugger
 #define osdebug(format, fmt, ...) ({                                           \
+  if (!SSC_OS_LOG_DEBUG_BUNDLE) {                                              \
+    static auto userConfig = SSC::getUserConfig();                             \
+    static auto bundleIdentifier = userConfig["meta_bundle_identifier"];       \
+    SSC_OS_LOG_DEBUG_BUNDLE = os_log_create(                                   \
+      bundleIdentifier.c_str(),                                                \
+      "socket.runtime.debug"                                                   \
+    );                                                                         \
+  }                                                                            \
+                                                                               \
   auto string = [NSString stringWithFormat: @fmt, ##__VA_ARGS__];              \
-  os_log_with_type(SSC_OS_LOG_DEBUG, OS_LOG_TYPE_DEBUG, format, string);       \
+  os_log_with_type(                                                            \
+    SSC_OS_LOG_DEBUG_BUNDLE,                                                   \
+    OS_LOG_TYPE_ERROR,                                                         \
+    "%{public}s",                                                              \
+    string.UTF8String                                                          \
+  );                                                                           \
 })
 #else
 #define osdebug(...)


### PR DESCRIPTION
We were not handling debug output to the `OSLogStore`. This properly handles debug logs for a macos app and queries them in the `ssc` cli