### PR TITLE
Allow for an inline build copy map

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2410,11 +2410,11 @@ int main (const int argc, const char* argv[]) {
     }
 
     for (const auto& tuple : settings) {
-      if (!tuple.first.starts_with("copy-map_")) {
+      if (!tuple.first.starts_with("build_copy-map_")) {
         continue;
       }
 
-      auto key = replace(tuple.first, "copy-map_", "");
+      auto key = replace(tuple.first, "build_copy-map_", "");
       auto value = tuple.second;
 
       auto src = fs::path { key };

--- a/src/common.hh
+++ b/src/common.hh
@@ -659,28 +659,43 @@ namespace SSC {
         continue;
       }
 
-      if (entry[0] == '[' && entry[entry.length() - 1] == ']') {
-        prefix = entry.substr(1, entry.length() - 2);
+      if (entry.starts_with("[") && entry.ends_with("]")) {
+        if (entry.starts_with("[.") && entry.ends_with("]")) {
+          prefix += entry.substr(2, entry.length() - 3);
+        } else {
+          prefix = entry.substr(1, entry.length() - 2);
+        }
+
+        prefix = replace(prefix, "\\.", "_");
         if (prefix.size() > 0) {
           prefix += "_";
         }
+
         continue;
       }
 
       auto index = entry.find_first_of('=');
 
       if (index >= 0 && index <= entry.size()) {
-        auto key = prefix + entry.substr(0, index);
-        auto value = entry.substr(index + 1);
-
-        value = trim(value);
+        auto key = trim(prefix + entry.substr(0, index));
+        auto value = trim(entry.substr(index + 1));
 
         // trim quotes from quoted strings
         if (value[0] == '"' && value[value.length() - 1] == '"') {
-          value = value.substr(1, value.length() - 2);
+          value = trim(value.substr(1, value.length() - 2));
         }
 
-        settings[trim(key)] = value;
+        auto i = value.find_first_of(';');
+        auto j = value.find_first_of('#');
+
+        if (i > 0) {
+          value = value.substr(0, i);
+        } else if (j > 0) {
+          value = value.substr(0, j);
+        }
+
+        // debug("[ini]: %s = %s", key.c_str(), value.c_str());
+        settings[key] = value;
       }
     }
 


### PR DESCRIPTION
This PR introduces support for inline build copy maps directly in the `socket.ini` file. It also introduces support for explicit (`[section.subsection]`) and implicit subsections (`[.subsection]`).

```ini
[build]
...

[.copy-map]
src = dst
```

OR

```ini
[build]
...

[build.copy-map]
src = dst
``` 