### PR TITLE
Introduce a reusable text context

### DIFF
--- a/api/test/context.js
+++ b/api/test/context.js
@@ -1,9 +1,11 @@
-import { GLOBAL_TEST_RUNNER } from 'socket:test'
-import console from 'socket:console'
-import process from 'socket:process'
-import ipc from 'socket:ipc'
+import { GLOBAL_TEST_RUNNER } from './index.js'
+import console from '../console.js'
+import process from '../process.js'
+import ipc from '../ipc.js'
 
-import 'socket:application'
+import '../application.js'
+
+export default null
 
 if (process.env.SOCKET_DEBUG_IPC) {
   ipc.debug.enabled = true
@@ -12,6 +14,7 @@ if (process.env.SOCKET_DEBUG_IPC) {
 
 if (typeof globalThis?.addEventListener === 'function') {
   globalThis.addEventListener('error', onerror)
+  globalThis.addEventListener('messageerror', onerror)
   globalThis.addEventListener('unhandledrejection', onerror)
 }
 

--- a/api/test/index.js
+++ b/api/test/index.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { format } from '../util.js'
 import deepEqual from './fast-deep-equal.js'
 import process from '../process.js'
 import os from '../os.js'
@@ -271,7 +272,7 @@ export class Test {
     }
 
     report('    stack:    |-')
-    const st = (err.stack || '').split('\n')
+    const st = format(err || '').split('\n').slice(1)
     for (const line of st) {
       report(`      ${line}`)
     }

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -798,7 +798,12 @@ void initializeEnv (Path targetPath) {
 
   auto path = targetPath / filename;
 
-  if (fs::exists(path)) {
+  // just set to `targetPath` if resolved `path` doesn't exist
+  if (!fs::exists(path) && fs::is_regular_file(path)) {
+    path = targetPath;
+  }
+
+  if (fs::exists(path) && fs::is_regular_file(path)) {
     auto env = parseINI(readFile(path));
     for (const auto& tuple : env) {
       auto key = tuple.first;
@@ -827,11 +832,11 @@ void initializeRC (Path targetPath) {
     : targetPath / filename;
 
   // just set to `targetPath` if resolved `path` doesn't exist
-  if (!fs::exists(path)) {
+  if (!fs::exists(path) && fs::is_regular_file(path)) {
     path = targetPath;
   }
 
-  if (fs::exists(path)) {
+  if (fs::exists(path) && fs::is_regular_file(path)) {
     extendMap(rc, parseINI(readFile(path)));
 
     for (const auto& tuple : rc) {

--- a/src/common.hh
+++ b/src/common.hh
@@ -621,6 +621,11 @@ namespace SSC {
 
   #if !TARGET_OS_IPHONE && !TARGET_OS_SIMULATOR
     inline String readFile (fs::path path) {
+      if (fs::is_directory(path)) {
+        stdWrite("WARNING: trying to read a directory as a file: " + path.string(), true);
+        return "";
+      }
+
       std::ifstream stream(path.c_str());
       String content;
       auto buffer = std::istreambuf_iterator<char>(stream);

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -5,7 +5,7 @@ globalThis.console.assert(
   'This could lead to undefined behavior.'
 )
 
-import './test-context.js' // this should be first
+import 'socket:test/context' // this should be first
 
 import './webview.js'
 import './diagnostics.js'


### PR DESCRIPTION
I found myself reusing the `text-context.js` file in other socket modules. This moves it into the standard library making it reusable in other projects/modules.