### PR TITLE
win32 + other path related failing tests

### DIFF
--- a/test/src/fs/promises.js
+++ b/test/src/fs/promises.js
@@ -42,6 +42,13 @@ if (process.platform !== 'ios') {
       const { err } = await fs.mkdir(dirname, {})
       t.equal(err, undefined, 'mkdir does not throw')
     })
+
+    test('fs.promises.mkdir({recursive: true})', async (t) => {
+      const dirname = FIXTURES + Math.random().toString(16).slice(2)
+      const { err } = await fs.mkdir(`${dirname}${path.sep}${dirname}`, {recursive: true})
+      await fs.access(`${dirname}${path.sep}${dirname}`, X_OK)
+      t.equal(err, undefined, 'mkdir does not throw and creates directories recursively')
+    })
   }
 
   test('fs.promises.open', async (t) => {

--- a/test/src/path.js
+++ b/test/src/path.js
@@ -84,6 +84,9 @@ test('path.win32.join', (t) => {
   t.equal(path.win32.join('a', 'b', 'c'), 'a\\b\\c', 'join(a, b, c)')
   t.equal(path.win32.join('a', 'b', 'c', '..\\d'), 'a\\b\\d', 'join(a, b, c, ..\\d)')
   t.equal(path.win32.join('a', 'b', 'c', '..\\d', '..\\..\\b'), 'a\\b', 'join(a, b, c, ..\\d, ..\\..\\b)')
+  t.equal(path.win32.join('c:\\dir\\', 'file.txt'), `c:\\dir\\file.txt`, `c:\\dir\\, file.txt`)
+  t.equal(path.win32.join('c:\\test', '', '', 'hello'), `c:\\test\\hello`, `c:\\test, '', '', hello`)
+  t.equal(path.win32.join('c:\\test', '\\', '\\', 'hello'), `c:\\test\\hello`, `c:\\test, '\\', '\\', hello`)
 })
 
 test('path.win32.dirname', (t) => {

--- a/test/src/process.js
+++ b/test/src/process.js
@@ -28,6 +28,7 @@ test('process.cwd', async (t) => {
   } else if (process.platform === 'win32') {
     // TODO(trevnorris): Fix to use path once implemented for Windows
     t.equal(process.cwd(), process.argv0.slice(0, process.argv0.lastIndexOf('\\') + 1), 'process.cwd() returns a correct value')
+    t.ok(process.cwd()[process.cwd().length-1] !== path.sep, 'process.cwd() does not end with trailing separator')
   } else {
     // for future platforms
     t.fail(`FIXME: not implemented for platform ${process.platform}`)


### PR DESCRIPTION
Examples of nodejs behavior for the newly added tests:
```js
import process from 'node:process'
import path from 'node:path'
import fs, { constants } from 'node:fs'

// join: c:\tests\nodefs
console.log(`join: ${process.cwd()}, ${path.join(process.cwd() + '\\', `${new Date().getTime()}.log`)}`)

// cwd last char: s
console.log(`cwd last char: ${process.cwd()[process.cwd().length-1]}`)

// c:\test\hello
console.log(`join empty paths: ${path.join('c:\\test', '', '', 'hello')}`)

// c:\test\hello
console.log(`join slashes: ${path.join('c:\\test', '\\', '\\', 'hello')}`)

// doesn't throw
fs.promises.mkdir('mkdir\\test\\path', {recursive: true})
fs.promises.access('mkdir\\test\\path', constants.X_OK)

// would be great to also see copyFile and utimes working
fs.writeFileSync('text.dat', '1234')
fs.promises.copyFile('text.dat', 'text2.dat')
let yesterday = new Date(new Date().getTime() - 86400000);
fs.promises.utimes('text.dat', new Date(), yesterday)
fs.promises.stat('text.dat').then((stat) => {
  if (stat.mtimeMs === yesterday.getTime()) {
    console.log(`utimes is good`)
  } else {
    console.log(`${stat.mtime} !== ${yesterday.getTime()}`)
  }
})
```