### PR TITLE
chore(deps): TypeScript semver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest-m
-    timeout-minutes: 6
+    timeout-minutes: 9
     needs: lint
 
     steps:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "acorn-walk": "8.2.0",
     "esbuild": "^0.17.19",
     "standard": "^17.1.0",
-    "typescript": "^5.1.3",
+    "typescript": "~5.2.0",
     "urlpattern-polyfill": "^9.0.0",
     "whatwg-fetch": "^3.6.17",
     "whatwg-url": "^13.0.0"


### PR DESCRIPTION
TypeScript doesn't follow SemVer and it can introduce breaking changes in the minor versions.

