### PR TITLE
install.sh: use .hh mtimes to invalidate .o

### DIFF
--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -22,6 +22,18 @@ function stat_mtime () {
   stat $stat_format_arg $stat_mtime_spec "$1" 2>/dev/null
 }
 
+function latest_mtime() {
+  local latest=0
+
+  while (( $# > 0 )); do
+    declare arg="$1"; shift
+    mtime="$(stat_mtime "$arg")"
+    (( mtime > latest )) && latest=$mtime
+  done
+
+  echo "$latest"
+}
+
 function stat_size () {
   stat $stat_format_arg $stat_size_spec "$1" 2>/dev/null
 }


### PR DESCRIPTION
Also use VERSION.txt mtime

Resolves publish-npm-modules.sh error: "Repo $REPO_VERSION and $SOCKET_HOME/bin/ssc $BUILD_VERSION don't match."

This is a quick way of handling this without determining the actual .hh dependency chain within each .cc file