### PR TITLE
Macos (Android) CI: Incorporate Android FTE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,35 +198,7 @@ jobs:
         SSC_ANDROID_CI: true
         ANDROID_SUPPORTED_ABIS: x86_64
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
-
-    - name: AVD cache
-      uses: actions/cache@v3
-      id: avd-cache
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-        key: avd-33
-
-    - name: create AVD and generate snapshot for caching
-      if: steps.avd-cache.outputs.cache-hit != 'true'
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: 33
-        arch: x86_64
-        disable-animations: false
-        emulator-boot-timeout: 1200
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        force-avd-creation: false
-        ndk: 25.0.8775105
-        profile: pixel_5
-        target: google_apis
-        script: echo "Generated AVD snapshot for caching."
-      env:
-        CI: true
-        SSC_ANDROID_CI: true
-        NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
-
+        
     - name: Run emulator tests
       uses: reactivecircus/android-emulator-runner@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,29 +174,29 @@ jobs:
       run: |
         brew install automake
 
-    - name: Set up JDK 18
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'zulu'
-        java-version: 18
-
-    - name: Setup Android SDK
-      uses: android-actions/setup-android@v2
-
-    - name: Gradle cache
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: 7.6.1
+    - name: Android FTE
+      run: |
+        ./bin/android-functions.sh --android-fte --yes-deps
+      env:
+        VERBOSE: 1
+        DEBUG: 1
+        NO_IOS: 1
+        CI: true
+        SSC_ANDROID_CI: true
+        ANDROID_SUPPORTED_ABIS: x86_64
+        JAVA_HOME: ""
+        NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
 
     - name: Build Socket Runtime
       run: |
-        yes | sdkmanager --licenses > /dev/null
-        sdkmanager --install 'ndk;25.0.8775105' 'build-tools;33.0.2' 'system-images;android-33;google_apis;x86_64'
-        VERBOSE=1 ./bin/install.sh
+        ./bin/install.sh
         ./bin/ci_version_check.sh
       env:
+        VERBOSE: 1
+        NO_IOS: true
         CI: true
         SSC_ANDROID_CI: true
+        ANDROID_SUPPORTED_ABIS: x86_64
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
 
     - name: AVD cache
@@ -242,10 +242,11 @@ jobs:
         script: |
           ./bin/ci_version_check.sh
           npm install
-          ANDROID_SUPPORTED_ABIS="x86_64" npm run test:android
+          npm run test:android
       env:
         CI: true
         SSC_ANDROID_CI: true
+        ANDROID_SUPPORTED_ABIS: x86_64
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
 
   android_linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,9 +183,10 @@ jobs:
         NO_IOS: 1
         CI: true
         SSC_ANDROID_CI: true
+        # Clear variables because CI supplied installs are out of date
         ANDROID_HOME: 
+        JAVA_HOME: 
         ANDROID_SUPPORTED_ABIS: x86_64
-        JAVA_HOME: ""
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
 
     - name: Build Socket Runtime
@@ -196,7 +197,8 @@ jobs:
         VERBOSE: 1
         NO_IOS: true
         CI: true
-        SSC_ANDROID_CI: true
+        SSC_ANDROID_CI: true        
+        # Clear variables because CI supplied installs are out of date
         ANDROID_HOME: 
         ANDROID_SUPPORTED_ABIS: x86_64
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
@@ -211,8 +213,9 @@ jobs:
         CI: 1
         SSC_ANDROID_CI: true
         ANDROID_SUPPORTED_ABIS: x86_64
-        JAVA_HOME: ""
+        # Clear variables because CI supplied installs are out of date
         ANDROID_HOME: 
+        JAVA_HOME: 
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
 
   android_linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
         NO_IOS: 1
         CI: true
         SSC_ANDROID_CI: true
+        ANDROID_HOME: 
         ANDROID_SUPPORTED_ABIS: x86_64
         JAVA_HOME: ""
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
@@ -196,29 +197,22 @@ jobs:
         NO_IOS: true
         CI: true
         SSC_ANDROID_CI: true
+        ANDROID_HOME: 
         ANDROID_SUPPORTED_ABIS: x86_64
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
-        
+
     - name: Run emulator tests
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: 33
-        arch: x86_64
-        disable-animations: false
-        emulator-boot-timeout: 1200
-        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-        force-avd-creation: false
-        ndk: 25.0.8775105
-        profile: pixel_5
-        target: google_apis
-        script: |
-          ./bin/ci_version_check.sh
+      run: |
           npm install
-          npm run test:android
+          npm run test:android-emulator
       env:
-        CI: true
+        VERBOSE: 1
+        NO_IOS: 1
+        CI: 1
         SSC_ANDROID_CI: true
         ANDROID_SUPPORTED_ABIS: x86_64
+        JAVA_HOME: ""
+        ANDROID_HOME: 
         NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_PAT }}
 
   android_linux:

--- a/bin/android-functions.sh
+++ b/bin/android-functions.sh
@@ -95,6 +95,12 @@ function test_javac_version() {
   local target_version=$2
   local jc_v
 
+  # Setting JAVA_HOME to /usr causes sdkmanager to hang
+  if [[ "$javac" == "/usr/bin/javac" ]] && [[ "$(host_os)" == "Darwin" ]]; then
+    write_log "h" "warn - Ignoring system java selector ($javac)"
+    return 1
+  fi
+
   jc_v="$("$javac" --version 2>/dev/null)"; r=$?
   if [[ "$r" != "0" ]]; then
     return $r

--- a/bin/android-functions.sh
+++ b/bin/android-functions.sh
@@ -204,9 +204,9 @@ function get_android_paths() {
 
     if ! test -d "$_jh" ; then
       write_log "d" "# find $java_home_test -type f -name "javac$exe"' -print0 2>/dev/null | while IFS= read -r -d '' javac"
-      find "$java_home_test" -type f -name "javac$exe" -print0 2>/dev/null | while IFS= read -r -d '' javac; do
-        # break doesn't work here, check that we don't have a result
-        if [[ $(stat_size "$temp") == 0 ]]; then
+      # break doesn't work here, check that we don't have a result
+      if [[ $(stat_size "$temp") == 0 ]]; then
+        find "$java_home_test" -type f -name "javac$exe" -print0 2>/dev/null | while IFS= read -r -d '' javac; do
           write_log "v" "# Found $javac"
           test_javac_version "$javac" "$JDK_VERSION" ; r=$?
           if [[ "$r" == "0" ]]; then
@@ -216,8 +216,8 @@ function get_android_paths() {
           else
             write_log "v" "# Ignoring found javac $javac $jc_v"
           fi
-        fi
-      done
+        done
+      fi
     fi
   done
 

--- a/bin/android-functions.sh
+++ b/bin/android-functions.sh
@@ -148,10 +148,10 @@ function get_android_paths() {
   get_android_default_search_paths
   write_log "h" "# Determining Android paths."
 
-  local _ah="$ANDROID_HOME"
+  local _ah
   local _sdk
-  local _jh=
-  local _gh=
+  local _jh
+  local _gh
   local android_home_test
   local sdk_man_test
   local bat="$(use_bin_ext ".bat")"

--- a/bin/android-functions.sh
+++ b/bin/android-functions.sh
@@ -78,7 +78,8 @@ function get_android_default_search_paths() {
     
     JAVA_HOME_SEARCH_PATHS+=("$HOME/Applications")
     JAVA_HOME_SEARCH_PATHS+=("$HOME/homebrew")
-    JAVA_HOME_SEARCH_PATHS+=("/Applications")
+    # This search is really slow under CI
+    [[ -z "$CI" ]] && JAVA_HOME_SEARCH_PATHS+=("/Applications")
   elif [[ "$host" = "Linux"  ]]; then
     ANDROID_HOME_SEARCH_PATHS+=("$HOME")
     JAVA_HOME_SEARCH_PATHS+=("$HOME/.local/bin")

--- a/bin/android-functions.sh
+++ b/bin/android-functions.sh
@@ -65,6 +65,12 @@ function get_android_default_search_paths() {
     GRADLE_SEARCH_PATHS+=("$HOME/.gradle")
   fi
 
+  # Add $PATH java to JAVA_HOME_SEARCH_PATHS
+  local java="$(readlink -f "$(which java 2>/dev/null)" 2>/dev/null)"
+  if [ -n "$java" ]; then
+    JAVA_HOME_SEARCH_PATHS+=("$(dirname "$(dirname "$java")")")
+  fi
+
   # Only attempt default homes if $ANDROID_HOME not defined
   if [[ "$host" = "Darwin"  ]]; then
     JAVA_HOME_SEARCH_PATHS+=("$HOME/.local/bin")
@@ -223,11 +229,6 @@ function get_android_paths() {
 
   if [[ $(stat_size "$temp") != 0 ]]; then
     _jh=$(cat "$temp")
-  else
-    local java="$(readlink -f "$(which java)")"
-    if [ -n "$java" ]; then
-      _jh="$(dirname "$(dirname "$java")")"
-    fi
   fi
 
   echo -n > "$temp"

--- a/bin/android-functions.sh
+++ b/bin/android-functions.sh
@@ -120,6 +120,12 @@ function test_javac_version() {
     return 1
   fi
 
+  # Limit upper end of java version by not returning 0 if it is higher than target version
+  # Resolves: android BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_' Unsupported class file major version 64 in CI when running gradle under Java 20
+  if [ "$(version "$jc_v")" -gt "$(version "$target_version")" ]; then
+    return 2
+  fi
+
   return 0
 }
 

--- a/bin/android-functions.sh
+++ b/bin/android-functions.sh
@@ -822,8 +822,10 @@ function android_fte() {
 function main() {
   while (( $# > 0 )); do
     declare arg="$1"; shift
-    [[ "$arg" == "--android-fte" ]] && android_fte "$@"
-    # [[ "$arg" == "--android-fte" ]] && exit 0
+    if [[ "$arg" == "--android-fte" ]]; then
+      android_fte "$@"
+      exit $?
+    fi
     [[ "$arg" == "--android-setup-required" ]] && android_setup_required "$@"
   done
 }

--- a/bin/android-functions.sh
+++ b/bin/android-functions.sh
@@ -65,15 +65,17 @@ function get_android_default_search_paths() {
     GRADLE_SEARCH_PATHS+=("$HOME/.gradle")
   fi
 
-  # Add $PATH java to JAVA_HOME_SEARCH_PATHS
-  local java="$(readlink -f "$(which java 2>/dev/null)" 2>/dev/null)"
-  if [ -n "$java" ]; then
-    JAVA_HOME_SEARCH_PATHS+=("$(dirname "$(dirname "$java")")")
-  fi
-
   # Only attempt default homes if $ANDROID_HOME not defined
   if [[ "$host" = "Darwin"  ]]; then
     JAVA_HOME_SEARCH_PATHS+=("$HOME/.local/bin")
+
+    # Add $PATH java to JAVA_HOME_SEARCH_PATHS
+    # Don't add this as first entry, first entry used as default install path
+    local java="$(readlink -f "$(which java 2>/dev/null)" 2>/dev/null)"
+    if [ -n "$java" ]; then
+      JAVA_HOME_SEARCH_PATHS+=("$(dirname "$(dirname "$java")")")
+    fi
+    
     JAVA_HOME_SEARCH_PATHS+=("$HOME/Applications")
     JAVA_HOME_SEARCH_PATHS+=("$HOME/homebrew")
     JAVA_HOME_SEARCH_PATHS+=("/Applications")

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -547,7 +547,7 @@ function determine_cxx () {
   fi
 
   export CXX
-  update_env_data
+  update_env_data "CXX=$CXX"
 }
 
 function first_time_experience_setup() {

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2969,7 +2969,7 @@ int main (const int argc, const char* argv[]) {
         exit(1);
       }
 
-      if (!androidEnableStandardNdkBuild && !flagRunUserBuildOnly) {
+      if (!androidEnableStandardNdkBuild) {
         StringStream ndkBuild;
         StringStream ndkBuildArgs;
         StringStream ndkTest;
@@ -3011,7 +3011,7 @@ int main (const int argc, const char* argv[]) {
         auto libs = _main / "libs";
         auto obj = _main / "obj";
 
-        if (!flagRunUserBuildOnly || !fs::exists(jniLibs)) {
+        if (!fs::exists(jniLibs)) {
 
           if (fs::exists(obj)) {
             fs::remove_all(obj);

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1906,8 +1906,8 @@ int main (const int argc, const char* argv[]) {
 
 
       String licenseAccept = 
-       (getEnv("ANDROID_SDK_MANAGER_ACCEPT_LICENSES").size() > 0 ? getEnv("ANDROID_SDK_MANAGER_ACCEPT_LICENSES") : "echo") + " | " +
-       sdkmanager.str() + " --licenses";
+       quote + (getEnv("ANDROID_SDK_MANAGER_ACCEPT_LICENSES").size() > 0 ? getEnv("ANDROID_SDK_MANAGER_ACCEPT_LICENSES") : "echo") + quote + " | " +
+       quote + sdkmanager.str() + quote + " --licenses";
 
       if (std::system((licenseAccept).c_str()) != 0) {
         // Windows doesn't support 'yes'

--- a/test/scripts/bootstrap-android-emulator.sh
+++ b/test/scripts/bootstrap-android-emulator.sh
@@ -112,14 +112,15 @@ fi
 
 [[ -z "$EMULATOR_FLAGS" ]] && EMULATOR_FLAGS=()
 
-EMULATOR_FLAGS+=("-gpu" "swiftshader_indirect")
+# Android platform support prep, older versions don't support -gpu swiftshader_indirect
+[[ -z "$ANDROID_PLATFORM" ]] && ANDROID_PLATFORM=33
+(( ANDROID_PLATFORM > 31 )) && EMULATOR_FLAGS+=("-gpu" "swiftshader_indirect")
 # fixes adb: failed to install cmd: Can't find service: package
 
 echo "Starting Android emulator..."
 if [[ -z "$CI" ]]; then
   "$emulator" @SSCAVD         \
     "${EMULATOR_FLAGS[@]}"    \
-    "-gpu swiftshader_indirect" \
     -camera-back none         \
     -no-boot-anim             \
     -no-window                \
@@ -128,7 +129,6 @@ if [[ -z "$CI" ]]; then
 else
   "$emulator" @SSCAVD         \
     "${EMULATOR_FLAGS[@]}"    \
-    "-gpu swiftshader_indirect" \
     -camera-back none         \
     -no-boot-anim             \
     -no-window                \

--- a/test/scripts/bootstrap-android-emulator.sh
+++ b/test/scripts/bootstrap-android-emulator.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# 'namespaced' root
+bae_root="$(CDPATH='' cd -- "$(dirname "$(dirname -- "$0")")" && pwd)"
+
 # enable async operation by writing exit code to a file for callee to test
 # call this to identify that emulator is about to be called, but don't exit script
 function write_code() {
@@ -9,6 +12,7 @@ function write_code() {
 
 # Call this on error, script will terminate
 error_file=$1
+echo >&2 "bae error file: $error_file"
 function exit_and_write_code() {
   local exit_code="$1"
   write_code "$exit_code"
@@ -18,7 +22,9 @@ function exit_and_write_code() {
 declare rc
 
 ssc_env=""
-if [ -f ".ssc.env" ]; then
+if [ -f "$bae_root/.ssc.env" ]; then
+  ssc_env="$bae_root/.ssc.env"
+elif [ -f ".ssc.env" ]; then
   ssc_env=".ssc.env"
 elif [ -f "../.ssc.env" ]; then
   ssc_env="../.ssc.env"
@@ -88,22 +94,52 @@ fi
 write_code 0
 
 if ! "$avdmanager" list avd | grep 'Name: SSCAVD$'; then
+  echo "Downloading AVD image..."
   pkg="system-images;android-33;google_apis;$(uname -m | sed -E 's/(arm64|aarch64)/arm64-v8a/g')"
-  "$sdkmanager" "$pkg"
+  yes | "$sdkmanager" "$pkg"
   rc=$?
-  (( !rc )) && exit_and_write_code $rc
-  echo yes | "$avdmanager" --clear-cache create avd -n SSCAVD -k "$pkg" -d 1 --force
+  echo >&2 "yes | $sdkmanager $pkg: rc: $rc"
+  (( rc != 0 )) && exit_and_write_code $rc
+
+  echo "Accepting licenses..."
+  yes | "$sdkmanager" --licenses
   rc=$?
-  (( !rc )) && exit_and_write_code $rc
+  (( rc != 0 )) && exit_and_write_code $rc
+
+  echo "Creating AVD..."
+  "$avdmanager" --clear-cache create avd -n SSCAVD -k "$pkg" -d 1 --force
+  rc=$?
+  echo >&2 "$avdmanager --clear-cache create avd -n SSCAVD -k $pkg -d 1 --force rc: $rc"
+  (( rc != 0 )) && exit_and_write_code $rc
 fi
 
-"$emulator" @SSCAVD         \
-  $EMULATOR_FLAGS           \
-  -gpu swiftshader_indirect \
-  -camera-back none         \
-  -no-boot-anim             \
-  -no-window                \
-  -noaudio                  \
-  >/dev/null
+[[ -z "$EMULATOR_FLAGS" ]] && EMULATOR_FLAGS=()
 
-exit_and_write_code $?
+declare emulator_output=">/dev/null"
+[[ -z "$CI" ]] && EMULATOR_FLAGS+=("-gpu" "swiftshader_indirect")
+[[ -n "$CI" ]] && emulator_output="| grep -v \"\\[CAMetalLayer nextDrawable\\] returning nil because device is nil.\""
+# fixes adb: failed to install cmd: Can't find service: package
+[[ -n "$CI" ]] && EMULATOR_FLAGS+=("-no-snapshot-load")
+
+echo "Starting Android emulator..."
+if [[ -z "$CI" ]]; then
+  "$emulator" @SSCAVD         \
+    "${EMULATOR_FLAGS[@]}"    \
+    -camera-back none         \
+    -no-boot-anim             \
+    -no-window                \
+    -noaudio                  \
+    >/dev/null
+else
+  "$emulator" @SSCAVD         \
+    "${EMULATOR_FLAGS[@]}"    \
+    -camera-back none         \
+    -no-boot-anim             \
+    -no-window                \
+    -noaudio                  \
+    | grep -v "\[CAMetalLayer nextDrawable\] returning nil because device is nil." \
+    2>&1
+fi
+
+rc=$?
+exit_and_write_code $rc

--- a/test/scripts/poll-adb-logcat.sh
+++ b/test/scripts/poll-adb-logcat.sh
@@ -27,8 +27,10 @@ count=0
 timeout=5
 [[ -n "$CI" ]] && timeout=30
 echo "App start timeout: $timeout"
+echo ""
 while [ -z "$pid" ] && (( count < timeout )); do
-  echo -n "$count..."
+  echo -e "\e[1A\e[K$count..."
+  # echo "$count..."
   pid="$($adb shell ps | grep "$id" | awk '{print $2}' 2>/dev/null)"
   ## Probe for application process ID
   sleep 1

--- a/test/scripts/poll-adb-logcat.sh
+++ b/test/scripts/poll-adb-logcat.sh
@@ -43,11 +43,8 @@ function watchdog_file_clear() {
   fi
 }
 
-function watchdog_file_exists() {
-  ls -l $poll_adb_watchdog_file >&2
-  
+function watchdog_file_exists() {  
   if [ -f "$poll_adb_watchdog_file" ]; then
-    echo >&2 "poll_adb_watchdog_file: $(cat "$poll_adb_watchdog_file")"
     data="$(cat "$poll_adb_watchdog_file")"
     if [ -z "$data" ]; then
       echo "0"
@@ -149,11 +146,10 @@ echo "Waiting 5m before aborting tests..."
 # while [[ "$(watchdog_file_exists)" == "0" ]]; do
 while (( count < timeout )) ; do
   if [[ "$(watchdog_file_exists)" != "0" ]]; then
-    echo "break"
     break
   fi
   
-  (( count % 30 == 0 )) && echo "Timeout count: $count/$timeout"
+  (( count > 0 )) && (( count % 30 == 0 )) && echo "Timeout count: $count/$timeout"
   sleep 1
   (( count++ ))
 done

--- a/test/scripts/poll-adb-logcat.sh
+++ b/test/scripts/poll-adb-logcat.sh
@@ -34,7 +34,7 @@ function watchdog_file_set() {
   poll_adb_watchdog_file="$(mktemp)"
 }
 
-function watchdog_file_clear() {
+function watchdog_file_update() {
   exit_code=$1
   if [[ "$exit_code" != "0" ]]; then
     echo "$exit_code" > "$poll_adb_watchdog_file"
@@ -109,7 +109,7 @@ while read -r line; do
   if echo "$line" | grep 'Fatal signal'; then
     # dump_pid terminates
     echo "dump_pid"
-    watchdog_file_clear 1
+    watchdog_file_update 1
     dump_pid "$pid"
   fi
 
@@ -118,20 +118,19 @@ while read -r line; do
 
     if [[ "$line" =~ __EXIT_SIGNAL__ ]]; then
       exit_signal="${line/__EXIT_SIGNAL__=/}"
-      echo "Received exit signal line: $line, signal: $exit_signal"
-      watchdog_file_clear "$exit_signal"
+      watchdog_file_update "$exit_signal"
       exit "$exit_signal"
     fi
 
     echo "$line"
 
     if [[ "$line" == "# ok" ]]; then
-      watchdog_file_clear 0
+      watchdog_file_update 0
       exit
     fi
 
     if [[ "$line" == "# fail" ]]; then
-      watchdog_file_clear 1
+      watchdog_file_update 1
       exit 1
     fi
   fi

--- a/test/scripts/poll-adb-logcat.sh
+++ b/test/scripts/poll-adb-logcat.sh
@@ -140,7 +140,9 @@ done < <($adb logcat --pid="$pid") & logcat_pid=$!
 # This section dumps the entire process log after it has gone away, note that we don't want the entire log on failed tests that were successfully reported
 count=0
 timeout=300
-echo "Waiting 5m before aborting tests..."
+[[ -z "$CI" ]] && timeout=30
+[[ -z "$CI" ]] && echo "Waiting 30s before aborting tests..."
+[[ -n "$CI" ]] && echo "Waiting 5m before aborting tests..."
 
 # while [[ "$(watchdog_file_exists)" == "0" ]]; do
 while (( count < timeout )) ; do
@@ -166,5 +168,6 @@ else
 fi
 
 echo "poll-adb-logcat.sh exiting without signal from adb loop"
+[[ -n "$pid" ]] && dump_pid $pid
 wait $logcat_pid
 exit 254

--- a/test/scripts/poll-adb-logcat.sh
+++ b/test/scripts/poll-adb-logcat.sh
@@ -3,8 +3,12 @@
 id="co.socketsupply.socket.tests"
 
 ## Start application
-adb="$(which adb 2>/dev/null)"
-[[ ! -f "$adb" ]] && (echo "adb not in path or ANDROID_HOME not set."; exit 1)
+[[ -z "$adb" ]] && adb="$(which adb 2>/dev/null)"
+if [[ ! -f "$adb" ]]; then
+  echo "adb not in path or ANDROID_HOME not set."
+  exit 1
+fi
+
 "$adb" shell am start -n "$id/.MainActivity" || exit $?
 
 echo "polling for '$id' PID in adb"

--- a/test/scripts/poll-adb-logcat.sh
+++ b/test/scripts/poll-adb-logcat.sh
@@ -1,11 +1,61 @@
 #!/usr/bin/env bash
 
 function dump_runtime_error() {
+  local logcat_pid
   # logcat blocks, output, switch to bg, wait a bit, quit
-  $adb logcat | grep "E AndroidRuntime" & pid=$?
-  sleep 1
-  kill $?
+  $adb logcat | grep "E AndroidRuntime" & logcat_pid=$?
+  sleep 3
+  kill $logcat_pid
   exit 1
+}
+
+function dump_pid() {
+  local app_pid="$1"
+  local exit_code="$2"
+  local logcat_pid
+
+  [[ -z "$exit_code" ]] && exit_code=1
+  # logcat blocks, output, switch to bg, wait a bit, quit
+  $adb logcat --pid="$app_pid" & logcat_pid=$?
+  sleep 1
+  kill $logcat_pid
+  exit $exit_code
+}
+
+function exit_on_adb_crash_signal() {
+  while read -r line; do
+    echo "'--------- beginning of crash' occured in adb output, exiting."
+    dump_runtime_error
+  done < <($adb logcat | grep -- "--------- beginning of crash")
+}
+
+declare poll_adb_watchdog_file
+function watchdog_file_set() {
+  poll_adb_watchdog_file="$(mktemp)"
+}
+
+function watchdog_file_clear() {
+  exit_code=$1
+  if [[ "$exit_code" != "0" ]]; then
+    echo "$exit_code" > "$poll_adb_watchdog_file"
+  else
+    rm -r "$poll_adb_watchdog_file"
+  fi
+}
+
+function watchdog_file_exists() {
+  ls -l $poll_adb_watchdog_file >&2
+  
+  if [ -f "$poll_adb_watchdog_file" ]; then
+    echo >&2 "poll_adb_watchdog_file: $(cat "$poll_adb_watchdog_file")"
+    data="$(cat "$poll_adb_watchdog_file")"
+    if [ -z "$data" ]; then
+      echo "0"
+      return
+    fi
+  fi
+
+  echo "1"
 }
 
 id="co.socketsupply.socket.tests"
@@ -18,19 +68,23 @@ if [[ ! -f "$adb" ]]; then
 fi
 
 "$adb" logcat -c
+exit_on_adb_crash_signal & adb_crash_pid=$!
 "$adb" shell am start -n "$id/.MainActivity" || exit $?
 
 
 echo "polling for '$id' PID in adb"
 # Additional timeout check to catch situation where app crashes before $pid is set
 count=0
+count_output=""
 timeout=5
 [[ -n "$CI" ]] && timeout=30
 echo "App start timeout: $timeout"
 echo ""
 while [ -z "$pid" ] && (( count < timeout )); do
-  echo -e "\e[1A\e[K$count..."
-  # echo "$count..."
+  count_output="$count_output$count..." # Ouput doesn't flush in CI with echo -n, rebuild line
+  
+  [[ -n "$CI" ]] && echo "$count..."
+  [[ -z "$CI" ]] && echo -e "\e[1A\e[K$count_output" # Replace previous line, doesn't work in CI
   pid="$($adb shell ps | grep "$id" | awk '{print $2}' 2>/dev/null)"
   ## Probe for application process ID
   sleep 1
@@ -45,10 +99,21 @@ fi
 echo "# got process pid: $pid"
 
 ## Process logs from 'adb logcat'
+watchdog_file_set
+# kill $adb_crash_pid
 while read -r line; do
 
   if echo "$line" | grep "E AndroidRuntime: FATAL EXCEPTION: main" | grep "$pid"; then
+    # dump_runtime_error terminates
+    echo "dump_runtime_error"
     dump_runtime_error
+  fi
+
+  if echo "$line" | grep 'Fatal signal'; then
+    # dump_pid terminates
+    echo "dump_pid"
+    watchdog_file_clear 1
+    dump_pid "$pid"
   fi
 
   if grep 'Console :' < <(echo "$line") >/dev/null; then
@@ -56,17 +121,55 @@ while read -r line; do
 
     if [[ "$line" =~ __EXIT_SIGNAL__ ]]; then
       exit_signal="${line/__EXIT_SIGNAL__=/}"
+      echo "Received exit signal line: $line, signal: $exit_signal"
+      watchdog_file_clear "$exit_signal"
       exit "$exit_signal"
     fi
 
     echo "$line"
 
     if [[ "$line" == "# ok" ]]; then
+      watchdog_file_clear 0
       exit
     fi
 
     if [[ "$line" == "# fail" ]]; then
+      watchdog_file_clear 1
       exit 1
     fi
   fi
-done < <($adb logcat --pid="$pid")
+done < <($adb logcat --pid="$pid") & logcat_pid=$!
+
+# Handle situation where logcat loop doesn't catch exit, because eg an unexpected error condition occured that isn't handled by the text processing above
+# This section dumps the entire process log after it has gone away, note that we don't want the entire log on failed tests that were successfully reported
+count=0
+timeout=300
+echo "Waiting 5m before aborting tests..."
+
+# while [[ "$(watchdog_file_exists)" == "0" ]]; do
+while (( count < timeout )) ; do
+  if [[ "$(watchdog_file_exists)" != "0" ]]; then
+    echo "break"
+    break
+  fi
+  
+  (( count % 30 == 0 )) && echo "Timeout count: $count/$timeout"
+  sleep 1
+  (( count++ ))
+done
+
+if [[ "$(watchdog_file_exists)" == "0" ]]; then
+  echo "Timeout exceeded."
+else
+  exit_code="$(cat "$poll_adb_watchdog_file" 2>/dev/null)"
+  if [[ -z "$exit_code" ]]; then
+    date
+    dump_pid "$logcat_pid" 25
+  else
+    exit $exit_code
+  fi
+fi
+
+echo "poll-adb-logcat.sh exiting without signal from adb loop"
+wait $logcat_pid
+exit 254

--- a/test/scripts/poll-adb-logcat.sh
+++ b/test/scripts/poll-adb-logcat.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+function dump_runtime_error() {
+  # logcat blocks, output, switch to bg, wait a bit, quit
+  $adb logcat | grep "E AndroidRuntime" & pid=$?
+  sleep 1
+  kill $?
+  exit 1
+}
+
 id="co.socketsupply.socket.tests"
 
 ## Start application
@@ -9,17 +17,38 @@ if [[ ! -f "$adb" ]]; then
   exit 1
 fi
 
+"$adb" logcat -c
 "$adb" shell am start -n "$id/.MainActivity" || exit $?
 
+
 echo "polling for '$id' PID in adb"
-while [ -z "$pid" ]; do
-  ## Probe for application process ID
+# Additional timeout check to catch situation where app crashes before $pid is set
+count=0
+timeout=5
+[[ -n "$CI" ]] && timeout=30
+echo "App start timeout: $timeout"
+while [ -z "$pid" ] && (( count < timeout )); do
+  echo -n "$count..."
   pid="$($adb shell ps | grep "$id" | awk '{print $2}' 2>/dev/null)"
+  ## Probe for application process ID
   sleep 1
+  (( count++ ))
 done
+
+if (( count >= timeout )); then
+  echo "timeout exceeded, assuming app crashed."
+  dump_runtime_error
+fi
+
+echo "# got process pid: $pid"
 
 ## Process logs from 'adb logcat'
 while read -r line; do
+
+  if echo "$line" | grep "E AndroidRuntime: FATAL EXCEPTION: main" | grep "$pid"; then
+    dump_runtime_error
+  fi
+
   if grep 'Console :' < <(echo "$line") >/dev/null; then
     line="$(echo "$line" | sed 's/.*[D|E|I|W] Console :\s*//g')"
 

--- a/test/scripts/test-android-emulator.sh
+++ b/test/scripts/test-android-emulator.sh
@@ -40,7 +40,10 @@ fi
 id="co.socketsupply.socket.tests"
 adb="$(which adb 2>/dev/null)"
 [[ -z "$adb" ]] && adb="$ANDROID_HOME/platform-tools/adb"
-[[ ! -f "$adb" ]] && (echo "adb not in path or ANDROID_HOME not set."; exit 1)
+if [[ ! -f "$adb" ]]; then
+  echo "adb not in path or ANDROID_HOME not set."
+  exit 1
+fi
 export adb
 
 temp="$(mktemp)"

--- a/test/scripts/test-android-emulator.sh
+++ b/test/scripts/test-android-emulator.sh
@@ -21,7 +21,9 @@ elif [[ "$host" == *"MSYS_NT"* ]]; then
 fi
 
 ssc_env=""
-if [ -f ".ssc.env" ]; then
+if [ -f "$root/.ssc.env" ]; then
+  ssc_env="$root/.ssc.env"
+elif [ -f ".ssc.env" ]; then
   ssc_env=".ssc.env"
 elif [ -f "../.ssc.env" ]; then
   ssc_env="../.ssc.env"


### PR DESCRIPTION
## Note that CI is currently failing due to a `commonjs` issue. This is proof that this CI setup does work.

### Note that https://github.com/socketsupply/socket/pull/354 should be merged first, and ASAP.

+ switch to using test-android-emulator
    This allows us to test outside CI more reliably, rather than relying
    on github actions

+  Implemented timeout / watchdog setup to handle app failures
    that aren't caught by main adb loop in poll-adb-logcat.sh

+ macos android ci: Don't use avd cache

    "The cache became corrupted"
    The cache doesn't seem any faster than just firing up a clean AVD image

+ fix jniLibs not building when flagRunUserBuildOnly set (CI wasn't testing this before, libsocket-runtime.so wasn't being deployed with the app)

+ implement app start timeout and error output to catch failed app starts, which in turn prevents CI hanging because it would never receive a signal from webview js

+ dont search /Applications for java, this is extremely slow under CI

+ require exact java version
   
android BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_' Unsupported class file major version 64

+ only build x86_64 - performance

+ determine_cxx: fix CXX not persisted to .ssc.env