### PR TITLE
Fix mobile builds

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2070,7 +2070,7 @@ int main (const int argc, const char* argv[]) {
     bool flagRunUserBuildOnly = optionsWithoutValue.find("--only-build") != optionsWithoutValue.end() || equal(rc["build_only"], "true");
     bool flagAppStore = optionsWithoutValue.find("-s") != optionsWithoutValue.end() || equal(rc["build_app_store"], "true");
     bool flagCodeSign = optionsWithoutValue.find("-c") != optionsWithoutValue.end() || equal(rc["build_codesign"], "true");
-    bool flagBuildHeadless = equal(rc["build_headless"], "true") || (settings["build_headless"] == "true" && !equal(rc["build_headless"], "true"));
+    bool flagBuildHeadless = settings["build_headless"] == "true";
     bool flagRunHeadless = optionsWithoutValue.find("--headless") != optionsWithoutValue.end();
     bool flagShouldRun = optionsWithoutValue.find("--run") != optionsWithoutValue.end() || equal(rc["build_run"], "true");
     bool flagEntitlements = optionsWithoutValue.find("-e") != optionsWithoutValue.end() || equal(rc["build_entitlements"], "true");
@@ -2565,9 +2565,6 @@ int main (const int argc, const char* argv[]) {
     if (isForDesktop) {
       fs::create_directories(paths.platformSpecificOutputPath / "include");
       writeFile(paths.platformSpecificOutputPath / "include" / "user-config-bytes.hh", settings["ini_code"]);
-
-      auto baked = String("const bool __headless = ") + (flagBuildHeadless ? "true" : "false") + ";\n";
-      writeFile(paths.platformSpecificOutputPath / "include" / "baked-vars.hh", baked);
     }
 
     //

--- a/src/common.hh
+++ b/src/common.hh
@@ -227,7 +227,6 @@ namespace SSC {
   extern bool isDebugEnabled ();
   extern const char* getDevHost ();
   extern int getDevPort ();
-  extern const bool isBakedHeadless ();
 
   inline String encodeURIComponent (const String& sSrc);
   inline String decodeURIComponent (const String& sSrc);

--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -84,7 +84,7 @@ MAIN {
 
   bool isCommandMode = false;
   bool isReadingStdin = false;
-  bool isHeadless = isBakedHeadless() || false;
+  bool isHeadless = app.appData["build_headless"] == "true" ? true : false;
   bool isTest = false;
 
   int exitCode = 0;

--- a/src/init.cc
+++ b/src/init.cc
@@ -1,5 +1,4 @@
 #include "common.hh"
-#include "baked-vars.hh" // NOLINT
 
 // These rely on project-specific, compile-time variables.
 namespace SSC {
@@ -13,10 +12,6 @@ namespace SSC {
       (const char*) __ssc_config_bytes,
       sizeof(__ssc_config_bytes)
     ));
-  }
-
-  const bool isBakedHeadless () {
-    return __headless;
   }
 
   const char* getDevHost () {


### PR DESCRIPTION
Mobile builds were broken by #564 

This also re-uses `[build] headless` from the baked-in config and simplifies build significantly.