### PR TITLE
Introduce 'ssc env'

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -231,7 +231,7 @@ function _build_cli {
   for (( i = 0; i < ${#sources[@]}; i++ )); do
     mkdir -p "$(dirname "${outputs[$i]}")"
     quiet $CXX "${cflags[@]}"  \
-      -c "${sources[$i]}"        \
+      -c "${sources[$i]}"      \
       -o "${outputs[$i]}"
     die $? "$CXX ${cflags[@]} -c \"${sources[$i]}\" -o \"${outputs[$i]}\""
   done

--- a/bin/publish-npm-modules.sh
+++ b/bin/publish-npm-modules.sh
@@ -181,7 +181,7 @@ if (( !only_top_level )); then
     _publish
 
     if (( do_global_link )); then
-      npm link
+      npm link --no-fund --no-audit --offline
     fi
   done
 fi
@@ -195,9 +195,9 @@ if (( !only_platforms || only_top_level )); then
   if (( do_global_link )); then
     for arch in "${archs[@]}"; do
       declare package="@socketsupply/socket-$platform-${arch/x86_64/x64}"
-      npm link "$package"
+      npm link --no-fund --no-audit --offline "$package"
     done
 
-    npm link
+    npm link --no-fund --no-audit --offline
   fi
 fi

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -15,10 +15,14 @@ subcommands:
   install-app         install app to the device
   print-build-dir     print build path to stdout
   run                 run application
+  env                 print relavent environment variables
 
 general options:
-  -h  help
-  -v  version
+  -h, --help          print help message
+  -v, --version       print program version
+  --prefix            print install path
+  --debug             enable debug mode
+  --verbose           enable verbose output
 )TEXT";
 
 constexpr auto gHelpTextBuild = R"TEXT(
@@ -28,13 +32,13 @@ usage:
   ssc build [options] [<project-dir>]
 
 general options:
-  --platform     target (android, android-emulator, ios, ios-simulator)
-  --port=n       load "index.html" from "http://localhost:n"
-  -o             only run user build step
-  -r             run after building
-  --headless     run headlessly
-  --stdin        read from stdin (emitted in window 0)
-  --test=path    indicate test mode
+  --platform<=platform> target (android, android-emulator, ios, ios-simulator)
+  --port=<port>         load "index.html" from "http://localhost:<port>"
+  -o, --only-build      only run build step,
+  -r, --run             run after building
+  --headless            run headlessly
+  --stdin               read from stdin (emitted in window 0)
+  --test[=path]         indicate test mode, optionally importing a test file
 
 packaging options:
   --prod  disable debugging info, inspector, etc.

--- a/src/common.hh
+++ b/src/common.hh
@@ -195,6 +195,7 @@ namespace SSC {
   using StringStream = std::stringstream;
   using WString = std::wstring;
   using WStringStream = std::wstringstream;
+  using Path = fs::path;
 
   template <typename T> using Queue = std::queue<T>;
   template <typename T> using Vector = std::vector<T>;
@@ -574,6 +575,10 @@ namespace SSC {
     #endif
   }
 
+  inline String getEnv (const String& variableName) {
+    return getEnv(variableName.c_str());
+  }
+
   inline auto setEnv (const String& k, const String& v) {
   #if _WIN32
     return _putenv((k + "=" + v).c_str());
@@ -947,14 +952,12 @@ namespace SSC {
     std::this_thread::sleep_for(std::chrono::milliseconds(n));
   }
 
-  inline Vector<String> parseStringList (const String& string) {
+  inline Vector<String> parseStringList (const String& string, Vector<char> separators) {
     auto list = Vector<String>();
-    for (const auto& part : split(string, ',')) {
-      list.push_back(part);
-    }
-
-    for (const auto& part : split(string, ' ')) {
-      list.push_back(part);
+    for (const auto& separator : separators) {
+      for (const auto& part: split(string, separator)) {
+        list.push_back(part);
+      }
     }
 
     return list;
@@ -962,6 +965,10 @@ namespace SSC {
 
   inline Vector<String> parseStringList (const String& string, const char separator) {
     return split(string, separator);
+  }
+
+  inline Vector<String> parseStringList (const String& string) {
+    return parseStringList(string, { ' ', ',' });
   }
 }
 


### PR DESCRIPTION
I found myself often trying to log various environment variables related to `ssc`. This PR introduces a `ssc env` command that outputs `<key>=<value>` environment variable pairs, suitable for usage in a shell environment:

```sh
$ ssc env
ANDROID_HOME=/Users/werle/Library/Android/sdk
GRADLE_HOME=/Users/werle/.sdkman/candidates/gradle/current
HOME=/Users/werle
JAVA_HOME=/Users/werle/.sdkman/candidates/java/current
LANG=en_US
LC_ALL=en_US.UTF-8
LC_CTYPE=UTF-8
LC_TERMINAL=iTerm2
LC_TERMINAL_VERSION=3.4.18
PREFIX=/Users/werle/repos/socketsupply/socket/build/npm/darwin/packages/@socketsupply/socket-darwin-arm64
PWD=/Users/werle
SHELL=/bin/bash
SOCKET_HOME=/Users/werle/repos/socketsupply/socket/build/npm/darwin/packages/@socketsupply/socket-darwin-arm64/
SOCKET_HOME_API=/Users/werle/repos/socketsupply/socket/build/npm/darwin/packages/@socketsupply/socket
USER=werle
```

This PR also introduces a `--prefix` argument to the `ssc` command that prints the resolved SOCKET_HOME path:

```sh
$ ssc --prefix
/Users/werle/repos/socketsupply/socket/build/npm/darwin/packages/@socketsupply/socket-darwin-arm64/
```