### PR TITLE
arm64-iPhoneSimulator: Enable support

### DIFF
--- a/bin/build-runtime-library.sh
+++ b/bin/build-runtime-library.sh
@@ -83,7 +83,7 @@ while (( $# > 0 )); do
       platform="iPhoneOS";
       export TARGET_OS_IPHONE=1
     elif [[ "$1" = "ios-simulator" ]] || [[ "$1" = "iPhoneSimulator" ]] || [[ "$1" = "iphonesimulator" ]]; then
-      arch="x86_64"
+      [[ -z "$arch" ]] && arch="x86_64"
       platform="iPhoneSimulator";
       export TARGET_IPHONE_SIMULATOR=1
     elif [[ "$1" = "android" ]]; then
@@ -116,6 +116,7 @@ elif [[ "$host" = "Darwin" ]]; then
     clang="xcrun -sdk iphoneos $clang"
   elif (( TARGET_IPHONE_SIMULATOR )); then
     clang="xcrun -sdk iphonesimulator $clang"
+    cflags+=("-arch "$arch"")
   else
     sources+=("$root/src/process/unix.cc")
   fi

--- a/bin/cflags.sh
+++ b/bin/cflags.sh
@@ -7,6 +7,7 @@ declare IOS_SIMULATOR_VERSION_MIN="${IOS_SIMULATOR_VERSION_MIN:-$IPHONEOS_VERSIO
 
 declare cflags=()
 declare arch="$(uname -m | sed 's/aarch64/arm64/g')"
+arch=${ARCH:-$arch}
 declare host="$(uname -s)"
 declare platform="desktop"
 
@@ -66,7 +67,7 @@ if (( TARGET_OS_IPHONE )) || (( TARGET_IPHONE_SIMULATOR )); then
     cflags+=("-miphoneos-version-min=$IPHONEOS_VERSION_MIN")
   elif (( TARGET_IPHONE_SIMULATOR )); then
     ios_sdk_path="$(xcrun -sdk iphonesimulator -show-sdk-path)"
-    cflags+=("-arch x86_64")
+    cflags+=("-arch $arch")
     cflags+=("-mios-simulator-version-min=$IPHONEOS_VERSION_MIN")
   fi
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2331,7 +2331,7 @@ int main (const int argc, const char* argv[]) {
       }
 
       if (!fs::exists(deviceObjects)) {
-        log("ERROR: libs folder for the target platform doesn't exist: " + deviceObjects.string());
+        log("ERROR: objects folder for the target platform doesn't exist: " + deviceObjects.string());
       }
 
       if (!fs::exists(deviceLibs) || !fs::exists(deviceObjects)) {

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2321,31 +2321,34 @@ int main (const int argc, const char* argv[]) {
         settings["apple_team_id"] = "";
       }
 
-      if (flagBuildForSimulator) {
-        fs::copy(
-          Path(prefixFile()) / "lib" / "x86_64-iPhoneSimulator",
-          paths.platformSpecificOutputPath / "lib",
-          fs::copy_options::overwrite_existing | fs::copy_options::recursive
-        );
+      auto deviceType = platform.arch + "-iPhone" + (flagBuildForSimulator ? "Simulator" : "OS");
 
-        fs::copy(
-          Path(prefixFile()) / "objects" / "x86_64-iPhoneSimulator",
-          paths.platformSpecificOutputPath / "objects",
-          fs::copy_options::overwrite_existing | fs::copy_options::recursive
-        );
-      } else {
-        fs::copy(
-          Path(prefixFile()) / "lib" / "arm64-iPhoneOS",
-          paths.platformSpecificOutputPath / "lib",
-          fs::copy_options::overwrite_existing | fs::copy_options::recursive
-        );
+      auto deviceLibs = Path(prefixFile()) / "lib" / deviceType;
+      auto deviceObjects = Path(prefixFile()) / "objects" / deviceType;
 
-        fs::copy(
-          Path(prefixFile()) / "objects" / "arm64-iPhoneOS",
-          paths.platformSpecificOutputPath / "objects",
-          fs::copy_options::overwrite_existing | fs::copy_options::recursive
-        );
+      if (!fs::exists(deviceLibs)) {
+        log("ERROR: libs folder for the target platform doesn't exist: " + deviceLibs.string());
       }
+
+      if (!fs::exists(deviceObjects)) {
+        log("ERROR: libs folder for the target platform doesn't exist: " + deviceObjects.string());
+      }
+
+      if (!fs::exists(deviceLibs) || !fs::exists(deviceObjects)) {
+        exit(1);
+      }
+
+      fs::copy(
+        deviceLibs,
+        paths.platformSpecificOutputPath / "lib",
+        fs::copy_options::overwrite_existing | fs::copy_options::recursive
+      );
+
+      fs::copy(
+        deviceObjects,
+        paths.platformSpecificOutputPath / "objects",
+        fs::copy_options::overwrite_existing | fs::copy_options::recursive
+      );
 
       fs::copy(
         Path(prefixFile()) / "include",

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -795,7 +795,6 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
         CURRENT_PROJECT_VERSION = 1;
         DEVELOPMENT_TEAM = "{{apple_team_id}}";
         ENABLE_BITCODE = NO;
-        "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
         GENERATE_INFOPLIST_FILE = YES;
         HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/include";
         INFOPLIST_FILE = Info.plist;
@@ -817,6 +816,7 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
         );
         LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/lib";
         MARKETING_VERSION = 1.0;
+        ONLY_ACTIVE_ARCH = YES;
         OTHER_CFLAGS = (
           "-DHOST={{host}}",
           "-DPORT={{port}}",
@@ -845,8 +845,6 @@ constexpr auto gXCodeProject = R"ASCII(// !$*UTF8*$!
         CURRENT_PROJECT_VERSION = 1;
         DEVELOPMENT_TEAM = "{{apple_team_id}}";
         ENABLE_BITCODE = NO;
-        "EXCLUDED_ARCHS[sdk=*]" = "";
-        "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
         GENERATE_INFOPLIST_FILE = YES;
         HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/include";
         INFOPLIST_FILE = Info.plist;


### PR DESCRIPTION
Fixes silent crash when testing apps on iPhoneSimulator running on Mac M1 or later

Fixes https://github.com/socketsupply/socket/issues/374