### PR TITLE
chore(ci): fail early

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,32 @@ name: Socket CI
 on: [push]
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js
+      uses: actions/setup-node@v3.6.0
+      with:
+        node-version: 18.x
+
+    - name: Lint
+      run: npm install && npm run test:lint
+    
+    - name: Check docs
+      run: |
+        npm run gen-docs
+        git diff --quiet
+
   linux:
     name: Linux
     runs-on: ubuntu-22.04
     timeout-minutes: 6
+    needs: lint
 
     steps:
     - uses: actions/checkout@v3
@@ -43,6 +65,7 @@ jobs:
     name: macOS
     runs-on: macOS-12
     timeout-minutes: 9
+    needs: lint
 
     steps:
     - uses: actions/checkout@v3
@@ -77,6 +100,7 @@ jobs:
     name: Windows
     runs-on: windows-2022
     timeout-minutes: 10
+    needs: lint
 
     steps:
     - uses: actions/checkout@v3
@@ -125,6 +149,7 @@ jobs:
     name: iOS (macOS)
     runs-on: macOS-12
     timeout-minutes: 25
+    needs: lint
 
     steps:
     - uses: actions/checkout@v3
@@ -161,6 +186,7 @@ jobs:
     name: Android (macOS)
     runs-on: macos-latest
     timeout-minutes: 60
+    needs: lint
 
     steps:
     - uses: actions/checkout@v3
@@ -252,6 +278,7 @@ jobs:
     name: Android (Linux)
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    needs: lint
 
     steps:
     - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "api"
   ],
   "scripts": {
-    "pretest": "standard .",
-    "readme": "node ./bin/generate-docs.js",
+    "gen-docs": "node ./bin/generate-docs.js",
     "test": "cp -f .ssc.env test | echo && cd test && npm install --silent --no-audit && npm test",
+    "test:lint": "standard .",
     "test:node": "node ./test/node/index.js",
     "test:ios-simulator": "cd test && npm install --silent --no-audit && npm run test:ios-simulator",
     "test:android": "cp -f .ssc.env test | echo && cd test && npm install --silent --no-audit && npm run test:android",


### PR DESCRIPTION
Fail CI early when linting doesn't pass or when git working directory is not clean after generating docs. This can save resources on building ssc on the platforms.