### PR TITLE
Pin TS to version 5.0.4

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1191,7 +1191,7 @@ External docs: https://nodejs.org/dist/latest-v16.x/docs/api/fs.html#fspromisesw
  import { send } from 'socket:ipc'
  ```
 
-## [`emit(name, value, target , options)`](https://github.com/socketsupply/socket/blob/master/api/ipc.js#L1027)
+## [`emit(name, value, target , options)`](https://github.com/socketsupply/socket/blob/master/api/ipc.js#L1031)
 
 Emit event to be dispatched on `window` object.
 
@@ -1203,7 +1203,7 @@ Emit event to be dispatched on `window` object.
 | options | Object |  | true |  |
 
 
-## [`send(command, value, options)`](https://github.com/socketsupply/socket/blob/master/api/ipc.js#L1086)
+## [`send(command, value, options)`](https://github.com/socketsupply/socket/blob/master/api/ipc.js#L1090)
 
 Sends an async IPC command request with parameters.
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "acorn-walk": "8.2.0",
     "esbuild": "^0.16.16",
     "standard": "^17.0.0",
-    "typescript": "^5.0.4"
+    "typescript": "5.0.4"
   },
   "optionalDependencies": {
     "@socketsupply/stream-relay": "^1.0.23-0"


### PR DESCRIPTION
Typescript 5.1.0 has some changes that lead to these errors. We have to figure out how to suppress them or how to change the code to pass checks, but for now we can just use v5.0.5

```
api/diagnostics/index.js:7:10 - error TS6232: Declaration augments declaration in another file. This cannot be serialized.

7 export { channels, window }
           ~~~~~~~~

  api/diagnostics.js:5:1
    5 import * as exports from './diagnostics.js'
      ~~~~~~
    This is the declaration being augmented. Consider moving the augmenting declaration into the same file.

api/diagnostics/index.js:7:20 - error TS6232: Declaration augments declaration in another file. This cannot be serialized.

7 export { channels, window }
                     ~~~~~~

  api/diagnostics.js:5:1
    5 import * as exports from './diagnostics.js'
      ~~~~~~
    This is the declaration being augmented. Consider moving the augmenting declaration into the same file.

api/diagnostics/index.js:13:17 - error TS6232: Declaration augments declaration in another file. This cannot be serialized.

13 export function channel (name) {
                   ~~~~~~~

  api/diagnostics.js:5:1
    5 import * as exports from './diagnostics.js'
      ~~~~~~
    This is the declaration being augmented. Consider moving the augmenting declaration into the same file.
```