### PR TITLE
cli.cc(fix): resolve build_script issue on win32

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2630,9 +2630,19 @@ int main (const int argc, const char* argv[]) {
         buildArgs << " --test=true";
       }
 
+      auto scriptArgs = buildArgs.str();
+      auto buildScript = settings["build_script"];
+      
+      // Windows CreateProcess() won't work if the script has an extension other than exe (say .cmd or .bat)
+      // cmd.exe can handle this translation
+      if (platform.win) {
+        scriptArgs =  " /c \"" + buildScript  + " " + scriptArgs + "\"";
+        buildScript = "cmd.exe";
+      }
+
       auto process = new SSC::Process(
-        settings["build_script"],
-        buildArgs.str(),
+        buildScript,
+        scriptArgs,
         fs::current_path().string(),
         [](SSC::String const &out) { stdWrite(out, false); },
         [](SSC::String const &out) { stdWrite(out, true); }

--- a/src/common.hh
+++ b/src/common.hh
@@ -612,14 +612,6 @@ namespace SSC {
 
   inline void stdWrite (const String &str, bool isError) {
     (isError ? std::cerr : std::cout) << str << std::endl;
-  #ifdef _WIN32
-    StringStream ss;
-    ss << str << std::endl;
-    auto lineStr = ss.str();
-    auto handle = isError ? STD_ERROR_HANDLE : STD_OUTPUT_HANDLE;
-    WriteConsoleA(GetStdHandle(handle), lineStr.c_str(), lineStr.size(), NULL, NULL);
-  #endif
-
     notifyCli();
   }
 


### PR DESCRIPTION
Windows CreateProcess() won't work if the script has an extension other than exe (say .cmd or .bat) cmd.exe can handle this translation

Also change stdWrite, remove duplicate output on win32, WriteConsoleA() doesn't seem to be required now.