### PR TITLE
use '@available' check for iOS 15 feature

### DIFF
--- a/src/ios/main.mm
+++ b/src/ios/main.mm
@@ -272,9 +272,13 @@ static dispatch_queue_t queue = dispatch_queue_create(
       URLWithString: [NSString stringWithFormat: @"http://%@:%d/", host, port]
     ];
 
-    [self.webview loadFileRequest: [NSURLRequest requestWithURL: url]
-          allowingReadAccessToURL: [NSURL fileURLWithPath: allowed]
-    ];
+    if (@available(iOS 15, *)) {
+      [self.webview loadFileRequest: [NSURLRequest requestWithURL: url]
+            allowingReadAccessToURL: [NSURL fileURLWithPath: allowed]
+      ];
+    } else {
+      [self.webview loadRequest: [NSURLRequest requestWithURL: url]];
+    }
   } else {
     url = [NSURL
       fileURLWithPath: [allowed stringByAppendingPathComponent:@"ui/index.html"]


### PR DESCRIPTION
- Renames `src/ios/ios.mm` to `src/ios/main.mm`
- Fixes `'loadFileRequest:allowingReadAccessToURL:' is only available on iOS 15.0 or newer` warning