### PR TITLE
fix(src/cli/template.hh): center text in the html template vertically

### DIFF
--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -122,6 +122,9 @@ constexpr auto gHelloWorld = R"HTML(
 <html>
   <head>
     <style type="text/css">
+      html, body {
+        height: 100%;
+      }
       body {
         display: grid;
         justify-content: center;


### PR DESCRIPTION
it's currently not visible on iPhone, because it's under the notch


