### PR TITLE
Pin API docs version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,7 @@ jobs:
     - name: Check docs and TS definitions
       run: |
         npm run gen
-        git diff --quiet
-        if [$? -eq 1]; then
-          echo "Documentation or TypeScript definitions are out of date. Please run \`npm run gen\`. to resolve"
-          exit 1
-        fi
+        ./bin/ci_changes_check.sh
 
   linux:
     name: Linux

--- a/bin/ci_changes_check.sh
+++ b/bin/ci_changes_check.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+git diff --quiet
+if [ $? -eq 1 ]; then
+    echo "Documentation or TypeScript definitions need update. Please do \`npm run gen\`"
+    exit 1
+fi


### PR DESCRIPTION
This will make links correct for both `master` and release branches.

When version from `VERSION.txt` doesn't exist on remote yet, we should generate docs for that version so links will point to the correct version when we publish a new version before we tag and merge it.