### PR TITLE
fix variable name typo

### DIFF
--- a/api/fs/index.js
+++ b/api/fs/index.js
@@ -309,7 +309,7 @@ export function mkdir (path, options, callback) {
   }
 
   const mode = options.mode || 0o777
-  const recursive = options.recurisve === true
+  const recursive = options.recursive === true
 
   if (typeof mode !== 'number') {
     throw new TypeError('mode must be a number.')


### PR DESCRIPTION
typo fix