### PR TITLE
native ext(fix): prevent template tag on no ext's

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2607,6 +2607,8 @@ int main (const int argc, const char* argv[]) {
         makefileContext["android_native_abis"] = "all";
       }
 
+      makefileContext["__android_native_extensions_context"] = "";
+
       // custom native sources
       for (
         auto const &file :


### PR DESCRIPTION
init makefileContext["__android_native_extensions_context"] with empty value, prevent {{__android_native_extensions_context}} in final output if there are no extensions