### PR TITLE
copy prebuilts to 'libs/' for JIT compile into 'jniLibs'

### DIFF
--- a/bin/android-functions.sh
+++ b/bin/android-functions.sh
@@ -46,7 +46,7 @@ function android_arch() {
     x86)
       echo -n "i686"
       ;;
-    x86-64)
+    arm64|x86-64)
       echo -n "x86_64"
       ;;
     *)

--- a/bin/publish-npm-modules.sh
+++ b/bin/publish-npm-modules.sh
@@ -14,7 +14,7 @@ declare remove_socket_home=1
 declare do_global_link=0
 
 function _publish () {
-  if (( !dry_run )) ; then
+  if (( !dry_run && !do_global_link )); then
     npm publish "${args[@]}" || exit $?
   elif (( !do_global_link )); then
     # echo "# npm publish ${args[@]}"

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -245,6 +245,11 @@ constexpr auto gAndroidManifest = R"XML(
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
 >
+  <uses-sdk
+    android:minSdkVersion="26"
+    android:targetSdkVersion="33"
+  />
+
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -1093,14 +1098,14 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 LOCAL_MODULE := libuv
 
-LOCAL_SRC_FILES = ../jniLibs/$(TARGET_ARCH_ABI)/libuv.a
+LOCAL_SRC_FILES = ../libs/$(TARGET_ARCH_ABI)/libuv.a
 include $(PREBUILT_STATIC_LIBRARY)
 
 ## libsocket-runtime.a
 include $(CLEAR_VARS)
 LOCAL_MODULE := libsocket-runtime-static
 
-LOCAL_SRC_FILES = ../jniLibs/$(TARGET_ARCH_ABI)/libsocket-runtime.a
+LOCAL_SRC_FILES = ../libs/$(TARGET_ARCH_ABI)/libsocket-runtime.a
 include $(PREBUILT_STATIC_LIBRARY)
 
 ## libsocket-runtime.so


### PR DESCRIPTION
copying the the prebuilt libraries to `jniLibs` resulted in them being removed subsequently when `ndk-build` was called with `NDK_LIBS_OUT=<...>/jniLibs`. This change copies the prebuilts to a `libs/` directory and refers to them that way in the `Android.mk` file