### PR TITLE
Add rebuild npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:android": "cp -f .ssc.env test | echo && cd test && npm install --silent --no-audit && npm run test:android",
     "test:android-emulator": "cp -f .ssc.env test | echo && cd test && npm install --silent --no-audit && npm run test:android-emulator",
     "test:clean": "cd test && rm -rf dist",
-    "update-stream-relay-source": "./bin/update-stream-relay-source.sh"
+    "update-stream-relay-source": "./bin/update-stream-relay-source.sh",
+    "rebuild": "NO_ANDROID=1 NO_IOS=1 ./bin/publish-npm-modules.sh --link"
   },
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
This adds a shortcut to a very common task. It would be nice to get the rest of the important bins set up as npm scripts to highlight their use some point soon. For now this exposes a the single most important script.