### PR TITLE
version-npm-modules: win32/mingw support

### DIFF
--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -91,3 +91,7 @@ function host_os() {
 function host_arch() {
   uname -m | sed 's/aarch64/arm64/g'
 }
+
+function lower() {
+  echo "$1"|tr '[:upper:]' '[:lower:]'
+}

--- a/bin/version-npm-modules.sh
+++ b/bin/version-npm-modules.sh
@@ -2,7 +2,10 @@
 
 declare root="$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)"
 declare archs=()
-declare platform="$(uname | tr '[[:upper:]]' '[[:lower:]]')"
+source "$root/bin/functions.sh"
+
+
+declare platform="$(lower "$(host_os)")"
 
 if [ "$(uname -m)" = "x86_64" ]; then
   archs+=("x64")


### PR DESCRIPTION
Resolves error:
./bin/version-npm-modules.sh: line 23: cd: /c/socket/npm/packages/@socketsupply/socket-mingw64_nt-10.0-x64: No such file or directory

lower() was implemented in android-fte and should be merged soon.