### PR TITLE
fix race condition when loading node:crypto

### DIFF
--- a/api/crypto.js
+++ b/api/crypto.js
@@ -14,9 +14,8 @@ import * as exports from './crypto.js'
 let getRandomValuesFallback = null
 
 if (globalThis?.process?.versions?.node) {
-  import('node:crypto').then((c) => {
-    getRandomValuesFallback = c.getRandomValues
-  })
+  let crypto = await import('node:crypto')
+  getRandomValuesFallback = crypto.getRandomValues
 }
 
 const sodium = {


### PR DESCRIPTION
heya,

I noticed this race when using `api/crypto.js` from node.

```js
import { getRandomValues } from './api/crypto.js'
console.error(getRandomValues(new Uint8Array(8)))
```

```js
Missing implementation for window.crypto.getRandomValues()
null
```

I think it's not triggered in the test suite because it executes on the next tick 🤔 