### PR TITLE
win32 / install: fix eval syntax error near...

### DIFF
--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -547,7 +547,10 @@ function determine_cxx () {
   fi
 
   export CXX
-  update_env_data "CXX=$CXX"
+  # win32 has partically escaping requirements, this is handled by install.ps1
+  if [[ "$host" != "Win32" ]]; then
+    update_env_data "CXX=$CXX"
+  fi
 }
 
 function first_time_experience_setup() {

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -581,7 +581,7 @@ function _install {
 
     if [[ -f "$root/$SSC_ENV_FILENAME" ]]; then
       if [[ -f "$SOCKET_HOME/$SSC_ENV_FILENAME" ]]; then
-        echo "# Not overwriting $SOCKET_HOME/$SSC_ENV_FILENAME"
+        echo "# warn - Won't overwrite $SOCKET_HOME/$SSC_ENV_FILENAME"
       else
         echo "# copying $SSC_ENV_FILENAME to $SOCKET_HOME"
         cp -fp "$root/$SSC_ENV_FILENAME" "$SOCKET_HOME/$SSC_ENV_FILENAME"


### PR DESCRIPTION
eval: line 222: syntax error near unexpected token `('

Don't call `update_env_data` on windows, it is managed by `install.ps1`