### PR TITLE
Android prebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,7 @@ jobs:
           npm install && npm run test:android
       env:
         CI: true
+        SSC_ANDROID_CI: true
         CXX: g++-12
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
 
@@ -313,6 +314,7 @@ jobs:
           npm install && npm run test:android
       env:
         CI: true
+        SSC_ANDROID_CI: true
         CXX: g++-12
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
 

--- a/bin/build-android-runtime-libraries.sh
+++ b/bin/build-android-runtime-libraries.sh
@@ -1,0 +1,106 @@
+declare root="$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)"
+
+declare args=()
+declare pids=()
+declare force=0
+
+declare CWD=$(pwd)
+declare BUILD_DIR="$CWD/build"
+
+declare arch="$(uname -m)"
+declare host="$(uname -s)"
+declare platform="desktop"
+
+if [ -n "$LOCALAPPDATA" ] && [ -z "$SOCKET_HOME" ]; then
+  SOCKET_HOME="$LOCALAPPDATA/Programs/socketsupply"
+else
+  SOCKET_HOME="${SOCKET_HOME:-"${XDG_DATA_HOME:-"$HOME/.local/share"}/socket"}"
+fi
+
+function quiet () {
+  if [ -n "$VERBOSE" ]; then
+    echo "$@"
+    "$@"
+  else
+    "$@" > /dev/null 2>&1
+  fi
+
+  return $?
+}
+
+function die {
+  local status=$1
+  if (( status != 0 && status != 127 )); then
+    for pid in "${pids[@]}"; do
+      kill TERM $pid >/dev/null 2>&1
+      kill -9 $pid >/dev/null 2>&1
+      wait "$pid" 2>/dev/null
+    done
+    echo "$2 - please report (https://discord.gg/YPV32gKCsH)"
+    exit 1
+  fi
+}
+
+if [[ "$host" = "Linux" ]]; then
+  if [ -n "$WSL_DISTRO_NAME" ] || uname -r | grep 'Microsoft'; then
+    host="Win32"
+  fi
+elif [[ "$host" == *"MINGW64_NT"* ]]; then
+  host="Win32"
+elif [[ "$host" == *"MSYS_NT"* ]]; then
+  # Have not confirmed this works as a build host, no gnu find in author's dev
+  host="Win32"
+fi
+
+if [[ "$host" == "Win32" ]]; then
+  cmd_suffix=".cmd"
+  exe=".exe"
+fi
+
+declare DEPS_ERROR=0
+
+if [[ ! -d $SOCKET_HOME ]]; then
+  echo "SOCKET_HOME not found at $SOCKET_HOME"
+  DEPS_ERROR=1
+fi
+
+if ! quiet command -v "ssc"; then
+  echo "ssc not found."
+  DEPS_ERROR=1
+fi;
+
+if [[ -z $ANDROID_HOME ]]; then
+  echo "ANDROID_HOME not set."
+  DEPS_ERROR=1
+fi
+
+if [[ -z $JAVA_HOME ]]; then
+  echo "JAVA_HOME not set."
+  DEPS_ERROR=1
+fi
+
+if [[ ! "$DEPS_ERROR"=="0" ]]; then
+  echo "Dependencies not satisfied: $DEPS_ERROR"
+  exit 1
+fi
+
+app_dir=$BUILD_DIR/android
+quiet mkdir -p $app_dir
+cd $app_dir
+echo "Building Android App"
+quiet ssc init
+temp=$(mktemp)
+quiet sed '/android/s/.*/&\
+skip_gradle = true/' $app_dir/socket.ini > $temp
+quiet mv $temp $app_dir/socket.ini
+if ! quiet ssc build -o --platform=android; then
+  echo "NDK build failed."
+  exit 1
+fi
+
+for abi in $(ls $app_dir/dist/android/app/src/main/obj/local)
+do
+  echo "copying $abi to $BUILD_DIR/$abi-android"
+  quiet mkdir -p $BUILD_DIR/$abi-android
+  quiet cp -rf $app_dir/dist/android/app/src/main/obj/local/$abi $BUILD_DIR/$abi-android
+done

--- a/bin/build-android-runtime-libraries.sh
+++ b/bin/build-android-runtime-libraries.sh
@@ -172,7 +172,6 @@ if [[ ! -d $obj_dir ]]; then
   # Using quiet with > is bad news
   quiet echo "Applying NDK build options..."
   sed '/\[android\]/s/.*/&\
-build_remove_path = dist\/android\/app\/src\/\
 build_socket_runtime = true\
 skip_gradle = true/' $app_dir/socket.ini > $temp
   mv $temp $app_dir/socket.ini

--- a/bin/build-android-runtime-libraries.sh
+++ b/bin/build-android-runtime-libraries.sh
@@ -126,10 +126,9 @@ if [[ ! -d $app_dir ]]; then
   quiet ssc init
   temp=$(mktemp)
   quiet sed '/\[android\]/s/.*/&\
-  build_remove_path = dist\/android\/app\/src\//' $app_dir/socket.ini > $temp
-  quiet mv $temp $app_dir/socket.ini
-  quiet sed '/\[android\]/s/.*/&\
-  skip_gradle = true/' $app_dir/socket.ini > $temp
+build_remove_path = dist\/android\/app\/src\/\
+build_socket_runtime = true\
+skip_gradle = true/' $app_dir/socket.ini > $temp
   quiet mv $temp $app_dir/socket.ini
   echo "starting ssc from $(pwd)"
   if ! quiet ssc build -o --platform=android > build.log 2>&1; then

--- a/bin/build-android-runtime-libraries.sh
+++ b/bin/build-android-runtime-libraries.sh
@@ -98,7 +98,6 @@ if [[ ! -d $app_dir ]]; then
   quiet mkdir -p $app_dir
   cd $app_dir
   echo "Building Android App"
-  rm socket.ini
   quiet ssc init
   temp=$(mktemp)
   quiet sed '/\[android\]/s/.*/&\

--- a/bin/build-android-runtime-libraries.sh
+++ b/bin/build-android-runtime-libraries.sh
@@ -41,7 +41,7 @@ fi
 
 for sig in ABRT HUP INT PIPE QUIT TERM; do
   trap "echo command $@ failed $sig;
-    [ $sig != EXIT ] && trap - $sig EXIT && kill -s $sig $$
+    trap - $sig EXIT && kill -s $sig $$
   " $sig
 done
 
@@ -50,8 +50,6 @@ function quiet () {
     echo "$@"
     "$@"
   else
-    # echo "$@"
-    # "$@"
     "$@" > /dev/null 2>&1
   fi
 
@@ -145,7 +143,7 @@ fi
 
 for abi in $(ls $app_dir/dist/android/app/src/main/obj/local)
 do
-  echo "copying $abi to $LIB_DIR/$abi-android"
-  quiet mkdir -p $LIB_DIR/$abi-android
-  quiet cp -rf $app_dir/dist/android/app/src/main/obj/local/$abi/* $LIB_DIR/$abi-android
+  [ ! -z $VERBOSE ] && echo "copying $abi to $LIB_DIR/$abi-android"
+  quiet mkdir -p $LIB_DIR/$abi-android/lib
+  quiet cp -rf $app_dir/dist/android/app/src/main/jniLibs/$abi/* $LIB_DIR/$abi-android/lib
 done

--- a/bin/build-android-runtime-libraries.sh
+++ b/bin/build-android-runtime-libraries.sh
@@ -32,6 +32,7 @@ declare root="$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)"
 # Standard Android development environment (IDEs not required):
 # $ANDROID_HOME which points to a folder containing cmdline-tools/latest and platform-tools
 # $JAVA_HOME which points to a folder containing bin\javac ~v19 (NOT the bin folder itself)
+# gradle > 8.0.1 in $PATH
 # ndk tools will be downloaded during build process
 
 ### Why do this?

--- a/bin/build-android-runtime-libraries.sh
+++ b/bin/build-android-runtime-libraries.sh
@@ -60,19 +60,18 @@ elif [[ "$host" == *"MSYS_NT"* ]]; then
   host="Win32"
 fi
 
-if [[ "$host" == "Win32" ]]; then
-  cmd_suffix=".cmd"
-  exe=".exe"
+if [[ "$host" == "Win32" ]] && [[ ! -z "$SOCKET_HOME" ]] ; then
   # ndk build doesn't like wrong slashes, even tough it generates them...
   SOCKET_HOME_X=$SOCKET_HOME
   # Android requires SOCKET_HOME that contains all source files, that won't be the case by the time this script runs 
   SOCKET_HOME=$(cygpath -w $(dirname $(dirname $(which ssc))))
+
+  if [[ ! -d $SOCKET_HOME_X ]]; then
+    echo "SOCKET_HOME not found at $SOCKET_HOME_X"
+    DEPS_ERROR=1
+  fi
 fi
 
-if [[ ! -d $SOCKET_HOME_X ]]; then
-  echo "SOCKET_HOME not found at $SOCKET_HOME_X"
-  DEPS_ERROR=1
-fi
 
 if ! quiet command -v "ssc"; then
   echo "ssc not found."

--- a/bin/build-runtime-library.sh
+++ b/bin/build-runtime-library.sh
@@ -78,7 +78,8 @@ while (( $# > 0 )); do
   fi
 
   if [[ "$arg" = "--force" ]] || [[ "$arg" = "-f" ]]; then
-   force=1; continue
+    pass_force="$arg"
+    force=1; continue
   fi
 
   if [[ "$arg" = "--platform" ]]; then
@@ -101,7 +102,7 @@ while (( $# > 0 )); do
 done
 
 if [[ "$platform" = "android" ]]; then
-  $root/bin/build-android-runtime-libraries.sh
+  $root/bin/build-android-runtime-libraries.sh $pass_force
   exit $?
 fi
 
@@ -210,13 +211,8 @@ function main () {
   fi
 
   local build_static=0
-  local static_library_mtime=$(stat_mtime "$static_library")
   for source in "${objects[@]}"; do
-    if ! test -f $source; then
-      echo "$source not built.."
-      exit 1
-    fi
-    if (( force )) || ! test -f "$static_library" || (( $(stat_mtime "$source") > $static_library_mtime )); then
+    if (( force )) || ! test -f "$static_library" || (( $(stat_mtime "$source") > $(stat_mtime "$static_library") )); then
       build_static=1
       break
     fi

--- a/bin/build-runtime-library.sh
+++ b/bin/build-runtime-library.sh
@@ -211,8 +211,13 @@ function main () {
   fi
 
   local build_static=0
+  local static_library_mtime=$(stat_mtime "$static_library")
   for source in "${objects[@]}"; do
-    if (( force )) || ! test -f "$static_library" || (( $(stat_mtime "$source") > $(stat_mtime "$static_library") )); then
+    if ! test -f $source; then
+      echo "$source not built.."
+      exit 1
+    fi
+    if (( force )) || ! test -f "$static_library" || (( $(stat_mtime "$source") > $static_library_mtime )); then
       build_static=1
       break
     fi

--- a/bin/build-runtime-library.sh
+++ b/bin/build-runtime-library.sh
@@ -100,6 +100,11 @@ while (( $# > 0 )); do
   args+=("$arg")
 done
 
+if [[ "$platform" = "android" ]]; then
+  $root/bin/build-android-runtime-libraries.sh
+  exit $?
+fi
+
 if [[ "$host" = "Darwin" ]]; then
   cflags+=("-ObjC++")
   sources+=("$root/src/window/apple.mm")

--- a/bin/generate-gradle-files.sh
+++ b/bin/generate-gradle-files.sh
@@ -17,7 +17,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.2.1'
+    classpath 'com.android.tools.build:gradle:7.3.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:\$kotlin_version"
   }
 }
@@ -62,6 +62,7 @@ org.gradle.parallel=true
 
 android.useAndroidX=true
 android.enableJetifier=true
+android.experimental.legacyTransform.forceNonIncremental=true
 
 kotlin.code.style=official
 GRADLE

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -25,19 +25,25 @@ $global:useCurl = $true
 $global:WIN_DEBUG_LIBS = ""
 $global:path_advice = @()
 $global:install_errors = @()
+$global:forceArg = ""
 $targetClangVersion = "15.0.0"
 $targetCmakeVersion = "3.24.0"
 
+# Powershell environment variables are maintained across sessions, clear if not explicitly set
+$set_debug=$null
 if ($debug -eq $true) {
   $LIBUV_BUILD_TYPE = "Debug"
   
   $SSC_BUILD_OPTIONS = "-g", "-O0"
-  [Environment]::SetEnvironmentVariable("DEBUG", "1")
+  $set_debug="1"
 }
+[Environment]::SetEnvironmentVariable("DEBUG", $set_debug)
 
+$set_verbose=$null
 if ($verbose -eq $true) {
-  [Environment]::SetEnvironmentVariable("VERBOSE", "1")
+  $set_verbose="1"
 }
+[Environment]::SetEnvironmentVariable("VERBOSE", $set_verbose)
 
 if ($force -eq $true) {
   $global:forceArg = "--force"
@@ -512,8 +518,8 @@ if ($shbuild) {
   $global:path_advice += "`$env:PATH='$BIN_PATH;'+`$env:PATH"
 
   cd $OLD_CWD
-  Write-Output "Calling bin\install.sh $forceArg"
-  iex "& ""$sh"" bin\install.sh $forceArg"
+  Write-Output "Calling bin\install.sh $global:forceArg"
+  iex "& ""$sh"" bin\install.sh $global:forceArg"
 }
 
 if ($global:path_advice.Count -gt 0) {

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -513,6 +513,7 @@ function _install {
     fi
   else 
     echo "no $BUILD_DIR/$arch-$platform/lib"
+    exit 1
   fi
 
   if [ $platform == "desktop" ]; then
@@ -800,8 +801,10 @@ fi
 
 _install_cli
 
-"$root/bin/build-runtime-library.sh" --platform android
-_install arm64-v8a android
-_install armeabi-v7a android
-_install x86 android
-_install x86_64 android
+quiet "$root/bin/build-runtime-library.sh" --platform android
+_install arm64-v8a android & pids+=($!)
+_install armeabi-v7a android & pids+=($!)
+_install x86 android & pids+=($!)
+_install x86_64 android & pids+=($!)
+
+wait

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -539,7 +539,7 @@ function _install_cli {
       local rc=$?
 
       if [[ " $status " =~ " Permission denied " ]]; then
-        echo "warn - Failed to link binrary to '$PREFIX/bin': Trying 'sudo'"
+        echo "warn - Failed to link binary to '$PREFIX/bin': Trying 'sudo'"
         sudo rm -f "$PREFIX/bin/ssc"
         sudo ln -sf "$SOCKET_HOME/bin/ssc" "$PREFIX/bin/ssc"
         die $? "not ok - unable to link binary into '$PREFIX/bin'"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -808,3 +808,5 @@ _install x86 android & pids+=($!)
 _install x86_64 android & pids+=($!)
 
 wait
+
+exit $?

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -797,7 +797,7 @@ _install_cli
 
 if [[ ! -z "$ANDROID_HOME" ]]; then  
   quiet "$root/bin/build-runtime-library.sh" --platform android
-  if [[ ! -z $? ]]; then
+  if [[ ! $? ]]; then
     exit $?
   fi
   _install arm64-v8a android & pids+=($!)

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -795,8 +795,8 @@ fi
 
 _install_cli
 
-if [[ ! -z "$ANDROID_HOME" ]]; then  
-  quiet "$root/bin/build-runtime-library.sh" --platform android
+if [[ ! -z "$ANDROID_HOME" ]]; then
+  "$root/bin/build-runtime-library.sh" --platform android
   if [[ ! $? ]]; then
     exit $?
   fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -499,15 +499,22 @@ function _install {
     cp -rfp "$BUILD_DIR"/lib$d/*.a "$SOCKET_HOME/lib$d/"
   fi
 
-  if test -d "$BUILD_DIR/$arch-$platform"/lib$d; then
-    echo "# copying libraries to $SOCKET_HOME/lib$d/$arch-$platform"
-    rm -rf "$SOCKET_HOME/lib$d/$arch-$platform"
-    mkdir -p "$SOCKET_HOME/lib$d/$arch-$platform"
+  _d=$d
+
+  if [[ $platform == "android" ]]; then
+    # Debug builds not currently supported for android
+    _d=""
+  fi
+
+  if test -d "$BUILD_DIR/$arch-$platform"/lib$_d; then
+    echo "# copying libraries to $SOCKET_HOME/lib$_d/$arch-$platform"
+    rm -rf "$SOCKET_HOME/lib$_d/$arch-$platform"
+    mkdir -p "$SOCKET_HOME/lib$_d/$arch-$platform"
     if [[ $platform != "android" ]]; then
-      cp -rfp "$BUILD_DIR/$arch-$platform"/lib$d/*.a "$SOCKET_HOME/lib$d/$arch-$platform"
+      cp -rfp "$BUILD_DIR/$arch-$platform"/lib$_d/*.a "$SOCKET_HOME/lib$_d/$arch-$platform"
     fi
     if [[ $host=="Win32" ]] && [[ $platform == "desktop" ]]; then
-      cp -rfp "$BUILD_DIR/$arch-$platform"/lib$d/*.lib "$SOCKET_HOME/lib$d/$arch-$platform"
+      cp -rfp "$BUILD_DIR/$arch-$platform"/lib$_d/*.lib "$SOCKET_HOME/lib$_d/$arch-$platform"
     fi
 
     if [[ $platform == "android" ]] && [[ -d "$BUILD_DIR/$arch-$platform"/lib ]]; then

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -169,7 +169,7 @@ function advice {
   elif [[ "$(uname -s)" == *"Linux"* ]]; then
     echo "apt-get install $1"
   elif [[ "$(uname -s)" == *"_NT"* ]]; then
-    echo "choco install $1 ?"
+    echo "Use install.ps1 to install $1."
   fi
 }
 
@@ -526,7 +526,6 @@ function _install {
 
   rm -rf "$SOCKET_HOME/include"
   mkdir -p "$SOCKET_HOME/include"
-  #cp -rf "$CWD"/include/* $SOCKET_HOME/include
   cp -rfp "$BUILD_DIR"/uv/include/* $SOCKET_HOME/include
 
   if [[ "$(uname -s)" == *"_NT"* ]]; then
@@ -801,12 +800,16 @@ fi
 
 _install_cli
 
-quiet "$root/bin/build-runtime-library.sh" --platform android
-_install arm64-v8a android & pids+=($!)
-_install armeabi-v7a android & pids+=($!)
-_install x86 android & pids+=($!)
-_install x86_64 android & pids+=($!)
+[ ! -z "$VERBOSE" ] && echo "CI flags: CI: $CI, SSC_ANDROID_CI: $SSC_ANDROID_CI"
 
-wait
+if [[ ! -n $CI ]] || [[ -n $SSC_ANDROID_CI ]]; then
+  quiet "$root/bin/build-runtime-library.sh" --platform android
+  _install arm64-v8a android & pids+=($!)
+  _install armeabi-v7a android & pids+=($!)
+  _install x86 android & pids+=($!)
+  _install x86_64 android & pids+=($!)
+  wait
+fi
+
 
 exit $?

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -796,17 +796,19 @@ fi
 _install_cli
 
 if [[ ! -z "$ANDROID_HOME" ]]; then
-  "$root/bin/build-runtime-library.sh" --platform android
-  if [[ ! $? ]]; then
-    exit $?
+  if [[ ! -n $CI ]] || [[ -n $SSC_ANDROID_CI ]]; then
+    "$root/bin/build-runtime-library.sh" --platform android
+    if [[ ! $? ]]; then
+      exit $?
+    fi
+    _install arm64-v8a android & pids+=($!)
+    _install armeabi-v7a android & pids+=($!)
+    _install x86 android & pids+=($!)
+    _install x86_64 android & pids+=($!)
+    wait
+  else
+    echo "ANDROID_HOME not set, won't attempt to build android."
   fi
-  _install arm64-v8a android & pids+=($!)
-  _install armeabi-v7a android & pids+=($!)
-  _install x86 android & pids+=($!)
-  _install x86_64 android & pids+=($!)
-  wait
-else
-  echo "ANDROID_HOME not set, won't attempt to build android."
 fi
 
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -291,6 +291,16 @@ function _build_runtime_library {
     "$root/bin/build-runtime-library.sh" --arch x86_64 --platform ios-simulator $pass_force & pids+=($!)
   fi
 
+  if [[ -z "$ANDROID_HOME" ]]; then
+    echo "ANDROID_HOME not set, won't attempt to build android."
+  else
+    if ! command -v ssc; then
+      echo "Deferring Android build until SSC build completed."
+    else
+     "$root/bin/build-runtime-library.sh" --platform android & pids+=($!)
+    fi
+  fi
+
   wait
 }
 
@@ -759,6 +769,8 @@ if [[ "$host" = "Darwin" ]]; then
     _prebuild_ios_main & pids+=($!)
     _prebuild_ios_simulator_main & pids+=($!)
   fi
+
+  # Not building android due to potential platform conflicts
 fi
 
 for pid in "${pids[@]}"; do

--- a/bin/publish-npm-modules.sh
+++ b/bin/publish-npm-modules.sh
@@ -93,6 +93,12 @@ if (( !only_top_level ))  && (( !no_rebuild )) ; then
   "$root/bin/install.sh" || exit $?
 fi
 
+if [[ "$(find $SOCKET_HOME -name libsocket-runtime.so | wc -l)" -lt "4" ]]; then
+  echo "Refusing to publish, < 4 android libs found using: "
+  echo "find $SOCKET_HOME -name libsocket-runtime.so"
+  exit 1
+fi
+
 mkdir -p "$SOCKET_HOME/packages/@socketsupply"
 
 if (( !only_platforms || only_top_level )); then

--- a/bin/publish-npm-modules.sh
+++ b/bin/publish-npm-modules.sh
@@ -8,6 +8,7 @@ declare args=()
 declare dry_run=0
 declare only_platforms=0
 declare only_top_level=0
+declare no_rebuild=0
 declare remove_socket_home=1
 declare do_global_link=0
 
@@ -55,6 +56,11 @@ while (( $# > 0 )); do
     continue
   fi
 
+  if [[ "$arg" = "--no-rebuild" ]]; then
+    no_rebuild=1
+    continue
+  fi
+
   if [[ "$arg" = "--link" ]]; then
     do_global_link=1
     continue
@@ -71,6 +77,17 @@ mkdir -p "$SOCKET_HOME"
 
 export SOCKET_HOME
 export PREFIX
+
+# Confirm that ssc in PATH matches current commit
+if command -v ssc >/dev/null 2>&1; then
+  REPO_VERSION="$(cat "$root/VERSION.txt") ($(git rev-parse --short=8 HEAD))"
+  PATH_VERSION=$(ssc --version)
+
+  if [[ "$REPO_VERSION" != "$PATH_VERSION" ]]; then
+    echo "Repo $REPO_VERSION and $(which ssc) $PATH_VERSION don't match."
+    exit 1
+  fi
+fi
 
 if (( !only_top_level ))  && (( !no_rebuild )) ; then
   "$root/bin/install.sh" || exit $?

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1622,7 +1622,7 @@ int main (const int argc, const char* argv[]) {
       }
 
       if (android_enable_standard_ndk_build) {
-        settings["android_defaultConfig_externalNativeBuild"].assign(
+        settings["default_config_external_native_build"].assign(
           "    externalNativeBuild {\n"
           "      ndkBuild {\n"
           "        arguments \"NDK_APPLICATION_MK:=src/main/jni/Application.mk\"\n"
@@ -1630,7 +1630,7 @@ int main (const int argc, const char* argv[]) {
           "    }"
         );
 
-        settings["android_android_externalNativeBuild"].assign(
+        settings["android_external_native_build"].assign(
           "  externalNativeBuild {\n"
           "    ndkBuild {\n"
           "      path \"src/main/jni/Android.mk\"\n"
@@ -1638,8 +1638,8 @@ int main (const int argc, const char* argv[]) {
           "  }"
         );
       } else {
-        settings["android_defaultConfig_externalNativeBuild"].assign("    // externalNativeBuild called manually for -j parallel support. Disable with [android]...enable_standard_ndk_build = true in socket.ini\n");
-        settings["android_android_externalNativeBuild"].assign("  // externalNativeBuild called manually for -j parallel support. Disable with [android]...enable_standard_ndk_build = true in socket.ini\n");
+        settings["default_config_external_native_build"].assign("    // externalNativeBuild called manually for -j parallel support. Disable with [android]...enable_standard_ndk_build = true in socket.ini\n");
+        settings["android_external_native_build"].assign("  // externalNativeBuild called manually for -j parallel support. Disable with [android]...enable_standard_ndk_build = true in socket.ini\n");
       }
       
       // Android Project

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -816,7 +816,6 @@ int main (const int argc, const char* argv[]) {
 
   signal(SIGINT, signalHandler);
   signal(SIGTERM, signalHandler);
-  // signal(SIGUSR1, signalHandler);
 
   if (is(subcommand, "-v") || is(subcommand, "--version")) {
     std::cout << SSC::VERSION_FULL_STRING << std::endl;

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2473,7 +2473,7 @@ int main (const int argc, const char* argv[]) {
       // just build for CI
       if (getEnv("SSC_CI").size() > 0) {
         StringStream gradlew;
-        gradlew << "./gradlew build";
+        gradlew << localDirPrefix << "gradlew build";
 
         if (std::system(gradlew.str().c_str()) != 0) {
           log("error: failed to invoke `gradlew build` command");
@@ -2485,8 +2485,8 @@ int main (const int argc, const char* argv[]) {
 
       if (!android_skip_gradle) {
         String bundle = flagDebugMode ?
-          "gradlew :app:bundleDebug --warning-mode all" :
-          "gradlew :app:bundle";
+          localDirPrefix + "gradlew :app:bundleDebug --warning-mode all" :
+          localDirPrefix + "gradlew :app:bundle";
 
         if (std::system(bundle.c_str()) != 0) {
           log("error: failed to invoke " + bundle + " command.");

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -144,6 +144,57 @@ String getSocketHome () {
   return socketHome;
 }
 
+String getAndroidHome() {
+  auto androidHome = getEnv("ANDROID_HOME");
+
+  if (androidHome.size() > 0)
+    return androidHome;
+
+  if (androidHome.size() == 0) {
+    androidHome = settings["android_" + platform.os + "_home"];
+  }
+
+  if (androidHome.size() == 0) {
+    androidHome = settings["android_home"];
+  }
+
+  if (androidHome.size() == 0) {
+    if (!platform.win) {
+      auto cmd = String(
+        "dirname $(dirname $(readlink $(which sdkmanager 2>/dev/null) 2>/dev/null) 2>/dev/null) 2>/dev/null"
+      );
+
+      auto r = exec(cmd);
+
+      if (r.exitCode == 0) {
+        androidHome = trim(r.output);
+      }
+    }
+  }
+
+  if (androidHome.size() == 0) {
+    if (platform.mac) {
+      androidHome = getEnv("HOME") + "/Library/Android/sdk";
+    } else if (platform.unix) {
+      androidHome = getEnv("HOME") + "/android";
+    } else if (platform.win) {
+      // TODO
+    }
+  }
+
+  if (androidHome.size() > 0) {
+    #ifdef _WIN32
+    setEnv((String("ANDROID_HOME=") + androidHome).c_str());
+    #else
+    setenv("ANDROID_HOME", androidHome.c_str(), 1);
+    #endif
+
+    log("warning: 'ANDROID_HOME' is set to '" + androidHome + "'");
+  }
+
+  return androidHome;
+}
+
 inline String prefixFile (String s) {
   static String socketHome = getSocketHome();
   return socketHome + s + " ";
@@ -765,7 +816,7 @@ int main (const int argc, const char* argv[]) {
 
   signal(SIGINT, signalHandler);
   signal(SIGTERM, signalHandler);
-  signal(SIGUSR1, signalHandler);
+  // signal(SIGUSR1, signalHandler);
 
   if (is(subcommand, "-v") || is(subcommand, "--version")) {
     std::cout << SSC::VERSION_FULL_STRING << std::endl;
@@ -1173,6 +1224,9 @@ int main (const int argc, const char* argv[]) {
     String devPort("0");
     auto cnt = 0;
 
+    bool debugEnv = getEnv("DEBUG").size() > 0;
+    bool verboseEnv = getEnv("VERBOSE").size() > 0;
+
     String localDirPrefix = !platform.win ? "./" : "";
     String quote = !platform.win ? "'" : "\"";
     String slash = !platform.win ? "/" : "\\";
@@ -1462,7 +1516,34 @@ int main (const int argc, const char* argv[]) {
       pathResources = { src / "main" / "assets" };
 
       // set current path to output directory
+      if (debugEnv || verboseEnv) log("cd " + output.string());
       fs::current_path(output);
+
+      auto androidHome = getAndroidHome();
+      StringStream sdkmanager;
+
+      if (debugEnv || verboseEnv) log("sdkmanager --version 2>&1 >/dev/null");
+      if (std::system("sdkmanager --version 2>&1 >/dev/null") != 0) {
+        if (!platform.win) {
+          sdkmanager << androidHome << "/cmdline-tools/latest/bin/";
+        } else {
+          sdkmanager << androidHome << "\\cmdline-tools\\latest\\bin\\";
+        }
+      }
+
+      // Create default output to advise user in case gradle init fails
+      
+      // TODO(mribbons): Check if we need this in CI - Upload licenses folder from workstation
+      // https://developer.android.com/studio/intro/update#download-with-gradle
+      String licenseAccept =  sdkmanager.str() + "sdkmanager" + (platform.win ? ".bat" : "") + " --licenses";
+
+      // echo nothing so command doesn't block
+      if (std::system(("echo |" + licenseAccept).c_str()) != 0) {
+        // This doesn't return a useful status on windows at least
+        log(("Check licenses and run again: \n" + licenseAccept + "\n").c_str());
+      }
+
+      settings["android_sdk_manager_path"] = sdkmanager.str();
 
       StringStream gradleInitCommand;
       gradleInitCommand
@@ -1475,8 +1556,11 @@ int main (const int argc, const char* argv[]) {
         << "--quiet "
         << "init";
 
+      if (debugEnv || verboseEnv) log(gradleInitCommand.str());
       if (std::system(gradleInitCommand.str().c_str()) != 0) {
         log("error: failed to invoke `gradle init` command");
+        // In case user didn't accept licenses above
+        log(("Check licenses and run again: \n" + licenseAccept + "\n").c_str());
         exit(1);
       }
 
@@ -2028,7 +2112,7 @@ int main (const int argc, const char* argv[]) {
 
       // See install.sh for more info on windows debug builds and d suffix
       auto missing_assets = false;
-      auto debugBuild = getEnv("DEBUG").size() > 0;
+      auto debugBuild = debugEnv;
       if (debugBuild) {
         for (String libString : split(getEnv("WIN_DEBUG_LIBS"), ',')) {
           if (libString.size() > 0) {
@@ -2309,49 +2393,7 @@ int main (const int argc, const char* argv[]) {
 
     if (flagBuildForAndroid) {
       auto app = paths.platformSpecificOutputPath / "app";
-      auto androidHome = getEnv("ANDROID_HOME");
-
-      if (androidHome.size() == 0) {
-        androidHome = settings["android_" + platform.os + "_home"];
-      }
-
-      if (androidHome.size() == 0) {
-        androidHome = settings["android_home"];
-      }
-
-      if (androidHome.size() == 0) {
-        if (!platform.win) {
-          auto cmd = String(
-            "dirname $(dirname $(readlink $(which sdkmanager 2>/dev/null) 2>/dev/null) 2>/dev/null) 2>/dev/null"
-          );
-
-          auto r = exec(cmd);
-
-          if (r.exitCode == 0) {
-            androidHome = trim(r.output);
-          }
-        }
-      }
-
-      if (androidHome.size() == 0) {
-        if (platform.mac) {
-          androidHome = getEnv("HOME") + "/Library/Android/sdk";
-        } else if (platform.unix) {
-          androidHome = getEnv("HOME") + "/android";
-        } else if (platform.win) {
-          // TODO
-        }
-      }
-
-      if (androidHome.size() > 0) {
-        #ifdef _WIN32
-        setEnv((String("ANDROID_HOME=") + androidHome).c_str());
-        #else
-        setenv("ANDROID_HOME", androidHome.c_str(), 1);
-        #endif
-
-        log("warning: 'ANDROID_HOME' is set to '" + androidHome + "'");
-      }
+      auto androidHome = getAndroidHome();
 
       StringStream sdkmanager;
       StringStream packages;
@@ -2359,14 +2401,12 @@ int main (const int argc, const char* argv[]) {
       String ndkVersion = "25.0.8775105";
       String androidPlatform = "android-33";
 
-      if (settings["android_accept_sdk_licenses"].size() > 0) {
-        sdkmanager << "echo " << settings["android_accept_sdk_licenses"] << "|";
-      }
-
       if (platform.unix) {
         gradlew
           << "ANDROID_HOME=" << androidHome << " ";
       }
+
+      sdkmanager << settings["android_sdk_manager_path"];
 
       packages
         << quote << "ndk;" << ndkVersion << quote << " "
@@ -2377,21 +2417,13 @@ int main (const int argc, const char* argv[]) {
         << quote << "system-images;" << androidPlatform << ";google_apis;x86_64" << quote << " "
         << quote << "system-images;" << androidPlatform << ";google_apis;arm64-v8a" << quote << " ";
 
-      if (std::system("sdkmanager --version 2>&1 >/dev/null") != 0) {
-        if (!platform.win) {
-          sdkmanager << androidHome << "/cmdline-tools/latest/bin/";
-        } else {
-          sdkmanager << androidHome << "\\cmdline-tools\\latest\\bin\\";
-        }
-      }
-
       sdkmanager
         << "sdkmanager "
         << packages.str();
 
+      if (debugEnv || verboseEnv) log(sdkmanager.str());
       if (std::system(sdkmanager.str().c_str()) != 0) {
         log("error: failed to initialize Android SDK (sdkmanager)");
-        log("You may need to add accept_sdk_licenses = \"y\" to the [android] section of socket.ini.");
         exit(1);
       }
 
@@ -2404,6 +2436,7 @@ int main (const int argc, const char* argv[]) {
         ndkBuild << "ndk-build" << (platform.win ? ".cmd" : "");
         ndkTest << ndkBuild.str() << " --version >" << (!platform.win ? "/dev/null" : "NUL") << " 2>&1";
 
+        if (debugEnv || verboseEnv) log(ndkTest.str());
         if (std::system(ndkTest.str().c_str()) != 0) {
             ndkBuild.str("");
             ndkBuild << androidHome << slash << "ndk" << slash <<  ndkVersion << slash << "ndk-build" << (platform.win ? ".cmd" : "");
@@ -2413,6 +2446,7 @@ int main (const int argc, const char* argv[]) {
             ndkTest
               << ndkBuild.str() << " --version >" << (!platform.win ? "/dev/null" : "NUL") << " 2>&1";
 
+            if (debugEnv || verboseEnv) log(ndkTest.str());
             if (std::system(ndkTest.str().c_str()) != 0) {
               StringStream ndkError;
               ndkError 
@@ -2445,6 +2479,7 @@ int main (const int argc, const char* argv[]) {
             << " >" << (!platform.win ? "/dev/null" : "NUL") << " 2>&1";
             ;
 
+          if (debugEnv || verboseEnv) log(ndkBuildArgs.str());
           if (std::system(ndkBuildArgs.str().c_str()) != 0)
           {        
             log(ndkBuildArgs.str());
@@ -2458,7 +2493,7 @@ int main (const int argc, const char* argv[]) {
             if (dir_entry.is_directory() && dir_entry.path().stem().string().find("-android") != String::npos) {
               auto dest = jniLibs / replace(dir_entry.path().stem().string(), "-android", "");
               try {
-                if (getEnv("DEBUG") == "1")
+                if (debugEnv)
                   log("copy android lib: "+ dir_entry.path().string() + " => " + dest.string());
                 fs::copy(dir_entry.path(), dest, fs::copy_options::overwrite_existing | fs::copy_options::recursive);
               } catch (fs::filesystem_error &e) {
@@ -2488,6 +2523,7 @@ int main (const int argc, const char* argv[]) {
           localDirPrefix + "gradlew :app:bundleDebug --warning-mode all" :
           localDirPrefix + "gradlew :app:bundle";
 
+        if (debugEnv || verboseEnv) log(bundle);
         if (std::system(bundle.c_str()) != 0) {
           log("error: failed to invoke " + bundle + " command.");
           exit(1);
@@ -2499,6 +2535,7 @@ int main (const int argc, const char* argv[]) {
           << localDirPrefix
           << "gradlew assemble";
 
+        if (debugEnv || verboseEnv) log(gradlew.str());
         if (std::system(gradlew.str().c_str()) != 0) {
           log("error: failed to invoke `gradlew assemble` command");
           exit(1);
@@ -2524,6 +2561,7 @@ int main (const int argc, const char* argv[]) {
           << "--abi google_apis/x86_64 "
           << "--package " << package;
 
+        if (debugEnv || verboseEnv) log(avdmanager.str());
         if (std::system(avdmanager.str().c_str()) != 0) {
           log("error: failed to Android Virtual Device (avdmanager)");
           exit(1);
@@ -2541,6 +2579,7 @@ int main (const int argc, const char* argv[]) {
           adb << androidHome << "\\platform-tools\\";
         }
         
+        if (debugEnv || verboseEnv) log((adb.str() + (" --version > ") + SSC::String((!platform.win) ? "/dev/null" : "NUL") + (" 2>&1")));
         if (!std::system((adb.str() + (" --version > ") + SSC::String((!platform.win) ? "/dev/null" : "NUL") + (" 2>&1")).c_str())) {
           log("Warn: Failed to locate adb at " + adb.str());
         } else {
@@ -2559,11 +2598,13 @@ int main (const int argc, const char* argv[]) {
           adb << (app / "build" / "outputs" / "apk" / "dev" / "release" / "app-dev-release-unsigned.apk").string();
         }
 
+        if (debugEnv || verboseEnv) log(adb.str());
         if (std::system(adb.str().c_str()) != 0) {
           log("error: failed to install APK to Android Emulator (adb)");
           exit(1);
         }
 
+        if (debugEnv || verboseEnv) log(adbShellStart.str());
         adbShellStart << "shell am start -n " << settings["meta_bundle_identifier"] << "/" << settings["meta_bundle_identifier"] << settings["android_main_activity"];
         if (std::system(adbShellStart.str().c_str()) != 0) {
           log("Failed to run app on emulator.");
@@ -2643,6 +2684,7 @@ int main (const int argc, const char* argv[]) {
         << " "
         << (paths.platformSpecificOutputPath).string();
 
+      if (debugEnv || verboseEnv) log(archiveCommand.str());
       auto r = std::system(archiveCommand.str().c_str());
 
       if (r != 0) {

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1394,8 +1394,8 @@ int main (const int argc, const char* argv[]) {
     }
 
     auto removePath = paths.platformSpecificOutputPath;
-      if (settings[targetPlatform + "_build_remove_path"].size() > 0)
-        removePath = targetPath / settings[targetPlatform + "_build_remove_path"];
+      if (targetPlatform == "android")
+        removePath = settings["output"] + "/android/app/src";
 
     if (flagRunUserBuildOnly == false && fs::exists(removePath)) {
       auto p = fs::current_path() / fs::path(removePath);

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1340,8 +1340,12 @@ int main (const int argc, const char* argv[]) {
       }
     }
 
-    if (flagRunUserBuildOnly == false && fs::exists(paths.platformSpecificOutputPath)) {
-      auto p = fs::current_path() / fs::path(paths.platformSpecificOutputPath);
+    auto removePath = paths.platformSpecificOutputPath;
+      if (settings[targetPlatform + "_build_remove_path"].size() > 0)
+        removePath = targetPath / settings[targetPlatform + "_build_remove_path"];
+
+    if (flagRunUserBuildOnly == false && fs::exists(removePath)) {
+      auto p = fs::current_path() / fs::path(removePath);
       try {
         fs::remove_all(p);
         log(String("cleaned: " + p.string()));

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1423,6 +1423,7 @@ int main (const int argc, const char* argv[]) {
     // used in multiple if blocks, need to declare here
     auto android_enable_standard_ndk_build = settings["android_enable_standard_ndk_build"] == "true";
     auto android_skip_gradle = settings["android_skip_gradle"] == "true";
+    auto android_build_socket_runtime = settings["android_build_socket_runtime"] == "true";
 
     if (flagBuildForAndroid) {
       auto bundle_identifier = settings["meta_bundle_identifier"];
@@ -2432,22 +2433,40 @@ int main (const int argc, const char* argv[]) {
         auto app_mk = _main / "jni" / "Application.mk";
         auto jniLibs = _main / "jniLibs";
 
-        ndkBuildArgs 
-          << ndkBuild.str()
-          << " -j"
-          << " NDK_PROJECT_PATH=" << _main
-          << " NDK_APPLICATION_MK=" << app_mk
-          << (flagDebugMode ? " NDK_DEBUG=1" : "")
-          << " APP_PLATFORM=" << androidPlatform
-          << " NDK_LIBS_OUT=" << jniLibs
-          << " >" << (!platform.win ? "/dev/null" : "NUL") << " 2>&1";
-          ;
+        if (android_build_socket_runtime) {
+          ndkBuildArgs 
+            << ndkBuild.str()
+            << " -j"
+            << " NDK_PROJECT_PATH=" << _main
+            << " NDK_APPLICATION_MK=" << app_mk
+            << (flagDebugMode ? " NDK_DEBUG=1" : "")
+            << " APP_PLATFORM=" << androidPlatform
+            << " NDK_LIBS_OUT=" << jniLibs
+            << " >" << (!platform.win ? "/dev/null" : "NUL") << " 2>&1";
+            ;
 
-        if (std::system(ndkBuildArgs.str().c_str()) != 0)
-        {        
-          log(ndkBuildArgs.str());
-          log("ndk build failed.");
-          exit(1);
+          if (std::system(ndkBuildArgs.str().c_str()) != 0)
+          {        
+            log(ndkBuildArgs.str());
+            log("ndk build failed.");
+            exit(1);
+          }
+        } else {
+          // TODO(mribbons) - Copy specific abis
+          fs::create_directories(jniLibs);
+          for (auto const& dir_entry : fs::directory_iterator(prefixFile() + "lib")) {
+            if (dir_entry.is_directory() && dir_entry.path().stem().string().find("-android") != String::npos) {
+              auto dest = jniLibs / replace(dir_entry.path().stem().string(), "-android", "");
+              try {
+                if (getEnv("DEBUG") == "1")
+                  log("copy android lib: "+ dir_entry.path().string() + " => " + dest.string());
+                fs::copy(dir_entry.path(), dest, fs::copy_options::overwrite_existing | fs::copy_options::recursive);
+              } catch (fs::filesystem_error &e) {
+                std::cerr << "Unable to copy android lib: " << fs::exists(dest) << ": " << e.what() << std::endl;
+                throw;
+              }
+            }
+          }
         }
       }
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1622,7 +1622,7 @@ int main (const int argc, const char* argv[]) {
       }
 
       if (android_enable_standard_ndk_build) {
-        settings["default_config_external_native_build"].assign(
+        settings["android_default_config_external_native_build"].assign(
           "    externalNativeBuild {\n"
           "      ndkBuild {\n"
           "        arguments \"NDK_APPLICATION_MK:=src/main/jni/Application.mk\"\n"
@@ -1638,7 +1638,7 @@ int main (const int argc, const char* argv[]) {
           "  }"
         );
       } else {
-        settings["default_config_external_native_build"].assign("    // externalNativeBuild called manually for -j parallel support. Disable with [android]...enable_standard_ndk_build = true in socket.ini\n");
+        settings["android_default_config_external_native_build"].assign("    // externalNativeBuild called manually for -j parallel support. Disable with [android]...enable_standard_ndk_build = true in socket.ini\n");
         settings["android_external_native_build"].assign("  // externalNativeBuild called manually for -j parallel support. Disable with [android]...enable_standard_ndk_build = true in socket.ini\n");
       }
       

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1410,6 +1410,10 @@ int main (const int argc, const char* argv[]) {
       writeFile(paths.pathResourcesRelativeToUserBuild / "Credits.html", credits);
     }
 
+
+    // used in multiple if blocks, need to declare here
+    auto android_enable_standard_ndk_build = settings["android_enable_standard_ndk_build"] == "true";
+
     if (flagBuildForAndroid) {
       auto bundle_identifier = settings["meta_bundle_identifier"];
       auto bundle_path = fs::path(replace(bundle_identifier, "\\.", "/")).make_preferred();
@@ -1615,6 +1619,27 @@ int main (const int argc, const char* argv[]) {
         } else {
           settings["android_allow_cleartext"] = "";
         }
+      }
+
+      if (android_enable_standard_ndk_build) {
+        settings["android_defaultConfig_externalNativeBuild"].assign(
+          "    externalNativeBuild {\n"
+          "      ndkBuild {\n"
+          "        arguments \"NDK_APPLICATION_MK:=src/main/jni/Application.mk\"\n"
+          "      }\n"
+          "    }"
+        );
+
+        settings["android_android_externalNativeBuild"].assign(
+          "  externalNativeBuild {\n"
+          "    ndkBuild {\n"
+          "      path \"src/main/jni/Android.mk\"\n"
+          "    }\n"
+          "  }"
+        );
+      } else {
+        settings["android_defaultConfig_externalNativeBuild"].assign("    // externalNativeBuild called manually for -j parallel support. Disable with [android]...enable_standard_ndk_build = true in socket.ini\n");
+        settings["android_android_externalNativeBuild"].assign("  // externalNativeBuild called manually for -j parallel support. Disable with [android]...enable_standard_ndk_build = true in socket.ini\n");
       }
       
       // Android Project
@@ -2359,60 +2384,62 @@ int main (const int argc, const char* argv[]) {
         exit(1);
       }
 
-      StringStream ndkBuild;
-      StringStream ndkBuildArgs;
-      StringStream ndkTest;
-      
-      ndkBuild << "ndk-build" << (platform.win ? ".cmd" : "");
-      ndkTest << ndkBuild.str() << " --version 2>&1 >" << (!platform.win ? "/dev/null" : "NUL");
+      if (!android_enable_standard_ndk_build)
+      {
+        StringStream ndkBuild;
+        StringStream ndkBuildArgs;
+        StringStream ndkTest;
+        
+        ndkBuild << "ndk-build" << (platform.win ? ".cmd" : "");
+        ndkTest << ndkBuild.str() << " --version 2>&1 >" << (!platform.win ? "/dev/null" : "NUL");
 
-      if (std::system(ndkTest.str().c_str()) != 0) {
-          ndkBuild.str("");
-          ndkBuild << androidHome << slash << "ndk" << slash <<  ndkVersion << slash << "ndk-build" << (platform.win ? ".cmd" : "");
+        if (std::system(ndkTest.str().c_str()) != 0) {
+            ndkBuild.str("");
+            ndkBuild << androidHome << slash << "ndk" << slash <<  ndkVersion << slash << "ndk-build" << (platform.win ? ".cmd" : "");
 
-          
-          ndkTest.str("");
-          ndkTest
-            << ndkBuild.str() << " --version 2>&1 >" << (!platform.win ? "/dev/null" : "NUL");
+            
+            ndkTest.str("");
+            ndkTest
+              << ndkBuild.str() << " --version 2>&1 >" << (!platform.win ? "/dev/null" : "NUL");
 
-          if (std::system(ndkTest.str().c_str()) != 0) {
-            StringStream ndkError;
-            ndkError 
-              << "ndk not in path or ANDROID_HOME at "
-              << ndkBuild.str();
-            log(ndkError.str());
-            exit(1);
-          }
+            if (std::system(ndkTest.str().c_str()) != 0) {
+              StringStream ndkError;
+              ndkError 
+                << "ndk not in path or ANDROID_HOME at "
+                << ndkBuild.str();
+              log(ndkError.str());
+              exit(1);
+            }
+        }
+
+        // TODO(mribbons): Cache binaries, hash based on source contents. Copy if cache matches rather than building.
+        // TODO(mribbons): Expand cache system to other target platforms
+
+        auto output = paths.platformSpecificOutputPath;
+        // auto app = output / "app";
+        auto src = app / "src";
+        auto _main = src / "main";
+        auto app_mk = _main / "jni" / "Application.mk";
+        auto jniLibs = _main / "jniLibs";
+
+        ndkBuildArgs 
+          << ndkBuild.str()
+          << " -j"
+          << " NDK_PROJECT_PATH=" << _main
+          << " NDK_APPLICATION_MK=" << app_mk
+          << (flagDebugMode ? " NDK_DEBUG=1" : "")
+          << " APP_PLATFORM=" << androidPlatform
+          << " NDK_LIBS_OUT=" << jniLibs
+          << "2>&1 >" << (!platform.win ? "/dev/null" : "NUL")
+          ;
+
+        if (std::system(ndkBuildArgs.str().c_str()) != 0)
+        {        
+          log(ndkBuildArgs.str());
+          log("ndk build failed.");
+          exit(1);
+        }
       }
-
-      // TODO(mribbons): Cache binaries, hash based on source contents. Copy if cache matches rather than building.
-      // TODO(mribbons): Expand cache system to other target platforms
-
-      auto output = paths.platformSpecificOutputPath;
-      // auto app = output / "app";
-      auto src = app / "src";
-      auto _main = src / "main";
-      auto app_mk = _main / "jni" / "Application.mk";
-      auto jniLibs = _main / "jniLibs";
-
-      ndkBuildArgs 
-        << ndkBuild.str()
-        << " -j"
-        << " NDK_PROJECT_PATH=" << _main
-        << " NDK_APPLICATION_MK=" << app_mk
-        << (flagDebugMode ? " NDK_DEBUG=1" : "")
-        << " APP_PLATFORM=" << androidPlatform
-        << " NDK_LIBS_OUT=" << jniLibs
-        << "2>&1 >" << (!platform.win ? "/dev/null" : "NUL")
-        ;
-
-      if (std::system(ndkBuildArgs.str().c_str()) != 0)
-      {        
-        log(ndkBuildArgs.str());
-        log("ndk build failed.");
-        exit(1);
-      }
-
 
       // just build for CI
       if (getEnv("SSC_CI").size() > 0) {

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1008,7 +1008,7 @@ android {
       abiFilters {{android_ndk_abi_filters}}
     }
 
-{{default_config_external_native_build}}
+{{android_default_config_external_native_build}}
   }
 
   aaptOptions {

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1008,7 +1008,7 @@ android {
       abiFilters {{android_ndk_abi_filters}}
     }
 
-{{android_defaultConfig_externalNativeBuild}}
+{{default_config_external_native_build}}
   }
 
   aaptOptions {
@@ -1016,7 +1016,7 @@ android {
     noCompress {{android_aapt_no_compress}}
   }
 
-{{android_android_externalNativeBuild}}
+{{android_external_native_build}}
 
   productFlavors {
     dev {

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1060,6 +1060,7 @@ dependencies {
 constexpr auto gGradleSettings = R"GROOVY(
 rootProject.name = "{{build_name}}"
 include ':app'
+startParameter.offline=false
 )GROOVY";
 
 //

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1008,7 +1008,7 @@ android {
       abiFilters {{android_ndk_abi_filters}}
     }
 
-    // externalNativeBuild called manually for -j parallel support
+{{android_defaultConfig_externalNativeBuild}}
   }
 
   aaptOptions {
@@ -1016,7 +1016,7 @@ android {
     noCompress {{android_aapt_no_compress}}
   }
 
-  // externalNativeBuild called manually for -j parallel support
+{{android_android_externalNativeBuild}}
 
   productFlavors {
     dev {

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1008,11 +1008,7 @@ android {
       abiFilters {{android_ndk_abi_filters}}
     }
 
-    externalNativeBuild {
-      ndkBuild {
-        arguments "NDK_APPLICATION_MK:=src/main/jni/Application.mk"
-      }
-    }
+    // externalNativeBuild called manually for -j parallel support
   }
 
   aaptOptions {
@@ -1020,11 +1016,7 @@ android {
     noCompress {{android_aapt_no_compress}}
   }
 
-  externalNativeBuild {
-    ndkBuild {
-      path "src/main/jni/Android.mk"
-    }
-  }
+  // externalNativeBuild called manually for -j parallel support
 
   productFlavors {
     dev {

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1416,8 +1416,6 @@ version = 1.0.0
 
 
 [android]
-build_remove_path = dist/android/app/src/
-
 ; TODO description needed
 main_activity = ""
 

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1415,6 +1415,7 @@ version = 1.0.0
 
 
 [android]
+build_remove_path = dist/android/app/src/
 
 ; TODO description needed
 main_activity = ""

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -967,7 +967,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.2.1'
+    classpath 'com.android.tools.build:gradle:7.3.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
 }
@@ -1073,6 +1073,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 kotlin.code.style=official
+android.experimental.legacyTransform.forceNonIncremental=true
 )GRADLE";
 
 //


### PR DESCRIPTION
Android prebuilds are built by default, as long as `ANDROID_HOME` is set.

See notes in https://github.com/socketsupply/socket/blob/android-prebuild/bin/build-android-runtime-libraries.sh

CI:
`ANDROID_HOME` seems to be set in all desktop variants.
Building Android for these slows things down too much, therefore we only build android if
`SSC_ANDROID_CI` is set.
