### PR TITLE
Android improvements

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -3012,51 +3012,55 @@ int main (const int argc, const char* argv[]) {
         auto libs = _main / "libs";
         auto obj = _main / "obj";
 
-        if (!fs::exists(jniLibs)) {
+        if (fs::exists(obj)) {
+          fs::remove_all(obj);
+        }
 
-          if (fs::exists(obj)) {
-            fs::remove_all(obj);
-          }
-
-          // TODO(mribbons) - Copy specific abis
-          fs::create_directories(libs);
-          for (auto const& dir_entry : fs::directory_iterator(prefixFile() + "lib")) {
-            if (dir_entry.is_directory() && dir_entry.path().stem().string().find("-android") != String::npos) {
-              auto dest = libs / replace(dir_entry.path().stem().string(), "-android", "");
-              try {
-                if (debugEnv) log("copy android lib: "+ dir_entry.path().string() + " => " + dest.string());
-                fs::copy(
-                  dir_entry.path(),
-                  dest,
-                  fs::copy_options::overwrite_existing | fs::copy_options::recursive
-                );
-              } catch (fs::filesystem_error &e) {
-                std::cerr << "Unable to copy android lib: " << fs::exists(dest) << ": " << e.what() << std::endl;
-                throw;
-              }
+        // TODO(mribbons) - Copy specific abis
+        fs::create_directories(libs);
+        int androidLibCount = 0;
+        for (auto const& dir_entry : fs::directory_iterator(prefixFile() + "lib")) {
+          if (dir_entry.is_directory() && dir_entry.path().stem().string().find("-android") != String::npos) {
+            auto dest = libs / replace(dir_entry.path().stem().string(), "-android", "");
+            try {
+              if (debugEnv) log("copy android lib: "+ dir_entry.path().string() + " => " + dest.string());
+              fs::copy(
+                dir_entry.path(),
+                dest,
+                fs::copy_options::overwrite_existing | fs::copy_options::recursive
+              );
+              androidLibCount++;
+            } catch (fs::filesystem_error &e) {
+              std::cerr << "Unable to copy android lib: " << fs::exists(dest) << ": " << e.what() << std::endl;
+              throw;
             }
           }
+        }
 
-          fs::create_directories(jniLibs);
-
-          ndkBuildArgs
-            << ndkBuild.str()
-            << " -j"
-            << " NDK_PROJECT_PATH=" << _main
-            << " NDK_APPLICATION_MK=" << app_mk
-            << (flagDebugMode ? " NDK_DEBUG=1" : "")
-            << " APP_PLATFORM=" << androidPlatform
-            << " NDK_LIBS_OUT=" << jniLibs
-          ;
-
-          if (!(debugEnv || verboseEnv)) ndkBuildArgs << " >" << (!platform.win ? "/dev/null" : "NUL") << " 2>&1";
-
-          if (debugEnv || verboseEnv) log(ndkBuildArgs.str());
-          if (std::system(ndkBuildArgs.str().c_str()) != 0) {
-            log(ndkBuildArgs.str());
-            log("ERROR: ndk build failed.");
+        if (androidLibCount == 0) {
+            log("ERROR: No android static libs copied, app won't build. Check " + prefixFile() + "lib");
             exit(1);
-          }
+        }
+
+        fs::create_directories(jniLibs);
+
+        ndkBuildArgs
+          << ndkBuild.str()
+          << " -j"
+          << " NDK_PROJECT_PATH=" << _main
+          << " NDK_APPLICATION_MK=" << app_mk
+          << (flagDebugMode ? " NDK_DEBUG=1" : "")
+          << " APP_PLATFORM=" << androidPlatform
+          << " NDK_LIBS_OUT=" << jniLibs
+        ;
+
+        if (!(debugEnv || verboseEnv)) ndkBuildArgs << " >" << (!platform.win ? "/dev/null" : "NUL") << " 2>&1";
+
+        if (debugEnv || verboseEnv) log(ndkBuildArgs.str());
+        if (std::system(ndkBuildArgs.str().c_str()) != 0) {
+          log(ndkBuildArgs.str());
+          log("ERROR: ndk build failed.");
+          exit(1);
         }
       }
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -1571,6 +1571,7 @@ int main (const int argc, const char* argv[]) {
       getEnv("VERBOSE").size() > 0
     );
     
+    auto oldCwd = fs::current_path();
     auto devNull = ">" + SSC::String((!platform.win) ? "/dev/null" : "NUL") + (" 2>&1");
 
     String localDirPrefix = !platform.win ? "./" : "";
@@ -2568,7 +2569,6 @@ int main (const int argc, const char* argv[]) {
       // pass it to the platform-specific directory where they
       // should send their build artifacts.
       //
-      auto oldCwd = fs::current_path();
       fs::current_path(oldCwd / targetPath);
 
       {
@@ -2822,7 +2822,6 @@ int main (const int argc, const char* argv[]) {
 
       log("building for iOS");
 
-      auto oldCwd = fs::current_path();
       auto pathToDist = oldCwd / paths.platformSpecificOutputPath;
 
       fs::create_directories(pathToDist);
@@ -3120,7 +3119,10 @@ int main (const int argc, const char* argv[]) {
           exit(1);
         }
 
+        // don't run devices query from build folder as it spawns adb server, which will prevent folder deletion on windows
+        fs::current_path(oldCwd);
         auto deviceQuery = exec(adb.str() + " devices");
+        fs::current_path(paths.platformSpecificOutputPath);
         androidEmulatorRunning = (deviceQuery.output.find("emulator") != SSC::String::npos);
       }
 
@@ -3186,7 +3188,7 @@ int main (const int argc, const char* argv[]) {
           auto androidEmulatorProcess = new SSC::Process(
             emulator.str(),
             " @SSCAVD -gpu swiftshader_indirect", // platform-33: swiftshader not supported below platform-32
-            fs::current_path().string(),
+            oldCwd.string(),
             [](SSC::String const &out) {  },
             [](SSC::String const &out) {  }
           );

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -3047,10 +3047,13 @@ int main (const int argc, const char* argv[]) {
           int androidSharedLibCount = 0;
           for (auto const& dir_entry : fs::recursive_directory_iterator(jniLibs)) {
             if (dir_entry.path().stem() == "libsocket-runtime.so") {
+              // Count the number of libsocket-runtime.so's in jniLibs, there will be one for each android architecture
               androidSharedLibCount++;
             }
           }
 
+          // if we have found libsocket-runtime.so, we don't need to recompile, unless:
+          // libsocket-runtime.so count doesn't match the static lib count - There should be one libuv.a and libsocket-runtime.a for each android architecture
           if (androidSharedLibCount > 0 && androidSharedLibCount != (androidStaticLibCount / 2)) {
             buildJniLibs = true;
             log("WARN: Android Shared Lib Count is incorrect, forcing rebuild.");
@@ -3062,6 +3065,7 @@ int main (const int argc, const char* argv[]) {
         
         fs::create_directories(jniLibs);
 
+        // don't build unless we're sure it is required, ndkbuild errors out if jniLibs is already populated
         if (buildJniLibs) {
           ndkBuildArgs
             << ndkBuild.str()


### PR DESCRIPTION
* android build cwd: don't run from build folder

(where possible)

Partially resolves file lock issue on windows where folders are locked
while processes are using them as pwd

Note that gradle has to run from build folder, but this change still
results in less process to kill.

* android: improve static lib dx

Always copy libs, even if jniLibs exists, this may have been an issue and the performance detriment is negligable
ERROR out if static libs don't exist in SOCKET_HOME