### PR TITLE
FTE should be quiet for regular commands

### DIFF
--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -454,18 +454,30 @@ function determine_cxx () {
         bin_version="$("$clang" --version|head -n1)#$clang"
         echo $bin_version;
       done
-    } | sort -r | cut -d"#" -f 2 | head -n1 > $tmp # sort by version, then cut out bin out to get the highest installed clang version
-    CXX="$(cat "$tmp")"
-    rm -f "$tmp"
+      } | sort -r | cut -d"#" -f 2 | head -n1 > $tmp # sort by version, then cut out bin out to get the highest installed clang version
+      CXX="$(cat "$tmp")"
+      rm -f "$tmp"
 
-    if [[ -z "$CXX" ]]; then
-      echo >&2 "not ok - missing build tools, try \"sudo $package_manager clang-14\""
-      return 1
-    fi
-  elif command -v clang++ >/dev/null 2>&1; then
-    CXX="$(command -v clang++)"
-  elif command -v g++ >/dev/null 2>&1; then
-    CXX="$(command -v g++)"
+      if [[ -z "$CXX" ]]; then
+        echo >&2 "not ok - missing build tools, try \"sudo $package_manager clang-14\""
+        return 1
+      fi
+    elif command -v clang++ >/dev/null 2>&1; then
+      CXX="$(command -v clang++)"
+    elif command -v clang++-16 >/dev/null 2>&1; then
+      CXX="$(command -v clang++-16)"
+    elif command -v clang++-15 >/dev/null 2>&1; then
+      CXX="$(command -v clang++-15)"
+    elif command -v clang++-14 >/dev/null 2>&1; then
+      CXX="$(command -v clang++-14)"
+    elif command -v clang++-13 >/dev/null 2>&1; then
+      CXX="$(command -v clang++-13)"
+    elif command -v clang++-12 >/dev/null 2>&1; then
+      CXX="$(command -v clang++-12)"
+    elif command -v clang++-11 >/dev/null 2>&1; then
+      CXX="$(command -v clang++-11)"
+    elif command -v g++ >/dev/null 2>&1; then
+      CXX="$(command -v g++)"
     fi
 
     if [ "$host" = "Win32" ]; then

--- a/npm/src/index.js
+++ b/npm/src/index.js
@@ -54,11 +54,7 @@ export const firstTimeExperienceSetup = async () => {
   const startInfo = {
     env: { ...process.env },
     cwd: installPath,
-    stdio: [process.stdin, process.stdout, process.stderr]
-  }
-
-  if (isSetupCall) {
-    startInfo.env.VERBOSE = 1
+    stdio: 'ignore'
   }
 
   const spawnArgs = []
@@ -80,7 +76,12 @@ export const firstTimeExperienceSetup = async () => {
   }
 
   if (spawnArgs.length) {
-    console.log('# Checking build dependencies...')
+    if (isSetupCall || platform) {
+      startInfo.env.VERBOSE = 1
+      startInfo.stdio = [process.stdin, process.stdout, process.stderr]
+      console.log('# Checking build dependencies...')
+    }
+
     // @ts-ignore
     const child = spawn(...spawnArgs)
 


### PR DESCRIPTION
Running `ssc --version` had a bunch of unrelated output:

```
# Checking build dependencies
# Determining default Android search paths.
ok - ANDROID_HOME, JAVA_HOME, and GRADLE_HOME search paths configured.
# Determining Android paths.
# Using predetermined javac
ok - Found JAVA_HOME (/opt/homebrew/Cellar/openjdk/19.0.2/libexec/openjdk.jdk/Contents/Home)
ok - Found GRADLE_HOME (/Users/werle/.gradle/wrapper/dists/gradle-7.6-bin/9l9tetv7ltxvx3i8an4pb86ye/gradle-7.6)
ok - Found ANDROID_HOME (/Users/werle/Library/Android/sdk)
ok - Found sdkmanager (cmdline-tools/latest/bin/sdkmanager)
# Ensuring Android dependencies are installed
[=======================================] 100% Computing updates...
```

This PR makes FTE output quiet for most commands that don't need the output