### PR TITLE
generate socket.ini documentation

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1297,6 +1297,103 @@ This is a `FunctionDeclaration` named `hrtime` in `api/os.js`, it's exported but
 This is a `FunctionDeclaration` named `availableMemory` in `api/os.js`, it's exported but undocumented.
 
 
+# [Peer](https://github.com/socketsupply/socket/blob/master/api/peer.js#L14)
+
+External docs: https://socketsupply.co/guides/#p2p-guide
+
+
+ Provides a higher level API over the stream-relay protocol.
+
+ Example usage:
+ ```js
+ import { Peer } from 'socket:peer'
+ ```
+
+
+## [`Peer` (extends `EventEmitter`)](https://github.com/socketsupply/socket/blob/master/api/peer.js#L50)
+
+
+The Peer class is an EventEmitter. It emits events when new network events
+are received (.on), it can also emit new events to the network (.emit).
+
+```js
+import { Peer } from 'socket:peer'
+
+const pair = await Peer.createKeys()
+const clusterId = await Peer.createClusterId()
+
+const peer = new Peer({ ...pair, clusterId })
+
+peer.on('greeting', (value, peer, address, port) => {
+  console.log(value)
+})
+
+window.onload = () => {
+  const value = { english: 'hello, world' }
+  const packet = await peer.emit('greeting', value)
+}
+```
+
+### [`constructor(options)`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L60)
+
+`Peer` class constructor.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| options | Object |  | false | All options for the Peer constructor |
+| options.publicKey | string |  | false | The public key required to sign and read |
+| options.privateKey | string |  | false | The private key required to sign and read |
+| options.clusterId | string |  | false | A unique appliction identity |
+| options.scheme | string |  | false | Specify which encryption scheme to use (ie, 'PTP') |
+| options.peers | Array |  | false | An array of RemotePeer |
+
+
+### [`createKeys()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L84)
+
+A method that will generate a public and private key pair.
+ The ed25519 pair can be stored by an app with a secure API.
+
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| pair | Object<Pair> | A pair of keys |
+
+
+### [`createClusterId()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L98)
+
+Create a clusterId from random bytes
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| id | string | a hex encoded sha256 hash |
+
+
+### [`emit(event, message)`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L109)
+
+Emits a message to the network
+
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| event | string |  | false | The name of the event to emit to the network |
+| message | Buffer |  | false | The data to emit to the network |
+
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Object<Packet> | The packet that will be sent when possible |
+
+
+### [`join()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L132)
+
+Starts the process of connecting to the network.
+
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Peer | Returns an instance of the underlying network peer |
+
+
 # [Path](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L9)
 
 
@@ -1520,103 +1617,6 @@ Converts this `Path` instance to a string.
 | Return Value | Type | Description |
 | :---         | :--- | :---        |
 | Not specified | string |  |
-
-
-# [Peer](https://github.com/socketsupply/socket/blob/master/api/peer.js#L14)
-
-External docs: https://socketsupply.co/guides/#p2p-guide
-
-
- Provides a higher level API over the stream-relay protocol.
-
- Example usage:
- ```js
- import { Peer } from 'socket:peer'
- ```
-
-
-## [`Peer` (extends `EventEmitter`)](https://github.com/socketsupply/socket/blob/master/api/peer.js#L50)
-
-
-The Peer class is an EventEmitter. It emits events when new network events
-are received (.on), it can also emit new events to the network (.emit).
-
-```js
-import { Peer } from 'socket:peer'
-
-const pair = await Peer.createKeys()
-const clusterId = await Peer.createClusterId()
-
-const peer = new Peer({ ...pair, clusterId })
-
-peer.on('greeting', (value, peer, address, port) => {
-  console.log(value)
-})
-
-window.onload = () => {
-  const value = { english: 'hello, world' }
-  const packet = await peer.emit('greeting', value)
-}
-```
-
-### [`constructor(options)`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L60)
-
-`Peer` class constructor.
-
-| Argument | Type | Default | Optional | Description |
-| :---     | :--- | :---:   | :---:    | :---        |
-| options | Object |  | false | All options for the Peer constructor |
-| options.publicKey | string |  | false | The public key required to sign and read |
-| options.privateKey | string |  | false | The private key required to sign and read |
-| options.clusterId | string |  | false | A unique appliction identity |
-| options.scheme | string |  | false | Specify which encryption scheme to use (ie, 'PTP') |
-| options.peers | Array |  | false | An array of RemotePeer |
-
-
-### [`createKeys()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L84)
-
-A method that will generate a public and private key pair.
- The ed25519 pair can be stored by an app with a secure API.
-
-
-| Return Value | Type | Description |
-| :---         | :--- | :---        |
-| pair | Object<Pair> | A pair of keys |
-
-
-### [`createClusterId()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L98)
-
-Create a clusterId from random bytes
-
-| Return Value | Type | Description |
-| :---         | :--- | :---        |
-| id | string | a hex encoded sha256 hash |
-
-
-### [`emit(event, message)`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L109)
-
-Emits a message to the network
-
-
-| Argument | Type | Default | Optional | Description |
-| :---     | :--- | :---:   | :---:    | :---        |
-| event | string |  | false | The name of the event to emit to the network |
-| message | Buffer |  | false | The data to emit to the network |
-
-
-| Return Value | Type | Description |
-| :---         | :--- | :---        |
-| Not specified | Object<Packet> | The packet that will be sent when possible |
-
-
-### [`join()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L132)
-
-Starts the process of connecting to the network.
-
-
-| Return Value | Type | Description |
-| :---         | :--- | :---        |
-| Not specified | Peer | Returns an instance of the underlying network peer |
 
 
 # [Process](https://github.com/socketsupply/socket/blob/master/api/process.js#L9)

--- a/api/config.md
+++ b/api/config.md
@@ -1,0 +1,90 @@
+# Configuration
+
+## Section `build`
+
+Key | Default Value | Description
+:--- | :--- | :---
+copy | "src" |  ssc will copy everything in this directory to the build output directory. This is useful when you want to avoid bundling or want to use tools like vite, webpack, rollup, etc. to build your project and then copy output to the Socket bundle resources directory.
+env |  |  An list of environment variables, separated by commas.
+flags |  |  Advanced Compiler Settings (ie C++ compiler -02, -03, etc).
+headless |  |  If false, the window will never be displayed.
+name |  |  The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
+output |  |  The binary output path. It's recommended to add this path to .gitignore.
+
+## Section `debug`
+
+Key | Default Value | Description
+:--- | :--- | :---
+flags |  |  Advanced Compiler Settings for debug purposes (ie C++ compiler -g, etc).
+
+## Section `meta`
+
+Key | Default Value | Description
+:--- | :--- | :---
+bundle_identifier |  |  A unique ID that identifies the bundle (used by all app stores).
+copyright |  |  A string that gets used in the about dialog and package meta info.
+description |  |  A short description of the app.
+file_limit |  |  Set the limit of files that can be opened by your process.
+lang |  |  Localization
+maintainer |  |  A String used in the about dialog and meta info.
+title |  |  The title of the app used in metadata files. This is NOT a window title. Can contain spaces and special characters. Defaults to name in a [build] section.
+version |  |  A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
+
+## Section `android`
+
+Key | Default Value | Description
+:--- | :--- | :---
+main_activity |  |  TODO description needed
+
+## Section `ios`
+
+Key | Default Value | Description
+:--- | :--- | :---
+codesign_identity |  |  signing guide: https://sockets.sh/guides/#ios-1
+distribution_method |  |  Describes how Xcode should export the archive. Available options: app-store, package, ad-hoc, enterprise, development, and developer-id.
+provisioning_profile |  |  A path to the provisioning profile used for signing iOS app.
+simulator_device |  |  which device to target when building for the simulator
+
+## Section `linux`
+
+Key | Default Value | Description
+:--- | :--- | :---
+categories |  |  Helps to make your app searchable in Linux desktop environments.
+cmd |  |  The command to execute to spawn the "back-end" process.
+icon |  |  The icon to use for identifying your app in Linux desktop environments.
+
+## Section `mac`
+
+Key | Default Value | Description
+:--- | :--- | :---
+appstore_icon |  |  Mac App Store icon
+category |  |  A category in the App Store
+cmd |  |  The command to execute to spawn the "back-end" process.
+icon |  |  The icon to use for identifying your app on MacOS.
+sign |  |  TODO description & value (signing guide: https://sockets.sh/guides/#macos-1)
+codesign_identity |  |  TODO description & value
+sign_paths |  |  TODO description & value
+
+## Section `native`
+
+Key | Default Value | Description
+:--- | :--- | :---
+files |  |  Files that should be added to the compile step.
+headers |  |  Extra Headers
+
+## Section `win`
+
+Key | Default Value | Description
+:--- | :--- | :---
+cmd |  |  The command to execute to spawn the “back-end” process.
+icon |  |  The icon to use for identifying your app on Windows.
+logo |  |  The icon to use for identifying your app on Windows.
+pfx |  |  A relative path to the pfx file used for signing.
+
+## Section `window`
+
+Key | Default Value | Description
+:--- | :--- | :---
+height |  |  The initial height of the first window.
+width |  |  The initial width of the first window.
+

--- a/api/config.md
+++ b/api/config.md
@@ -34,7 +34,10 @@ version |  |  A string that indicates the version of the application. It should 
 
 Key | Default Value | Description
 :--- | :--- | :---
-main_activity |  |  TODO description needed
+allow_cleartext |  |  Allow unencrypted http requests, useful for live reload.
+enable_standard_ndk_build |  |  Enables gradle based ndk build rather than using external native build (standard ndk is the old slow way)
+main_activity |  |  Name of the MainActivity class. Could be overwritten by custom native code.
+manifest_permissions |  |  Which permissions does your application need: https://developer.android.com/guide/topics/permissions/overview
 
 ## Section `ios`
 

--- a/api/config.md
+++ b/api/config.md
@@ -34,10 +34,12 @@ version |  |  A string that indicates the version of the application. It should 
 
 Key | Default Value | Description
 :--- | :--- | :---
+aapt_no_compress |  |  Extensions of files that will not be stored compressed in the APK.
 allow_cleartext |  |  Allow unencrypted http requests, useful for live reload.
 enable_standard_ndk_build |  |  Enables gradle based ndk build rather than using external native build (standard ndk is the old slow way)
 main_activity |  |  Name of the MainActivity class. Could be overwritten by custom native code.
 manifest_permissions |  |  Which permissions does your application need: https://developer.android.com/guide/topics/permissions/overview
+native_abis |  |  To restrict the set of ABIs that your application supports, set them here.
 native_cflags |  |  Used for adding custom source files and related compiler attributes.
 native_sources |  | 
 native_makefile |  | 

--- a/api/config.md
+++ b/api/config.md
@@ -68,9 +68,9 @@ appstore_icon |  |  Mac App Store icon
 category |  |  A category in the App Store
 cmd |  |  The command to execute to spawn the "back-end" process.
 icon |  |  The icon to use for identifying your app on MacOS.
-sign |  |  TODO description & value (signing guide: https://sockets.sh/guides/#macos-1)
-codesign_identity |  |  TODO description & value
-sign_paths |  |  TODO description & value
+sign |  |  TODO Signing guide: https://socketsupply.co/guides/#code-signing-certificates
+codesign_identity |  | 
+sign_paths |  | 
 
 ## Section `native`
 

--- a/api/config.md
+++ b/api/config.md
@@ -38,6 +38,10 @@ allow_cleartext |  |  Allow unencrypted http requests, useful for live reload.
 enable_standard_ndk_build |  |  Enables gradle based ndk build rather than using external native build (standard ndk is the old slow way)
 main_activity |  |  Name of the MainActivity class. Could be overwritten by custom native code.
 manifest_permissions |  |  Which permissions does your application need: https://developer.android.com/guide/topics/permissions/overview
+native_cflags |  |  Used for adding custom source files and related compiler attributes.
+native_sources |  | 
+native_makefile |  | 
+sources |  | 
 
 ## Section `ios`
 
@@ -90,4 +94,21 @@ Key | Default Value | Description
 :--- | :--- | :---
 height |  |  The initial height of the first window.
 width |  |  The initial width of the first window.
+
+## Section `headless`
+
+Key | Default Value | Description
+:--- | :--- | :---
+runner |  |  The headless runner command. It is used when no OS specific runner is set.
+runner_flags |  |  The headless runner command flags. It is used when no OS specific runner is set.
+runner_android |  |  The headless runner command for Android
+runner_android_flags |  |  The headless runner command flags for Android
+runner_ios |  |  The headless runner command for iOS
+runner_ios_flags |  |  The headless runner command flags for iOS
+runner_linux |  |  The headless runner command for Linux
+runner_linux_flags |  |  The headless runner command flags for Linux
+runner_mac |  |  The headless runner command for MacOS
+runner_mac_flags |  |  The headless runner command flags for MacOS
+runner_win32 |  |  The headless runner command for Windows
+runner_win32_flags |  |  The headless runner command flags for Windows
 

--- a/bin/generate-docs.js
+++ b/bin/generate-docs.js
@@ -339,7 +339,7 @@ const parseIni = (iniText) => {
           key: keyValue[0].trim(),
           value: keyValue[1].trim(),
           defaultValue,
-          description: lastComment,
+          description: lastComment
         })
         lastComment = ''
         defaultValue = ''

--- a/bin/generate-docs.js
+++ b/bin/generate-docs.js
@@ -286,10 +286,9 @@ export function transform (filename, dest, md) {
   'fs/promises.js',
   'ipc.js',
   'os.js',
-  'path/path.js',
   'peer.js',
+  'path/path.js',
   'process.js',
-  // 'test/index.js', // add docs for this module
   'window.js'
 ].forEach(file => transform(file, JS_INTERFACE_DIR, 'README.md'))
 

--- a/bin/generate-docs.js
+++ b/bin/generate-docs.js
@@ -299,7 +299,6 @@ const startMarker = 'constexpr auto gDefaultConfig = R"INI('
 const endMarker = ')INI";'
 
 const src = path.relative(process.cwd(), 'src/cli/templates.hh')
-console.log(src)
 const data = fs.readFileSync(src, 'utf8')
 
 const startIndex = data.indexOf(startMarker)

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1902,6 +1902,9 @@ int main (const int argc, const char* argv[]) {
         // Windows doesn't support 'yes'
         log(("Check licenses and run again: \n" + licenseAccept + "\n").c_str());
       }
+
+      // TODO: internal, no need to save to settings
+      settings["android_sdk_manager_path"] = sdkmanager.str();
       
       String gradlePath = getEnv("GRADLE_HOME").size() > 0 ? getEnv("GRADLE_HOME") + slash + "bin" + slash : "";
 
@@ -2925,6 +2928,7 @@ int main (const int argc, const char* argv[]) {
       auto app = paths.platformSpecificOutputPath / "app";
       auto androidHome = getAndroidHome();
 
+      StringStream sdkmanager;
       StringStream packages;
       StringStream gradlew;
       String ndkVersion = "25.0.8775105";
@@ -2934,6 +2938,8 @@ int main (const int argc, const char* argv[]) {
         gradlew
           << "ANDROID_HOME=" << androidHome << " ";
       }
+
+      sdkmanager << settings["android_sdk_manager_path"];
 
       packages
         << " "

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1370,6 +1370,7 @@ constexpr auto gDefaultConfig = R"INI(
 ; This is useful when you want to avoid bundling or want to use tools like
 ; vite, webpack, rollup, etc. to build your project and then copy output to
 ; the Socket bundle resources directory.
+; default value: "src"
 copy = "src"
 
 ; An list of environment variables, separated by commas.

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1424,11 +1424,18 @@ version = 1.0.0
 
 
 [android]
-; TODO description needed
+
+; Allow unencrypted http requests, useful for live reload.
+allow_cleartext = false
+
+; Enables gradle based ndk build rather than using external native build (standard ndk is the old slow way)
+enable_standard_ndk_build = false
+
+; Name of the MainActivity class. Could be overwritten by custom native code.
 main_activity = ""
 
-; TODO description needed
-; home = ""
+; Which permissions does your application need: https://developer.android.com/guide/topics/permissions/overview
+manifest_permissions = ""
 
 
 [ios]

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1483,13 +1483,11 @@ cmd = ""
 ; The icon to use for identifying your app on MacOS.
 icon = ""
 
-; TODO description & value (signing guide: https://sockets.sh/guides/#macos-1)
+; TODO Signing guide: https://socketsupply.co/guides/#code-signing-certificates
 sign = ""
 
-; TODO description & value
 codesign_identity = ""
 
-; TODO description & value
 sign_paths = ""
 
 

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -335,7 +335,7 @@ Comment={{meta_description}}
 Categories={{linux_categories}};
 )INI";
 
-constexpr auto gDebianManifest = R"DEB(Package: {{deb_name}}
+constexpr auto gDebianManifest = R"DEB(Package: {{build_name}}
 Version: {{meta_version}}
 Architecture: amd64
 Maintainer: {{meta_maintainer}}
@@ -389,7 +389,7 @@ constexpr auto gWindowsAppManifest = R"XML(<?xml version="1.0" encoding="utf-8"?
     <Application
       Id="{{build_name}}"
       EntryPoint="Windows.FullTrustApplication"
-      Executable="{{exe}}"
+      Executable="{{win_exe}}"
     >
       <uap:VisualElements DisplayName="{{meta_title}}"
         Square150x150Logo="{{win_logo}}"
@@ -403,10 +403,10 @@ constexpr auto gWindowsAppManifest = R"XML(<?xml version="1.0" encoding="utf-8"?
         <uap3:Extension
           Category="windows.appExecutionAlias"
           EntryPoint="Windows.FullTrustApplication"
-          Executable="{{exe}}"
+          Executable="{{win_exe}}"
         >
           <uap3:AppExecutionAlias>
-            <desktop:ExecutionAlias Alias="{{exe}}" />
+            <desktop:ExecutionAlias Alias="{{win_exe}}" />
           </uap3:AppExecutionAlias>
         </uap3:Extension>
       </Extensions>
@@ -415,7 +415,7 @@ constexpr auto gWindowsAppManifest = R"XML(<?xml version="1.0" encoding="utf-8"?
   </Applications>
   <Extensions>
     <desktop2:Extension Category="windows.firewallRules">
-      <desktop2:FirewallRules Executable="{{exe}}">
+      <desktop2:FirewallRules Executable="{{win_exe}}">
         <desktop2:Rule
           Direction="in"
           IPProtocol="TCP"
@@ -1426,6 +1426,9 @@ version = 1.0.0
 [android]
 ; TODO description needed
 main_activity = ""
+
+; TODO description needed
+; home = ""
 
 
 [ios]

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1437,6 +1437,11 @@ main_activity = ""
 ; Which permissions does your application need: https://developer.android.com/guide/topics/permissions/overview
 manifest_permissions = ""
 
+; Used for adding custom source files and related compiler attributes.
+native_cflags = ""
+native_sources = ""
+native_makefile = ""
+sources = ""
 
 [ios]
 
@@ -1521,6 +1526,34 @@ height = 50%
 
 ; The initial width of the first window.
 width = 50%
+
+[headless]
+
+; The headless runner command. It is used when no OS specific runner is set.
+runner = ""
+; The headless runner command flags. It is used when no OS specific runner is set.
+runner_flags = ""
+; The headless runner command for Android
+runner_android = ""
+; The headless runner command flags for Android
+runner_android_flags = ""
+; The headless runner command for iOS
+runner_ios = ""
+; The headless runner command flags for iOS
+runner_ios_flags = ""
+; The headless runner command for Linux
+runner_linux = ""
+; The headless runner command flags for Linux
+runner_linux_flags = ""
+; The headless runner command for MacOS
+runner_mac = ""
+; The headless runner command flags for MacOS
+runner_mac_flags = ""
+; The headless runner command for Windows
+runner_win32 = ""
+; The headless runner command flags for Windows
+runner_win32_flags = ""
+
 )INI";
 
 constexpr auto gDefaultGitignore = R"GITIGNORE(

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1425,6 +1425,9 @@ version = 1.0.0
 
 [android]
 
+; Extensions of files that will not be stored compressed in the APK.
+aapt_no_compress = ""
+
 ; Allow unencrypted http requests, useful for live reload.
 allow_cleartext = false
 
@@ -1436,6 +1439,9 @@ main_activity = ""
 
 ; Which permissions does your application need: https://developer.android.com/guide/topics/permissions/overview
 manifest_permissions = ""
+
+; To restrict the set of ABIs that your application supports, set them here.
+native_abis = ""
 
 ; Used for adding custom source files and related compiler attributes.
 native_cflags = ""


### PR DESCRIPTION
Undocumented stuff from config:
- [x] `"android_" + platform.os + "_home"`
- [x] `android_home`
- [x] `android_enable_standard_ndk_build`
- [x] `android_skip_gradle`
- [x] `android_build_socket_runtime`
- [x] `android_main_activity`
- [x] `android_sdk_manager_path`
- [x] `android_aapt_no_compress`
- [x] `android_aapt` (undocumented)
- [x] `android_native_abis`
- [x] `android_ndk_abi_filters` (undocumented)
- [x] `android_manifest_permissions`
- [x] `android_allow_cleartext`
- [x] `android_default_config_external_native_build`
- [x] `android_external_native_build`
- [x] `android_native_cflags`
- [x] `android_native_sources`
- [x] `android_native_makefile`
- [x] `android_sources`
- [x] `android_sdk_manager_path`
- [x] `ios_provisioning_specifier`
- [x] `ios_provisioning_profile`
- [x] `ios_codesign_identity`
- [x] `apple_team_id`
- [x] `apple_instruments`
- [x] `headless_runner`
- [x] `headless_runner_flags`
- [x] `"headless_" + platform.os + "_runner"`
- [x] `"headless_" + platform.os + "_runner_flags"`
- [x] `build_suffix`
- [x] `linux_executable_path`
- [x] `deb_name`
- [x] `win_version`
- [x] `exe`
- [x] `mac_sign`
- [x] `mac_sign_paths`