### PR TITLE
Fix Android threading

### DIFF
--- a/api/dgram.js
+++ b/api/dgram.js
@@ -115,7 +115,7 @@ function defaultCallback (socket) {
 
 function createDataListener (socket) {
   // subscribe this socket to the firehose
-  window.addEventListener('data', ondata)
+  globalThis.addEventListener('data', ondata)
   return ondata
 
   function ondata ({ detail }) {
@@ -140,14 +140,14 @@ function createDataListener (socket) {
     }
 
     if (data.EOF) {
-      window.removeEventListener('data', ondata)
+      globalThis.removeEventListener('data', ondata)
     }
   }
 }
 
 function destroyDataListener (socket) {
   if (typeof socket?.dataListener === 'function') {
-    window.removeEventListener('data', socket.dataListener)
+    globalThis.removeEventListener('data', socket.dataListener)
     delete socket.dataListener
   }
 }

--- a/api/diagnostics/window.js
+++ b/api/diagnostics/window.js
@@ -177,12 +177,16 @@ export class XMLHttpRequestMetric extends Metric {
 }
 
 export class WorkerMetric extends Metric {
-  static GlobalWorker = globalThis.Worker
+  static GlobalWorker = globalThis.Worker || class Worker {
+    constructor () {
+      console.warn('Worker is not supported in this environment')
+    }
+  }
 
   constructor (options) {
     super()
     this.channel = dc.channel('Worker')
-    this.Worker = class Worker extends globalThis.Worker {
+    this.Worker = class Worker extends WorkerMetric.GlobalWorker {
       constructor (url, options, ...args) {
         super(url, options, ...args)
         dc.channel('Worker').publish({ worker: this, url, options })

--- a/api/diagnostics/window.js
+++ b/api/diagnostics/window.js
@@ -34,7 +34,10 @@ export class RequestAnimationFrameMetric extends Metric {
   }
 
   init () {
-    if (this.originalRequestAnimationFrame === null) {
+    if (
+      this.originalRequestAnimationFrame === null &&
+      typeof globalThis.requestAnimationFrame === 'function'
+    ) {
       this.samples = new Uint8Array(this.sampleSize)
       this.originalRequestAnimationFrame = globalThis.requestAnimationFrame
       globalThis.requestAnimationFrame = this.requestAnimationFrame

--- a/api/events.js
+++ b/api/events.js
@@ -484,6 +484,54 @@ export const CustomEvent = globalThis.CustomEvent || class CustomEvent extends g
   }
 }
 
+export const MessageEvent = globalThis.MessageEvent || class MessageEvent extends globalThis.Event {
+  #detail = null
+  #data = null
+
+  constructor (type, options) {
+    super(type, options)
+    if (options?.detail) {
+      this.#detail = options.detail
+    }
+
+    if (options?.data) {
+      this.#data = options.data
+    }
+  }
+
+  get detail () {
+    return this.#detail
+  }
+
+  get data () {
+    return this.#data
+  }
+}
+
+export const ErrorEvent = globalThis.ErrorEvent || class ErrorEvent extends globalThis.Event {
+  #detail = null
+  #error = null
+
+  constructor (type, options) {
+    super(type, options)
+    if (options?.detail) {
+      this.#detail = options.detail
+    }
+
+    if (options?.error) {
+      this.#error = options.error
+    }
+  }
+
+  get detail () {
+    return this.#detail
+  }
+
+  get error () {
+    return this.#error
+  }
+}
+
 export {
   EventEmitter,
   once

--- a/api/hooks.js
+++ b/api/hooks.js
@@ -1,4 +1,4 @@
-import { CustomEvent } from './events.js'
+import { MessageEvent, ErrorEvent, CustomEvent } from './events.js'
 
 /**
  * An interface for registering callbacks for various hooks in

--- a/api/internal/globals.js
+++ b/api/internal/globals.js
@@ -1,9 +1,9 @@
 /**
- * Globals
+ * Symbolic global registry
  * @ignore
  */
 /* eslint-disable-next-line new-parens */
-const registry = new class GlobalsRegistery {
+const registry = new class GlobalsRegistry {
   get global () {
     return globalThis ?? this
   }

--- a/api/internal/init.js
+++ b/api/internal/init.js
@@ -1,5 +1,6 @@
 /* global CustomEvent, Blob */
 /* eslint-disable import/first */
+// mark when runtime did init
 globalThis.__RUNTIME_INIT_NOW__ = performance.now()
 
 import { IllegalConstructor, InvertedPromise } from '../util.js'
@@ -8,9 +9,19 @@ import globals from './globals.js'
 import hooks from '../hooks.js'
 import ipc from '../ipc.js'
 
-class RuntimeXHRPostQueue extends EventTarget {
-  concurrency = 4 * (globalThis?.navigator?.hardwareConcurrency || 4)
+const GlobalWorker = globalThis?.Worker || class Worker extends EventTarget {}
+const hardwareConcurrency = globalThis?.navigator?.hardwareConcurrency || 4
+
+class ConcurrentQueue extends EventTarget {
+  concurrency = hardwareConcurrency
   pending = []
+
+  constructor (concurrency) {
+    super()
+    if (typeof concurrency === 'number' && concurrency > 0) {
+      this.concurrency = concurrency
+    }
+  }
 
   async wait () {
     if (this.pending.length < this.concurrency) return
@@ -21,10 +32,32 @@ class RuntimeXHRPostQueue extends EventTarget {
     return this.pending[0]
   }
 
-  async dispatch (id, seq, params, headers) {
+  timeout (request, timer) {
+    const onresolve = () => {
+      clearTimeout(timeout)
+      queueMicrotask(() => {
+        const index = this.pending.indexOf(request)
+        if (index > -1) {
+          this.pending.splice(index, 1)
+        }
+      })
+    }
+
+    const timeout = setTimeout(onresolve, timer || 256)
+    return onresolve
+  }
+
+  async push (request, timer) {
     await this.wait()
+    this.pending.push(request)
+    request.then(this.timeout(request, timer))
+  }
+}
+
+class RuntimeXHRPostQueue extends ConcurrentQueue {
+  async dispatch (id, seq, params, headers) {
     const promise = new InvertedPromise()
-    this.pending.push(promise)
+    await this.push(promise, 64)
 
     if (typeof params !== 'object') {
       params = {}
@@ -32,94 +65,132 @@ class RuntimeXHRPostQueue extends EventTarget {
 
     params = { ...params, id }
     const options = { responseType: 'arraybuffer' }
-    const result = await ipc.request('post', params, options)
-    const index = this.pending.indexOf(promise)
-
-    if (index >= 0) {
-      this.pending.splice(index, 1)
-    }
+    const result = await ipc.request('post', { id }, options)
 
     if (result.err) {
-      this.dispatchEvent(new CustomEvent('error', { detail: result.err }))
       promise.resolve()
+      this.dispatchEvent(new CustomEvent('error', { detail: result.err }))
       return
     }
 
-    queueMicrotask(() => {
+    setTimeout(() => {
       const { data } = result
       const detail = { headers, params, data, id }
-      globalThis.dispatchEvent(new CustomEvent('data', { detail }))
       promise.resolve()
+      globalThis.dispatchEvent(new CustomEvent('data', { detail }))
     })
   }
 }
 
-if (typeof globalThis?.Worker === 'function' && globalThis.window) {
-  // async preload modules
-  hooks.onReady(async () => {
-    // precache fs.constants
-    await ipc.request('fs.constants', {}, { cache: true })
-    import('../diagnostics.js')
-    import('../fs/fds.js')
-    import('../fs/constants.js')
-  })
+class RuntimeWorker extends GlobalWorker {
+  #onmessage = null
 
-  globalThis.Worker = class Worker extends globalThis?.Worker {
-    #onmessage = null
+  constructor (url, options, ...args) {
+    const preload = `
+    globalThis.__args = ${JSON.stringify(globalThis.__args)}
+    await import('socket:internal/init')
+    await import('socket:internal/worker')
+    await import('${new URL(url, globalThis.location?.href || '/')}')
+    `
 
-    constructor (url, options, ...args) {
-      const preload = `
-      globalThis.__args = ${JSON.stringify(globalThis.__args)}
-      await import('socket:internal/init')
-      await import('socket:internal/worker')
-      await import('${new URL(url, globalThis.location?.href || '/')}')
-      `
+    const blob = new Blob([preload.trim()], { type: 'application/javascript' })
+    const uri = URL.createObjectURL(blob)
 
-      const blob = new Blob([preload], { type: 'application/javascript' })
-      const uri = URL.createObjectURL(blob)
+    super(uri, { ...options, type: 'module' }, ...args)
 
-      super(uri, { ...options, type: 'module' }, ...args)
-
-      this.addEventListener('message', (event) => {
-        const { data } = event
-        if (data?.__runtime_worker_ipc_request) {
-          const request = data.__runtime_worker_ipc_request
-          if (
-            typeof request?.message === 'string' &&
-            request.message.startsWith('ipc://')
-          ) {
-            queueMicrotask(async () => {
-              try {
-                const message = ipc.Message.from(request.message, request.bytes)
-                const options = { bytes: message.bytes }
-                const result = await ipc.send(message.name, message.rawParams, options)
-                this.postMessage({
-                  __runtime_worker_ipc_result: JSON.parse(JSON.stringify({
-                    message,
-                    result
-                  }))
-                })
-              } catch (err) {
-                console.warn('__runtime_worker_ipc_result:', err.stack || err)
-              }
-            })
-          }
-        } else if (typeof this.onmessage === 'function') {
-          return this.onmessage(event)
+    this.addEventListener('message', (event) => {
+      const { data } = event
+      if (data?.__runtime_worker_ipc_request) {
+        const request = data.__runtime_worker_ipc_request
+        if (
+          typeof request?.message === 'string' &&
+          request.message.startsWith('ipc://')
+        ) {
+          queueMicrotask(async () => {
+            try {
+              const message = ipc.Message.from(request.message, request.bytes)
+              const options = { bytes: message.bytes }
+              const result = await ipc.send(message.name, message.rawParams, options)
+              this.postMessage({
+                __runtime_worker_ipc_result: JSON.parse(JSON.stringify({
+                  message,
+                  result
+                }))
+              })
+            } catch (err) {
+              console.warn('__runtime_worker_ipc_result:', err.stack || err)
+            }
+          })
         }
-      })
-    }
+      } else if (typeof this.onmessage === 'function') {
+        return this.onmessage(event)
+      }
+    })
+  }
 
-    get onmessage () {
-      return this.#onmessage
-    }
+  get onmessage () {
+    return this.#onmessage
+  }
 
-    set onmessage (onmessage) {
-      this.#onmessage = onmessage
-    }
+  set onmessage (onmessage) {
+    this.#onmessage = onmessage
   }
 }
 
+// patch `globalThis.Worker`
+if (globalThis.Worker === GlobalWorker) {
+  globalThis.Worker = RuntimeWorker
+}
+
+// patch `globalThis.XMLHttpRequest`
+if (typeof globalThis.XMLHttpRequest === 'function') {
+  const { open, send } = globalThis.XMLHttpRequest.prototype
+  const isAsync = Symbol('isAsync')
+  const queue = new ConcurrentQueue()
+
+  globalThis.XMLHttpRequest.prototype.open = function (...args) {
+    const [,, async] = args
+    Object.defineProperty(this, isAsync, {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: async !== false
+    })
+
+    return open.call(this, ...args)
+  }
+
+  globalThis.XMLHttpRequest.prototype.send = async function (...args) {
+    if (!this[isAsync]) {
+      return await send.call(this, ...args)
+    }
+
+    await queue.push(new Promise((resolve) => {
+      this.addEventListener('error', resolve)
+      this.addEventListener('readystatechange', () => {
+        if (
+          this.readyState === globalThis.XMLHttpRequest.DONE ||
+          this.readyState === globalThis.XMLHttpRequest.UNSENT
+        ) {
+          resolve()
+        }
+      })
+    }))
+
+    return await send.call(this, ...args)
+  }
+}
+
+// async preload modules
+hooks.onReady(async () => {
+  // precache fs.constants
+  await ipc.request('fs.constants', {}, { cache: true })
+  import('../diagnostics.js')
+  import('../fs/fds.js')
+  import('../fs/constants.js')
+})
+
+// symbolic globals
 globals.register('RuntimeXHRPostQueue', new RuntimeXHRPostQueue())
 // prevent further construction if this class is indirectly referenced
 RuntimeXHRPostQueue.prototype.constructor = IllegalConstructor

--- a/api/internal/worker.js
+++ b/api/internal/worker.js
@@ -1,26 +1,77 @@
 /* global CustomEvent */
+import './init.js'
 import ipc from '../ipc.js'
+import hooks from '../hooks.js'
+import console from '../console.js'
 
-if (typeof globalThis?.addEventListener === 'function') {
-  globalThis.addEventListener('message', onMessage)
+export default undefined // we MUST export _something_
+
+let didImportSource = false
+
+if (typeof globalThis.addEventListener === 'function') {
+  globalThis.addEventListener('message', onWorkerMessage)
 }
 
-export function onMessage (event) {
+hooks.onReady(() => {
+  globalThis.postMessage({ __runtime_worker_request_args: true })
+})
+
+let onmessage = null
+Object.defineProperty(globalThis, 'onmessage', {
+  get: () => onmessage,
+  set: (value) => {
+    onmessage = value
+  }
+})
+
+export function onWorkerMessage (event) {
   const { data } = event
 
-  if (typeof data?.__runtime_worker_ipc_result === 'object') {
-    const resultData = data?.__runtime_worker_ipc_result || {}
-    const message = ipc.Message.from(resultData.message)
-    const { seq } = message
-    const index = globalThis.__args.index
-    const event = new CustomEvent(`resolve-${index}-${seq}`, {
-      detail: resultData.result
-    })
+  if (typeof data?.__runtime_worker_args === 'object') {
+    globalThis.__args = data.__runtime_worker_args
 
-    globalThis.dispatchEvent(event)
+    if (!didImportSource) {
+      didImportSource = true
+      hooks.onReady(async () => {
+        const url = new URL(import.meta.url)
+        const source = url.searchParams.get('source')
+
+        try {
+          await import(source)
+        } catch (err) {
+          console.error(
+            'RuntimeWorker: Failed to import worker:', err.stack || err
+          )
+        }
+      })
+    }
+
+    event.stopImmediatePropagation()
+    return false
+  } else if (typeof data?.__runtime_worker_ipc_result === 'object') {
+    const resultData = data?.__runtime_worker_ipc_result || {}
+    if (resultData.message && resultData.result) {
+      const message = ipc.Message.from(resultData.message)
+      const { seq } = message
+      const index = globalThis.__args.index
+
+      globalThis.dispatchEvent(new CustomEvent(`resolve-${index}-${seq}`, {
+        detail: resultData.result
+      }))
+    }
+
+    event.stopImmediatePropagation()
+    return false
+  } else if (typeof data?.__runtime_worker_event === 'object') {
+    const { type, detail } = data?.__runtime_worker_event || {}
+    if (type) {
+      globalThis.dispatchEvent(new CustomEvent(type, { detail }))
+    }
     event.stopImmediatePropagation()
     return false
   }
-}
 
-export * as default from './worker.js'
+  if (typeof onmessage === 'function') {
+    return onmessage(event)
+  }
+}

--- a/api/internal/worker.js
+++ b/api/internal/worker.js
@@ -40,7 +40,7 @@ export function onWorkerMessage (event) {
           await import(source)
         } catch (err) {
           console.error(
-            'RuntimeWorker: Failed to import worker:', err.stack || err
+            'RuntimeWorker: Failed to import worker:', err
           )
         }
       })

--- a/api/ipc.js
+++ b/api/ipc.js
@@ -977,9 +977,9 @@ export function sendSync (command, params = {}, options = {}) {
   const uri = `ipc://${command}`
 
   params = new URLSearchParams(params)
-  params.set('nonce', Date.now())
   params.set('index', index)
   params.set('seq', 'R' + seq)
+  params.set('nonce', Date.now())
 
   const query = `?${params}`
 
@@ -1166,9 +1166,9 @@ export async function write (command, params, buffer, options) {
   }
 
   params = new URLSearchParams(params)
-  params.set('nonce', Date.now())
   params.set('index', index)
   params.set('seq', 'R' + seq)
+  params.set('nonce', Date.now())
 
   const query = `?${params}`
 
@@ -1271,9 +1271,9 @@ export async function request (command, params, options) {
   }
 
   params = new URLSearchParams(params)
-  params.set('nonce', Date.now())
   params.set('index', index)
   params.set('seq', 'R' + seq)
+  params.set('nonce', Date.now())
 
   const query = `?${params}`
 

--- a/api/worker.js
+++ b/api/worker.js
@@ -1,0 +1,10 @@
+import console from './console.js'
+
+export const Worker = globalThis.Worker || class extends EventTarget {
+  constructor () {
+    super()
+    console.warn('Worker is not supported in this environment')
+  }
+}
+
+export default Worker

--- a/src/android/bridge.cc
+++ b/src/android/bridge.cc
@@ -96,16 +96,16 @@ extern "C" {
     }
 
     auto routed = bridge->route(uri.str(), input, size, [=](auto result) mutable {
+      if (result.seq == "-1") {
+        bridge->router.send(result.seq, result.str(), result.post);
+        return;
+      }
+
       auto attachment = JNIEnvironmentAttachment { jvm, jniVersion };
       auto self = bridge->self;
       auto env = attachment.env;
 
       if (!attachment.hasException()) {
-        if (result.seq == "-1") {
-          bridge->router.send(result.seq, result.str(), result.post);
-          return;
-        }
-
         auto size = result.post.length;
         auto body = result.post.body;
         auto bytes = body ? env->NewByteArray(size) : nullptr;

--- a/src/android/bridge.kt
+++ b/src/android/bridge.kt
@@ -236,14 +236,14 @@ open class Bridge (runtime: Runtime, configuration: IBridgeConfiguration) {
 
     val result = Result(id, seq, source, value ?: "", bytes, headers ?: emptyMap<String, String>())
 
-    runtime.get()?.activity?.get()?.runOnUiThread {
-      this.onResult(result)
-    }
+    this.onResult(result)
   }
 
   open fun onResult (result: Result) {
     this.requests[result.id]?.apply {
-      callback(result)
+      kotlin.concurrent.thread {
+        callback(result)
+      }
     }
 
     if (this.requests.contains(result.id)) {

--- a/src/android/main.kt
+++ b/src/android/main.kt
@@ -6,6 +6,10 @@ object console {
     android.util.Log.i(TAG, string)
   }
 
+  fun info (string: String) {
+    android.util.Log.i(TAG, string)
+  }
+
   fun debug (string: String) {
     android.util.Log.d(TAG, string)
   }


### PR DESCRIPTION
Given enough concurrent load, the UI thread locks up. This PR introduces concurrency control and moves route processing to a thread to prevent request interception from deadlocking or the UI thread from blocking