### PR TITLE
Windows socket scheme + Win32 debug build fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
 
     - name: install an example app
       run: |
-        npm install && cd test && npm install && ssc build -r --headless
+        npm install && npm test
       env:
         CI: true
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}

--- a/bin/build-runtime-library.sh
+++ b/bin/build-runtime-library.sh
@@ -23,8 +23,13 @@ elif [[ "$host" == *"MSYS_NT"* ]]; then
   host="Win32"
 fi
 
-
+declare d=""
 if [[ "$host" == "Win32" ]]; then
+  # We have to differentiate release and debug for Win32
+  if [[ ! -z "$DEBUG" ]]; then
+    d="d"
+  fi
+
   if command -v $clang >/dev/null 2>&1; then
     echo > /dev/null
   else
@@ -95,9 +100,6 @@ while (( $# > 0 )); do
   args+=("$arg")
 done
 
-# echo "Platform: $platform, clang: $clang"
-# exit 0
-
 if [[ "$host" = "Darwin" ]]; then
   cflags+=("-ObjC++")
   sources+=("$root/src/window/apple.mm")
@@ -127,7 +129,7 @@ cd "$(dirname "$output_directory")"
 echo "# building runtime static libary ($arch-$platform)"
 for source in "${sources[@]}"; do
   declare src_directory="$root/src"
-  declare object="${source/.cc/.o}"
+  declare object="${source/.cc/$d.o}"
   declare object="${object/$src_directory/$output_directory}"
   objects+=("$object")
 done
@@ -168,7 +170,7 @@ function main () {
 
     {
       declare src_directory="$root/src"
-      declare object="${source/.cc/.o}"
+      declare object="${source/.cc/$d.o}"
       declare object="${object/$src_directory/$output_directory}"
       if (( force )) || ! test -f "$object" || (( $(stat_mtime "$source") > $(stat_mtime "$object") )); then
         mkdir -p "$(dirname "$object")"
@@ -186,7 +188,7 @@ function main () {
     wait "$pid" 2>/dev/null
   done
 
-  declare static_library="$root/build/$arch-$platform/lib/libsocket-runtime.a"
+  declare static_library="$root/build/$arch-$platform/lib$d/libsocket-runtime$d.a"
   mkdir -p "$(dirname "$static_library")"
   declare ar="ar"
 

--- a/bin/cflags.sh
+++ b/bin/cflags.sh
@@ -86,6 +86,8 @@ if (( !TARGET_OS_ANDROID && !TARGET_ANDROID_EMULATOR )); then
   elif [[ "$host" = "Linux" ]]; then
     cflags+=($(pkg-config --cflags --static gtk+-3.0 webkit2gtk-4.1))
   elif [[ "$host" = "Win32" ]]; then
+    # https://learn.microsoft.com/en-us/cpp/c-runtime-library/crt-library-features?view=msvc-170
+    # Because we can't pass /MT[d] directly, we have to manually set the flags
     cflags+=(
       -D_MT
       -D_DLL
@@ -94,6 +96,9 @@ if (( !TARGET_OS_ANDROID && !TARGET_ANDROID_EMULATOR )); then
       -Xlinker /NODEFAULTLIB:libcmt
       -Wno-nonportable-include-path
     )
+    if [[ ! -z "$DEBUG" ]]; then
+      cflags+=("-D_DEBUG")
+    fi
   fi
 fi
 

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -86,11 +86,6 @@ Function Install-Files {
   # install `.\build\lib\*`
   Copy-Item -Path "$WORKING_BUILD_PATH\lib\*" -Destination "$LIB_PATH" -Recurse -Force -Container
 
-  # Remove .pdb file if not debug build.
-  if (($debug -ne $true) -and  (Test-Path -Path "$LIB_PATH\uv_a.pdb" -PathType Leaf)) {
-    Remove-Item -Path "$LIB_PATH\uv_a.pdb"
-  }
-
   # install `.\build\bin\*`
   Copy-Item -Path "$WORKING_BUILD_PATH\bin\*" -Destination "$BIN_PATH"
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -206,7 +206,7 @@ function _build_cli {
     local output="${source/$src/$output_directory}"
     # For some reason cli causes issues when debug and release are in the same folder
     output="${output/.cc/$d.o}"
-    output="${output/\/cli\//\/cli$d\/}"
+    output="${output/cli/cli$d}"
     if (( force )) || ! test -f "$output" || (( $(stat_mtime "$source") > $(stat_mtime "$output") )); then
       sources+=("$source")
       outputs+=("$output")

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -429,6 +429,12 @@ function _prepare {
   if [ ! -d "$BUILD_DIR/uv" ]; then
     git clone --depth=1 https://github.com/socketsupply/libuv.git $BUILD_DIR/uv > /dev/null 2>&1
     rm -rf $BUILD_DIR/uv/.git
+    # Comment out compiler tests, we've covered these sufficiently for now
+    if [[ -z "$ENABLE_LIBUV_C_COMPILER_CHECKS" ]]; then
+      tempmkl=$(mktemp)
+      sed 's/check_c_compiler_flag/# check_c_compiler_flag/' $BUILD_DIR/uv/CMakeLists.txt > $tempmkl
+      mv $tempmkl $BUILD_DIR/uv/CMakeLists.txt
+    fi
 
     die $? "not ok - unable to clone. See trouble shooting guide in the README.md file"
   fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -446,7 +446,7 @@ function _install {
     echo "# copying objects to $SOCKET_HOME/objects/$arch-$platform"
     rm -rf "$SOCKET_HOME/objects/$arch-$platform"
     mkdir -p "$SOCKET_HOME/objects/$arch-$platform"
-    cp -rup "$BUILD_DIR/$arch-$platform/objects"/* "$SOCKET_HOME/objects/$arch-$platform"
+    cp -rfp "$BUILD_DIR/$arch-$platform/objects"/* "$SOCKET_HOME/objects/$arch-$platform"
   fi
 
   if test -d "$BUILD_DIR/lib$d"; then

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -446,35 +446,35 @@ function _install {
     echo "# copying objects to $SOCKET_HOME/objects/$arch-$platform"
     rm -rf "$SOCKET_HOME/objects/$arch-$platform"
     mkdir -p "$SOCKET_HOME/objects/$arch-$platform"
-    cp -r "$BUILD_DIR/$arch-$platform/objects"/* "$SOCKET_HOME/objects/$arch-$platform"
+    cp -rup "$BUILD_DIR/$arch-$platform/objects"/* "$SOCKET_HOME/objects/$arch-$platform"
   fi
 
   if test -d "$BUILD_DIR/lib$d"; then
     echo "# copying libraries to $SOCKET_HOME/lib$d"
     mkdir -p "$SOCKET_HOME/lib$d"
-    cp -fr "$BUILD_DIR"/lib$d/*.a "$SOCKET_HOME/lib$d/"
+    cp -rfp "$BUILD_DIR"/lib$d/*.a "$SOCKET_HOME/lib$d/"
   fi
 
   if test -d "$BUILD_DIR/$arch-$platform"/lib$d; then
     echo "# copying libraries to $SOCKET_HOME/lib$d/$arch-$platform"
     rm -rf "$SOCKET_HOME/lib$d/$arch-$platform"
     mkdir -p "$SOCKET_HOME/lib$d/$arch-$platform"
-    cp -fr "$BUILD_DIR/$arch-$platform"/lib$d/*.a "$SOCKET_HOME/lib$d/$arch-$platform"
+    cp -rfp "$BUILD_DIR/$arch-$platform"/lib$d/*.a "$SOCKET_HOME/lib$d/$arch-$platform"
     if [[ $host=="Win32" ]]; then
-      cp -fr "$BUILD_DIR/$arch-$platform"/lib$d/*.lib "$SOCKET_HOME/lib$d/$arch-$platform"
+      cp -rfp "$BUILD_DIR/$arch-$platform"/lib$d/*.lib "$SOCKET_HOME/lib$d/$arch-$platform"
     fi
   fi
 
   echo "# copying js api to $SOCKET_HOME/api"
   mkdir -p "$SOCKET_HOME/api"
-  cp -fr "$root"/api/* "$SOCKET_HOME/api"
+  cp -rfp "$root"/api/* "$SOCKET_HOME/api"
   rm -f "$SOCKET_HOME/api/importmap.json"
   "$root/bin/generate-api-import-map.sh" > "$SOCKET_HOME/api/importmap.json"
 
   rm -rf "$SOCKET_HOME/include"
   mkdir -p "$SOCKET_HOME/include"
   #cp -rf "$CWD"/include/* $SOCKET_HOME/include
-  cp -rf "$BUILD_DIR"/uv/include/* $SOCKET_HOME/include
+  cp -rfp "$BUILD_DIR"/uv/include/* $SOCKET_HOME/include
 
   if [[ "$(uname -s)" == *"_NT"* ]]; then
     if [ $platform == "desktop" ]; then
@@ -597,9 +597,12 @@ function _compile_libuv {
         cmake .. -DBUILD_TESTING=OFF -DLIBUV_BUILD_SHARED=OFF
         cd $STAGING_DIR
         cmake --build $STAGING_DIR/build/ --config $config
-        mkdir -p $BUILD_DIR/$target-$platform/lib
+        mkdir -p $BUILD_DIR/$target-$platform/lib$d
         echo "cp -up $STAGING_DIR/build/$config/uv_a.lib $BUILD_DIR/$target-$platform/lib$d/uv_a.lib"
         cp -up $STAGING_DIR/build/$config/uv_a.lib $BUILD_DIR/$target-$platform/lib$d/uv_a.lib
+        if [[ ! -z "$DEBUG" ]]; then
+          cp -up $STAGING_DIR/build/$config/uv_a.pdb $BUILD_DIR/$target-$platform/lib$d/uv_a.pdb
+        fi;
       fi
     fi
 

--- a/bin/ldflags.sh
+++ b/bin/ldflags.sh
@@ -13,7 +13,19 @@ declare ios_sdk_path=""
 
 if [[ "$host" = "Linux" ]]; then
   if [ -n "$WSL_DISTRO_NAME" ] || uname -r | grep 'Microsoft'; then
-    HOST="Win32"
+    host="Win32"
+  fi
+fi
+
+if [[ "$host" == *"MINGW64_NT"* ]]; then
+  host="Win32"
+fi
+
+declare d=""
+if [[ "$host" == "Win32" ]]; then
+  # We have to differentiate release and debug for Win32
+  if [[ ! -z "$DEBUG" ]]; then
+    d="d"
   fi
 fi
 
@@ -99,9 +111,18 @@ if [[ "$host" = "Darwin" ]]; then
   ldflags+=("-framework" "OSLog")
 elif [[ "$host" = "Linux" ]]; then
   ldflags+=($(pkg-config --libs gtk+-3.0 webkit2gtk-4.1))
+elif [[ "$host" = "Win32" ]]; then
+  if [[ ! -z "$DEBUG" ]]; then
+    # https://learn.microsoft.com/en-us/cpp/c-runtime-library/crt-library-features?view=msvc-170
+    # TODO(@mribbons): Populate from vcvars64.bat
+    IFS=',' read -r -a libs <<< "$WIN_DEBUG_LIBS"
+    for (( i = 0; i < ${#libs[@]}; ++i )); do
+      ldflags+=("${libs[$i]}")
+    done
+  fi
 fi
 
-ldflags+=("-L$root/build/$arch-$platform/lib")
+ldflags+=("-L$root/build/$arch-$platform/lib$d")
 
 for (( i = 0; i < ${#args[@]}; ++i )); do
   ldflags+=("${args[$i]}")

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1910,8 +1910,11 @@ int main (const int argc, const char* argv[]) {
         " -L\"" + prefix + "lib\""
       ;
 
+
+      // See install.sh for more info on windows debug builds and d suffix
       auto missing_assets = false;
-      if (flagDebugMode) {
+      auto debugBuild = getEnv("DEBUG").size() > 0;
+      if (debugBuild) {
         for (String libString : split(getEnv("WIN_DEBUG_LIBS"), ',')) {
           if (libString.size() > 0) {
             if (libString[0] == '\"' && libString[libString.size()-2] == '\"')
@@ -1929,11 +1932,11 @@ int main (const int argc, const char* argv[]) {
         }
       }
 
-      if (flagDebugMode) {
+      if (debugBuild) {
         flags += " -D_DEBUG";
       }
 
-      auto d = String(flagDebugMode ? "d" : "" );
+      auto d = String(debugBuild ? "d" : "" );
 
       flags += " -I" + prefixFile("include");
       flags += " -L" + prefixFile("lib" + d + "/" + platform.arch + "-desktop");

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1940,7 +1940,13 @@ int main (const int argc, const char* argv[]) {
 
       flags += " -I" + prefixFile("include");
       flags += " -L" + prefixFile("lib" + d + "/" + platform.arch + "-desktop");
-      files += prefixFile("objects/" + platform.arch + "-desktop/desktop/main" + d + ".o");
+      auto main_o = prefixFile("objects/" + platform.arch + "-desktop/desktop/main" + d + ".o");
+      if (!fs::exists(main_o)) {
+        log("Can't find main obj, unable to build: " + main_o);
+        missing_assets = true;        
+      } else {
+        files += main_o;
+      }
       files += prefixFile("src/init.cc");
       auto static_runtime = prefixFile("lib" + d + "/" + platform.arch + "-desktop/libsocket-runtime" + d + ".a");
       if (!fs::exists(static_runtime)) {

--- a/src/ipc/bridge.cc
+++ b/src/ipc/bridge.cc
@@ -9,17 +9,6 @@ extern const SSC::Map SSC::getUserConfig ();
 using namespace SSC;
 using namespace SSC::IPC;
 
-// create a proxy module so imports of the module of concern are imported
-// exactly once at the canonical URL (file:///...) in contrast to module
-// URLs (socket:...)
-
-static constexpr auto moduleTemplate =
-R"S(
-import module from '{{url}}'
-export * from '{{url}}'
-export default module
-)S";
-
 #if defined(__APPLE__)
 static dispatch_queue_attr_t qos = dispatch_queue_attr_make_with_qos_class(
   DISPATCH_QUEUE_CONCURRENT,

--- a/src/ipc/ipc.hh
+++ b/src/ipc/ipc.hh
@@ -8,6 +8,17 @@ namespace SSC::IPC {
   class Bridge;
 }
 
+// create a proxy module so imports of the module of concern are imported
+// exactly once at the canonical URL (file:///...) in contrast to module
+// URLs (socket:...)
+
+static constexpr auto moduleTemplate =
+R"S(
+import module from '{{url}}'
+export * from '{{url}}'
+export default module
+)S";
+
 #if defined(__APPLE__)
 namespace SSC::IPC {
   using Task = id<WKURLSchemeTask>;

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -660,11 +660,12 @@ namespace SSC {
       // UNREACHABLE - cannot continue
     }
 
-    const WCHAR* customSchemes[2] = { L"ipc", L"socket" };    
+    // TODO(@mribbons): Get Socket scheme working
+    // const WCHAR* customSchemes[2] = { L"ipc", L"socket" };
+    const WCHAR* customSchemes[1] = { L"ipc" }; 
     const WCHAR* allowedIPCOrigin[3] = { L"http://*", L"https://*", L"file://*" };
-    for (int s = 0; s < 2; ++s)
+    for (int s = 0; s < 1; ++s)
     {
-      std::wcout << "Registering " << customSchemes[s] << std::endl;
       auto ipcSchemeRegistration = Microsoft::WRL::Make<CoreWebView2CustomSchemeRegistration>(customSchemes[s]);
       oeResult = ipcSchemeRegistration->put_TreatAsSecure(TRUE);
       if (oeResult != S_OK) {
@@ -796,9 +797,6 @@ namespace SSC {
                         bool socket_scheme = false;
                         bool handled = false;
 
-                        std::cout << "handle uri: " << uri_s << std::endl;
-
-                        // Only handle ipc: requests.
                         if (uri_s.compare(0, 4, "ipc:") == 0) {
                           ipc_scheme = true;
                         } else if (uri_s.compare(0, 7, "socket:") == 0) {

--- a/src/window/window.hh
+++ b/src/window/window.hh
@@ -55,6 +55,7 @@ namespace SSC {
       int index = 0;
       int width = 0;
       int height = 0;
+      fs::path modulePath;
 
 #if defined(__APPLE__)
 #if !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR

--- a/test/build.js
+++ b/test/build.js
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 import path from 'node:path'
 import fs from 'node:fs/promises'
-import os from 'node:os'
 
 import esbuild from 'esbuild'
-
-const dirname = path.resolve(path.dirname(import.meta.url.replace('file://', '').replace(/^\/[A-Za-z]:\//, '/')))
 
 const cp = async (a, b) => fs.cp(
   path.resolve(a),
@@ -35,24 +32,9 @@ async function main () {
     keepNames: true,
     platform: 'browser',
     sourcemap: 'inline',
-    external: ['node:*'],
+    external: ['node:*', 'socket:*'],
     outdir: path.resolve(process.argv[2]),
     plugins: []
-  }
-
-  if (os.platform() !== 'win32') {
-    params.external.push('socket:*')
-  } else {
-    params.plugins.push({
-      name: 'socket-runtime-import-path',
-      setup (build) {
-        build.onResolve({ filter: /^socket:.*$/ }, (args) => {
-          const basename = args.path.replace('socket:', '').replace(/.js$/, '') + '.js'
-          const filename = path.resolve(path.dirname(dirname), 'api', basename)
-          return { path: filename, external: true }
-        })
-      }
-    })
   }
 
   await Promise.all([

--- a/test/src/frontend/index.html
+++ b/test/src/frontend/index.html
@@ -5,7 +5,7 @@
     <meta
       http-equiv="Content-Security-Policy"
       content="
-        connect-src data://* http://* https://* ipc://* file://*;
+        connect-src http://localhost:8080 ipc://* file://* socket:*;
         child-src 'none';
         img-src https: data: file:;
       "


### PR DESCRIPTION

Win32 socket: scheme is partially implemented, I had to resolve the below issue first.

install.sh: fix Win32 debug

Problem:
When building libuv and socket-runtime with debug enabled, our apps crash when 
using ifstream (readFile):
Debug Assertion Failed. Expression: (_osfile(fh) & fopen)
This build issue also interferred with debugging in Visual Studio.

This occured because by default the clang incorrectly links to the non 
threaded, production version of C runtime .lib (libcrt)
After taking the nessary steps to manually link to the correct lib 
(Including adding preprocessor definitions for /MT[d]),
ssc and apps would not link, therefore:

Solution:
This commit splits debug and release build artifacts:
d is set if $DEBUG and $host == Win32
*.o files are now named *$d.o
Libs are copied to build/platform/lib$d
libsocket-runtime.a is now named libsocket-runtime$d.a
ssc build --prod defines whether or not the app is being built for debug 
and therefore links to the correct libsocket-runtime$d.a

There should be no changes on other OS's.

More changes are required:
install.ps1 will need to build a WIN_DEBUG_LIBS and inject into ssc.cmd
publish-npm-modules.sh should ship release and debug libs on windows
(Call install.sh with DEBUG enabled and disabled)
