### PR TITLE
CI and .d.ts gen fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Lint
       run: npm install && npm run test:lint
     
-    - name: Check docs
+    - name: Check docs and TS definitions
       run: |
         npm run gen-docs
         npm run tsc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
     
     - name: Check docs and TS definitions
       run: |
-        npm run gen-docs
-        npm run tsc
+        npm run gen
         git diff --quiet
 
   linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Check docs
       run: |
         npm run gen-docs
+        npm run tsc
         git diff --quiet
 
   linux:

--- a/bin/generate-typescript-typings.sh
+++ b/bin/generate-typescript-typings.sh
@@ -6,5 +6,7 @@ cd "$root" || exit $?
 
 tsc --emitDeclarationOnly --module es2022 --outFile api/index || exit $?
 
-sed -i '' -e 's/declare module "\(.*\)"/declare module "socket:\1"/g' api/index.d.ts || exit $?
-sed -i '' -e 's/namespace \_\_\_.*$//g' api/index.d.ts || exit $?
+ls -la api
+
+sed -i -e 's/declare module "\(.*\)"/declare module "socket:\1"/g' api/index.d.ts || exit $?
+sed -i -e 's/namespace \_\_\_.*$//g' api/index.d.ts || exit $?

--- a/bin/generate-typescript-typings.sh
+++ b/bin/generate-typescript-typings.sh
@@ -6,7 +6,5 @@ cd "$root" || exit $?
 
 tsc --emitDeclarationOnly --module es2022 --outFile api/index || exit $?
 
-ls -la api
-
 sed -i -e 's/declare module "\(.*\)"/declare module "socket:\1"/g' api/index.d.ts || exit $?
 sed -i -e 's/namespace \_\_\_.*$//g' api/index.d.ts || exit $?

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "gen-docs": "node ./bin/generate-docs.js",
     "tsc": "./bin/generate-typescript-typings.sh",
     "test": "cp -f .ssc.env test | echo && cd test && npm install --silent --no-audit && npm test",
-    "test:lint": "standard . && tsc --noEmit",
+    "test:lint": "standard .",
     "test:node": "node ./test/node/index.js",
     "test:ios-simulator": "cd test && npm install --silent --no-audit && npm run test:ios-simulator",
     "test:android": "cp -f .ssc.env test | echo && cd test && npm install --silent --no-audit && npm run test:android",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
     "api"
   ],
   "scripts": {
-    "gen-docs": "node ./bin/generate-docs.js",
-    "tsc": "./bin/generate-typescript-typings.sh",
+    "gen": "npm run gen:docs && npm run gen:tsc",
+    "gen:docs": "node ./bin/generate-docs.js",
+    "gen:tsc": "./bin/generate-typescript-typings.sh",
     "test": "cp -f .ssc.env test | echo && cd test && npm install --silent --no-audit && npm test",
     "test:lint": "standard .",
     "test:node": "node ./test/node/index.js",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   ],
   "scripts": {
     "gen-docs": "node ./bin/generate-docs.js",
-    "pretest": "standard .",
-    "readme": "node ./bin/generate-docs.js",
     "tsc": "./bin/generate-typescript-typings.sh",
-    "pretest": "npm run lint",
     "test": "cp -f .ssc.env test | echo && cd test && npm install --silent --no-audit && npm test",
     "test:lint": "standard . && tsc --noEmit",
     "test:node": "node ./test/node/index.js",


### PR DESCRIPTION
now the `Lint` CI job correctly checks linting and ensures that TS definitions and docs are generated against the latest version.

To generate all the necessary files do `npm run gen` and push them to pass the linting