### PR TITLE
import 'socket:internal/init' when interactive

### DIFF
--- a/src/core/runtime-preload.hh
+++ b/src/core/runtime-preload.hh
@@ -130,11 +130,13 @@ namespace SSC {
       "})();                                                                 \n"
     );
 
-    if (preloadOptions.module) {
-      preload += "import 'socket:internal/init'\n";
-    } else {
-      preload += "import('socket:internal/init');\n";
-    }
+    preload += (
+      "document.addEventListener('readystatechange', () => {                 \n"
+      "  if (document.readyState === 'interactive') {                        \n"
+      "    import('socket:internal/init');                                   \n"
+      "  }                                                                   \n"
+      "});                                                                   \n"
+    );
 
     return preload;
   }


### PR DESCRIPTION
This will give user space a chance to declare an [ImportMap](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) before any scripts are loaded, include `socket:internal/init`