### PR TITLE
android: allow_cleartext: Remove from ini.

### DIFF
--- a/api/config.md
+++ b/api/config.md
@@ -35,7 +35,6 @@ version |  |  A string that indicates the version of the application. It should 
 Key | Default Value | Description
 :--- | :--- | :---
 aapt_no_compress |  |  Extensions of files that will not be stored compressed in the APK.
-allow_cleartext |  |  Allow unencrypted http requests, useful for live reload.
 enable_standard_ndk_build |  |  Enables gradle based ndk build rather than using external native build (standard ndk is the old slow way)
 main_activity |  |  Name of the MainActivity class. Could be overwritten by custom native code.
 manifest_permissions |  |  Which permissions does your application need: https://developer.android.com/guide/topics/permissions/overview

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1426,9 +1426,6 @@ version = 1.0.0
 ; Extensions of files that will not be stored compressed in the APK.
 aapt_no_compress = ""
 
-; Allow unencrypted http requests, useful for live reload.
-allow_cleartext = false
-
 ; Enables gradle based ndk build rather than using external native build (standard ndk is the old slow way)
 enable_standard_ndk_build = false
 


### PR DESCRIPTION
This is an internal value used to create a setting in debug. Fixes 'false' appearing in AndroidManifest.xml (Invalid XML)