### PR TITLE
cli.c: Fix  ssc -help shows empty version in win32

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -68,7 +68,7 @@ auto start = system_clock::now();
 
 bool flagDebugMode = true;
 bool flagQuietMode = false;
-Map defaultTemplateAttrs = {{ "ssc_version", SSC::VERSION_FULL_STRING }};
+Map defaultTemplateAttrs;
 
 #if defined(__APPLE__)
 std::atomic<bool> checkLogStore = true;
@@ -844,7 +844,8 @@ void initializeRC (fs::path targetPath) {
   }
 }
 
-int main (const int argc, const char* argv[]) {
+int main (const int argc, const char* argv[]) {  
+  defaultTemplateAttrs = {{ "ssc_version", SSC::VERSION_FULL_STRING }};
   if (argc < 2) {
     printHelp("ssc");
     exit(0);


### PR DESCRIPTION
I'm not sure if this is the best solution, but it gets the issue on the agenda.

ssc --version works on win32.
`SSC::VERSION_FULL_STRING` is definitely being set, not sure why it doesn't work in the heap declaration.

before:
ssc -h
ssc v

after:
ssc -h
ssc v0.1.0 (a96824cc)