### PR TITLE
Rework hooks API internals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Check docs and TS definitions
       run: |
         npm run gen
+        git diff --quiet
 
   linux:
     name: Linux

--- a/api/README.md
+++ b/api/README.md
@@ -1198,7 +1198,7 @@ Emit event to be dispatched on `window` object.
 | Argument | Type | Default | Optional | Description |
 | :---     | :--- | :---:   | :---:    | :---        |
 | name | string |  | false |  |
-| value | Mixed |  | false |  |
+| value | any |  | false |  |
 | target | EventTarget | window | true |  |
 | options | Object |  | true |  |
 
@@ -1210,7 +1210,7 @@ Sends an async IPC command request with parameters.
 | Argument | Type | Default | Optional | Description |
 | :---     | :--- | :---:   | :---:    | :---        |
 | command | string |  | false |  |
-| value | Mixed |  | true |  |
+| value | any |  | true |  |
 | options | object |  | true |  |
 | options.cache | boolean | false | true |  |
 | options.bytes | boolean | false | true |  |
@@ -1310,7 +1310,7 @@ External docs: https://socketsupply.co/guides/#p2p-guide
  ```
 
 
-## [`Peer` (extends `EventEmitter`)](https://github.com/socketsupply/socket/blob/master/api/peer.js#L50)
+## [`Peer` (extends `EventEmitter`)](https://github.com/socketsupply/socket/blob/master/api/peer.js#L52)
 
 
 The Peer class is an EventEmitter. It emits events when new network events
@@ -1328,13 +1328,13 @@ peer.on('greeting', (value, peer, address, port) => {
   console.log(value)
 })
 
-window.addEventListener('load', () => {
+window.onload = () => {
   const value = { english: 'hello, world' }
   const packet = await peer.emit('greeting', value)
-}, { once: true }})
+}
 ```
 
-### [`constructor(options)`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L60)
+### [`constructor(options)`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L62)
 
 `Peer` class constructor.
 
@@ -1348,7 +1348,7 @@ window.addEventListener('load', () => {
 | options.peers | Array |  | false | An array of RemotePeer |
 
 
-### [`createKeys()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L80)
+### [`createKeys()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L82)
 
 A method that will generate a public and private key pair.
  The ed25519 pair can be stored by an app with a secure API.
@@ -1359,7 +1359,7 @@ A method that will generate a public and private key pair.
 | pair | Object<Pair> | A pair of keys |
 
 
-### [`createClusterId()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L94)
+### [`createClusterId()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L96)
 
 Create a clusterId from random bytes
 
@@ -1368,7 +1368,7 @@ Create a clusterId from random bytes
 | id | string | a hex encoded sha256 hash |
 
 
-### [`emit(event, message)`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L105)
+### [`emit(event, message)`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L107)
 
 Emits a message to the network
 
@@ -1384,7 +1384,7 @@ Emits a message to the network
 | Not specified | Object<Packet> | The packet that will be sent when possible |
 
 
-### [`join()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L128)
+### [`join()`](https://github.com/socketsupply/socket/blob/master/api/peer.js#L130)
 
 Starts the process of connecting to the network.
 
@@ -1698,7 +1698,7 @@ External docs: module:Application Application
 
  Represents a window in the application
 
-### [`index()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L57)
+### [`index()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L56)
 
 Get the index of the window
 
@@ -1707,7 +1707,7 @@ Get the index of the window
 | Not specified | number | the index of the window |
 
 
-### [`getSize()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L65)
+### [`getSize()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L64)
 
 Get the size of the window
 
@@ -1716,7 +1716,7 @@ Get the size of the window
 | Not specified | { width: number, height: number  | } - the size of the window |
 
 
-### [`getTitle()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L76)
+### [`getTitle()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L75)
 
 Get the title of the window
 
@@ -1725,7 +1725,7 @@ Get the title of the window
 | Not specified | string | the title of the window |
 
 
-### [`getStatus()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L84)
+### [`getStatus()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L83)
 
 Get the status of the window
 
@@ -1734,7 +1734,7 @@ Get the status of the window
 | Not specified | string | the status of the window |
 
 
-### [`close()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L92)
+### [`close()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L91)
 
 Close the window
 
@@ -1743,7 +1743,7 @@ Close the window
 | Not specified | Promise<object> | the options of the window |
 
 
-### [`show()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L107)
+### [`show()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L106)
 
 Shows the window
 
@@ -1752,7 +1752,7 @@ Shows the window
 | Not specified | Promise<ipc.Result> |  |
 
 
-### [`hide()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L116)
+### [`hide()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L115)
 
 Hides the window
 
@@ -1761,7 +1761,7 @@ Hides the window
 | Not specified | Promise<ipc.Result> |  |
 
 
-### [`setTitle(title)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L126)
+### [`setTitle(title)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L125)
 
 Sets the title of the window
 
@@ -1775,7 +1775,7 @@ Sets the title of the window
 | Not specified | Promise<ipc.Result> |  |
 
 
-### [`setSize(opts)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L139)
+### [`setSize(opts)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L138)
 
 Sets the size of the window
 
@@ -1791,7 +1791,7 @@ Sets the size of the window
 | Not specified | Promise<ipc.Result> |  |
 
 
-### [`navigate(path)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L179)
+### [`navigate(path)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L178)
 
 Navigate the window to a given path
 
@@ -1805,7 +1805,7 @@ Navigate the window to a given path
 | Not specified | Promise<ipc.Result> |  |
 
 
-### [`showInspector()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L188)
+### [`showInspector()`](https://github.com/socketsupply/socket/blob/master/api/window.js#L187)
 
 Opens the Web Inspector for the window
 
@@ -1814,7 +1814,7 @@ Opens the Web Inspector for the window
 | Not specified | Promise<object> |  |
 
 
-### [`setBackgroundColor(opts)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L205)
+### [`setBackgroundColor(opts)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L204)
 
 Sets the background color of the window
 
@@ -1832,7 +1832,7 @@ Sets the background color of the window
 | Not specified | Promise<object> |  |
 
 
-### [`setContextMenu(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L215)
+### [`setContextMenu(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L214)
 
 Opens a native context menu.
 
@@ -1846,7 +1846,7 @@ Opens a native context menu.
 | Not specified | Promise<object> |  |
 
 
-### [`showOpenFilePicker(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L232)
+### [`showOpenFilePicker(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L231)
 
 Shows a native open file dialog.
 
@@ -1860,7 +1860,7 @@ Shows a native open file dialog.
 | Not specified | Promise<string[]> | an array of file paths |
 
 
-### [`showSaveFilePicker(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L243)
+### [`showSaveFilePicker(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L242)
 
 Shows a native save file dialog.
 
@@ -1874,7 +1874,7 @@ Shows a native save file dialog.
 | Not specified | Promise<string[]> | an array of file paths |
 
 
-### [`showDirectoryFilePicker(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L254)
+### [`showDirectoryFilePicker(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L253)
 
 Shows a native directory dialog.
 
@@ -1888,7 +1888,7 @@ Shows a native directory dialog.
 | Not specified | Promise<string[]> | an array of file paths |
 
 
-### [`send(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L269)
+### [`send(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L268)
 
 Sends an IPC message to the window or to qthe backend.
 
@@ -1901,7 +1901,7 @@ Sends an IPC message to the window or to qthe backend.
 | options.value | string \| object |  | true | the value to send |
 
 
-### [`openExternal(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L306)
+### [`openExternal(options)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L305)
 
 Opens an URL in the default browser.
 
@@ -1915,7 +1915,7 @@ Opens an URL in the default browser.
 | Not specified | Promise<ipc.Result> |  |
 
 
-### [`addListener(event, cb)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L317)
+### [`addListener(event, cb)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L316)
 
 Adds a listener to the window.
 
@@ -1925,7 +1925,7 @@ Adds a listener to the window.
 | cb | function(*): void |  | false | the callback to call |
 
 
-### [`on(event, cb)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L335)
+### [`on(event, cb)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L334)
 
 Adds a listener to the window. An alias for `addListener`.
 
@@ -1935,7 +1935,7 @@ Adds a listener to the window. An alias for `addListener`.
 | cb | function(*): void |  | false | the callback to call |
 
 
-### [`once(event, cb)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L352)
+### [`once(event, cb)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L351)
 
 Adds a listener to the window. The listener is removed after the first call.
 
@@ -1945,7 +1945,7 @@ Adds a listener to the window. The listener is removed after the first call.
 | cb | function(*): void |  | false | the callback to call |
 
 
-### [`removeListener(event, cb)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L368)
+### [`removeListener(event, cb)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L367)
 
 Removes a listener from the window.
 
@@ -1955,7 +1955,7 @@ Removes a listener from the window.
 | cb | function(*): void |  | false | the callback to remove |
 
 
-### [`removeAllListeners(event)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L381)
+### [`removeAllListeners(event)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L380)
 
 Removes all listeners from the window.
 
@@ -1964,7 +1964,7 @@ Removes all listeners from the window.
 | event | string |  | false | the event to remove the listeners from |
 
 
-### [`off(event, cb)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L397)
+### [`off(event, cb)`](https://github.com/socketsupply/socket/blob/master/api/window.js#L396)
 
 Removes a listener from the window. An alias for `removeListener`.
 
@@ -1974,7 +1974,7 @@ Removes a listener from the window. An alias for `removeListener`.
 | cb | function(*): void |  | false | the callback to remove |
 
 
-## [constants](https://github.com/socketsupply/socket/blob/master/api/window.js#L407)
+## [constants](https://github.com/socketsupply/socket/blob/master/api/window.js#L406)
 
 This is a `VariableDeclaration` named `constants` in `api/window.js`, it's exported but undocumented.
 

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1444,7 +1444,7 @@ declare module "socket:diagnostics/channels" {
          * A no-op for `Channel` instances. This function always returns `false`.
          * @param {string} name
          * @param {object} message
-         * @return Promiise<boolean>
+         * @return Promise<boolean>
          */
         publish(name: string, message: object): Promise<boolean>;
         /**
@@ -1473,7 +1473,7 @@ declare module "socket:diagnostics/channels" {
         unsubscribe(onMessage: any): boolean;
         /**
          * @param {object|any} message
-         * @return Promiise<boolean>
+         * @return Promise<boolean>
          */
         publish(message: object | any): Promise<boolean>;
     }
@@ -3819,44 +3819,79 @@ declare module "socket:dgram" {
     
 }
 declare module "socket:hooks" {
-    const _default: {
-        didGlobalLoad: boolean;
-        didRuntimeInit: boolean;
+    /**
+     * An event dispatched when the runtime has been initialized.
+     */
+    export class InitEvent {
+        constructor();
+    }
+    /**
+     * An event dispatched when the runtime global has been loaded.
+     */
+    export class LoadEvent {
+        constructor();
+    }
+    /**
+     * An event dispatched when the runtime is considered ready.
+     */
+    export class ReadyEvent {
+        constructor();
+    }
+    /**
+     * An interface for registering callbacks for various hooks in
+     * the runtime.
+     */
+    export class Hooks extends EventTarget {
         /**
          * Reference to global object
          * @type {Global}
          */
-        readonly global: Global;
+        get global(): Global;
         /**
-         * Returns document for global
+         * Returns `document` in global.
          * @type {Document}
          */
-        readonly document: Document;
+        get document(): Document;
+        /**
+         * Returns `document` in global.
+         * @type {Window}
+         */
+        get window(): Window;
         /**
          * Predicate for determining if the global document is ready.
          * @type {boolean}
          */
-        readonly isDocumentReady: boolean;
+        get isDocumentReady(): boolean;
         /**
          * Predicate for determining if the global object is ready.
          * @type {boolean}
          */
-        readonly isGlobalReady: boolean;
+        get isGlobalReady(): boolean;
         /**
          * Predicate for determining if the runtime is ready.
          * @type {boolean}
          */
-        readonly isRuntimeReady: boolean;
+        get isRuntimeReady(): boolean;
         /**
          * Predicate for determining if everything is ready.
          * @type {boolean}
          */
-        readonly isReady: boolean;
+        get isReady(): boolean;
         /**
          * Predicate for determining if the runtime is working online.
          * @type {boolean}
          */
-        readonly isOnline: boolean;
+        get isOnline(): boolean;
+        /**
+         * Predicate for determining if the runtime is in a Worker context.
+         * @type {boolean}
+         */
+        get isWorkerContext(): boolean;
+        /**
+         * Predicate for determining if the runtime is in a Window context.
+         * @type {boolean}
+         */
+        get isWindowContext(): boolean;
         /**
          * Wait for the global Window, Document, and Runtime to be ready.
          * The callback function is called exactly once.
@@ -3880,6 +3915,7 @@ declare module "socket:hooks" {
         onInit(callback: Function): Function;
         /**
          * Calls callback when a global exception occurs.
+         * 'error', 'messageerror', and 'unhandledrejection' events are handled here.
          * @param {function} callback
          * @return {function}
          */
@@ -3910,10 +3946,9 @@ declare module "socket:hooks" {
          * @return {function}
          */
         onOffline(callback: Function): Function;
-        addEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        dispatchEvent(event: Event): boolean;
-        removeEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-    };
+        #private;
+    }
+    const _default: Hooks;
     export default _default;
 }
 declare module "socket:test/fast-deep-equal" {

--- a/api/internal/init.js
+++ b/api/internal/init.js
@@ -1,4 +1,4 @@
-/* global CustomEvent, ErrorEvent, Blob */
+/* global Blob */
 /* eslint-disable import/first */
 // mark when runtime did init
 console.assert(
@@ -11,6 +11,9 @@ console.assert(
   'socket:internal/init.js was imported in Node.js. ' +
   'This could lead to undefined behavior.'
 )
+
+import { IllegalConstructor, InvertedPromise } from '../util.js'
+import { Event, CustomEvent, ErrorEvent } from '../events.js'
 
 const RUNTIME_INIT_EVENT_NAME = '__runtime_init__'
 const GlobalWorker = globalThis.Worker || class Worker extends EventTarget {}
@@ -192,7 +195,6 @@ if (typeof globalThis.XMLHttpRequest === 'function') {
   }
 }
 
-import { IllegalConstructor, InvertedPromise } from '../util.js'
 import { applyPolyfills } from '../polyfills.js'
 import { config } from '../application.js'
 import globals from './globals.js'
@@ -270,7 +272,7 @@ class RuntimeXHRPostQueue extends ConcurrentQueue {
     promise.resolve()
 
     if (result.err) {
-      this.dispatchEvent(new CustomEvent('error', { detail: result.err }))
+      this.dispatchEvent(new ErrorEvent('error', { error: result.err }))
     } else {
       const { data } = result
       const detail = { headers, params, data, id }
@@ -282,7 +284,7 @@ class RuntimeXHRPostQueue extends ConcurrentQueue {
 hooks.onLoad(() => {
   if (typeof globalThis.dispatchEvent === 'function') {
     globalThis.__RUNTIME_INIT_NOW__ = performance.now()
-    globalThis.dispatchEvent(new CustomEvent(RUNTIME_INIT_EVENT_NAME))
+    globalThis.dispatchEvent(new Event(RUNTIME_INIT_EVENT_NAME))
   }
 })
 

--- a/api/test/context.js
+++ b/api/test/context.js
@@ -32,7 +32,7 @@ GLOBAL_TEST_RUNNER.onFinish(({ fail }) => {
 
 function onerror (e) {
   const err = e.error || e.stack || e.reason || e.message || e
-  if (err.ignore) return
+  if (err.ignore || err[Symbol.for('socket.test.error.ignore')]) return
   console.error(err)
   if (!finishing && !process.env.DEBUG) {
     process.nextTick(() => {

--- a/test/src/hooks.js
+++ b/test/src/hooks.js
@@ -1,0 +1,79 @@
+import { ErrorEvent } from 'socket:events'
+import hooks from 'socket:hooks'
+import test from 'socket:test'
+
+const initial = {
+  isDocumentReady: hooks.isDocumentReady,
+  isRuntimeReady: hooks.isRuntimeReady,
+  isGlobalReady: hooks.isGlobalReady,
+  isReady: hooks.isReady
+}
+
+const callbacks = {
+  onReady () { callbacks.onReady.called = true },
+  onLoad () { callbacks.onLoad.called = true },
+  onInit () { callbacks.onInit.called = true }
+}
+
+class TestIgnoredError extends Error {
+  [Symbol.for('socket.test.error.ignore')] = true
+}
+
+hooks.onReady(callbacks.onReady)
+hooks.onLoad(callbacks.onLoad)
+hooks.onInit(callbacks.onInit)
+
+test('hooks - initial state', async (t) => {
+  t.ok(initial.isDocumentReady === false, 'isDocumentReady === false')
+  t.ok(initial.isRuntimeReady === false, 'isRuntimeReady === false')
+  t.ok(initial.isGlobalReady === false, 'isGlobalReady === false')
+  t.ok(initial.isReady === false, 'isReady === false')
+})
+
+test('hooks - properties after load', async (t) => {
+  t.ok(hooks.global === globalThis, 'hooks.global')
+  t.ok(hooks.document === globalThis.document, 'hooks.document')
+  t.ok(hooks.window === globalThis.window, 'hooks.window')
+  t.ok(hooks.isDocumentReady === true, 'hooks.isDocumentReady === true')
+  t.ok(hooks.isGlobalReady === true, 'hooks.isGlobalReady === true')
+  t.ok(hooks.isRuntimeReady === true, 'hooks.isRuntimeReady === true')
+  t.ok(hooks.isReady === true, 'hooks.isReady === true')
+  t.ok(typeof hooks.isOnline === 'boolean', 'typeof hooks.isOnline === boolean')
+  t.ok(typeof hooks.isWorkerContext === 'boolean', 'typeof hooks.isWorkerContext === boolean')
+  t.ok(typeof hooks.isWindowContext === 'boolean', 'typeof hooks.isWindowContext === boolean')
+})
+
+test('hooks - callbacks called during load', async (t) => {
+  t.ok(callbacks.onReady.called === true, 'onReady called')
+  t.ok(callbacks.onLoad.called === true, 'onLoad called')
+  t.ok(callbacks.onInit.called === true, 'onInit called')
+})
+
+test('hooks - callbacks called after load', async (t) => {
+  const pending = []
+  pending.push(new Promise((resolve) => hooks.onInit(resolve)))
+  pending.push(new Promise((resolve) => hooks.onLoad(resolve)))
+  pending.push(new Promise((resolve) => hooks.onReady(resolve)))
+  await Promise.all(pending)
+  t.pass('onInit, onLoad, onReady called')
+})
+
+test('hooks - error callback for global errors', async (t) => {
+  let pending = 3
+  queueMicrotask(() => { throw new TestIgnoredError('oops') })
+  setTimeout(() => Promise.reject(new TestIgnoredError('oopsies')))
+  Promise.resolve().then(() => {
+    globalThis.dispatchEvent(new ErrorEvent('messageerror', {
+      error: new TestIgnoredError('ouch')
+    }))
+  })
+  await new Promise((resolve) => {
+    hooks.onError((event) => {
+      if (--pending === 0) {
+        resolve()
+      }
+    })
+  })
+
+  t.pass('error, messageerror, and unhandledrejection handled')
+})

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -2,6 +2,7 @@
 import 'socket:test/context' // this should be first
 
 import './webview.js'
+import './hooks.js'
 import './diagnostics.js'
 import './ipc.js'
 import './os.js'


### PR DESCRIPTION
This PR also introduces new tests to cover the API which should look like:

```js
import hooks from 'socket:hooks'
hooks.onLoad(() => {
  // called when the runtime context has loaded,
  // but not ready or initialized
})

hooks.onReady(() => {
  // called when the runtime is ready, but not initialized
})

hooks.onInit(() => {
  // called when the runtime is initialized
})

hooks.onError((event) => {
  // called when 'error', 'messageerror', and 'unhandledrejection' error
  // events are dispatched on the global object
})

hooks.onData((event) => {
  // called when 'data' events are dispatched on the global object
})

hooks.onMessage((event) => {
  // called when 'message' events are dispatched on the global object
})

hooks.onOnline((event) => {
  // called when 'online' events are dispatched on the global object
 })

hooks.onOffline((event) => {
  // called when 'offline' events are dispatched on the global object
})
 ```