### PR TITLE
Make `ssc build` fail early when `[meta] build_identifier` is not provided

### DIFF
--- a/api/config.md
+++ b/api/config.md
@@ -67,13 +67,14 @@ flags |  |  Advanced Compiler Settings for debug purposes (ie C++ compiler -g, e
 
 Key | Default Value | Description
 :--- | :--- | :---
-bundle_identifier |  |  A unique ID that identifies the bundle (used by all app stores). Required field.
+bundle_identifier |  |  A unique ID that identifies the bundle (used by all app stores). It's required when `[meta] type` is not `"extension"`.
 copyright |  |  A string that gets used in the about dialog and package meta info.
 description |  |  A short description of the app.
 file_limit |  |  Set the limit of files that can be opened by your process.
 lang |  |  Localization
 maintainer |  |  A String used in the about dialog and meta info.
 title |  |  The title of the app used in metadata files. This is NOT a window title. Can contain spaces and special characters. Defaults to name in a [build] section.
+type |  |  Builds an extension when set to "extension".
 version |  |  A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
 
 # Section `android`

--- a/api/config.md
+++ b/api/config.md
@@ -67,7 +67,7 @@ flags |  |  Advanced Compiler Settings for debug purposes (ie C++ compiler -g, e
 
 Key | Default Value | Description
 :--- | :--- | :---
-bundle_identifier |  |  A unique ID that identifies the bundle (used by all app stores). It's required when `[meta] type` is not `"extension"`.
+bundle_identifier |  |  A unique ID that identifies the bundle (used by all app stores). It's required when `[meta] type` is not `"extension"`. It should be in a reverse DNS notation https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier#discussion
 copyright |  |  A string that gets used in the about dialog and package meta info.
 description |  |  A short description of the app.
 file_limit |  |  Set the limit of files that can be opened by your process.

--- a/api/config.md
+++ b/api/config.md
@@ -74,8 +74,7 @@ file_limit |  |  Set the limit of files that can be opened by your process.
 lang |  |  Localization
 maintainer |  |  A String used in the about dialog and meta info.
 title |  |  The title of the app used in metadata files. This is NOT a window title. Can contain spaces and special characters. Defaults to name in a [build] section.
-type |  |  Builds an extension when set to "extension".
-version |  |  A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
+version | "" |  Builds an extension when set to "extension". type = "" A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
 
 # Section `android`
 

--- a/api/config.md
+++ b/api/config.md
@@ -40,9 +40,9 @@ Key | Default Value | Description
 copy | "src" |  ssc will copy everything in this directory to the build output directory. This is useful when you want to avoid bundling or want to use tools like vite, webpack, rollup, etc. to build your project and then copy output to the Socket bundle resources directory.
 env |  |  An list of environment variables, separated by commas.
 flags |  |  Advanced Compiler Settings (ie C++ compiler -02, -03, etc).
-headless |  |  If true, the window will never be displayed.
+headless | false |  If true, the window will never be displayed.
 name |  |  The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
-output |  |  The binary output path. It's recommended to add this path to .gitignore.
+output | "build" |  The binary output path. It's recommended to add this path to .gitignore.
 
 # Section `build.watch`
 
@@ -54,8 +54,8 @@ sources |  |
 
 Key | Default Value | Description
 :--- | :--- | :---
-root |  |  Make root open index.html
-watch |  | 
+root | "/" |  Make root open index.html
+watch | false |  Enable watch mode
 
 # Section `debug`
 
@@ -67,7 +67,7 @@ flags |  |  Advanced Compiler Settings for debug purposes (ie C++ compiler -g, e
 
 Key | Default Value | Description
 :--- | :--- | :---
-bundle_identifier |  |  A unique ID that identifies the bundle (used by all app stores).
+bundle_identifier |  |  A unique ID that identifies the bundle (used by all app stores). Required field.
 copyright |  |  A string that gets used in the about dialog and package meta info.
 description |  |  A short description of the app.
 file_limit |  |  Set the limit of files that can be opened by your process.

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2413,9 +2413,19 @@ int main (const int argc, const char* argv[]) {
   createSubcommand("build", buildOptions, true, [&](Map optionsWithValue, std::unordered_set<String> optionsWithoutValue) -> void {
     auto isForExtensionOnly = settings["meta_type"] == "extension" || settings["build_type"] == "extension";
 
-    if (settings["meta_bundle_identifier"].size() == 0 !isForExtensionOnly) {
-      log("ERROR: [meta] bundle_identifier option is empty");
-      exit(1);
+    if (!isForExtensionOnly) {
+      if (settings["meta_bundle_identifier"].size() == 0) {
+        log("ERROR: [meta] bundle_identifier option is empty");
+        exit(1);
+      }
+
+      std::regex reverseDnsPattern(R"(^[a-z0-9]+([-a-z0-9]*[a-z0-9]+)?(\.[a-z0-9]+([-a-z0-9]*[a-z0-9]+)?)*$)", std::regex::icase);
+      if (!std::regex_match(settings["meta_bundle_identifier"], reverseDnsPattern)) {
+          log("ERROR: [meta] bundle_name has invalid format :" + settings["meta_bundle_identifier"]);
+          log("Please use reverse DNS notation (https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier#discussion)");
+          exit(1);
+      }
+
     }
 
     String argvForward = "";

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2411,7 +2411,9 @@ int main (const int argc, const char* argv[]) {
   // Insert the elements of runOptions into buildOptions
   buildOptions.insert(buildOptions.end(), runOptions.begin(), runOptions.end());
   createSubcommand("build", buildOptions, true, [&](Map optionsWithValue, std::unordered_set<String> optionsWithoutValue) -> void {
-    if (settings["meta_bundle_identifier"].size() == 0) {
+    auto isForExtensionOnly = settings["meta_type"] == "extension" || settings["build_type"] == "extension";
+
+    if (settings["meta_bundle_identifier"].size() == 0 !isForExtensionOnly) {
       log("ERROR: [meta] bundle_identifier option is empty");
       exit(1);
     }
@@ -2646,7 +2648,6 @@ int main (const int argc, const char* argv[]) {
     }
 
     bool isForDesktop = !flagBuildForIOS && !flagBuildForAndroid;
-    auto isForExtensionOnly = settings["meta_type"] == "extension" || settings["build_type"] == "extension";
 
     if (isForDesktop) {
       fs::create_directories(paths.platformSpecificOutputPath / "include");

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -975,10 +975,6 @@ void runIOSSimulator (const Path& path, Map& settings) {
     log("ERROR: [ios] simulator_device option is empty");
     exit(1);
   }
-  if (settings["meta_bundle_identifier"].size() == 0) {
-    log("ERROR: [meta] bundle_identifier option is empty");
-    exit(1);
-  }
   String deviceType;
   StringStream listDeviceTypesCommand;
   listDeviceTypesCommand
@@ -2415,6 +2411,11 @@ int main (const int argc, const char* argv[]) {
   // Insert the elements of runOptions into buildOptions
   buildOptions.insert(buildOptions.end(), runOptions.begin(), runOptions.end());
   createSubcommand("build", buildOptions, true, [&](Map optionsWithValue, std::unordered_set<String> optionsWithoutValue) -> void {
+    if (settings["meta_bundle_identifier"].size() == 0) {
+      log("ERROR: [meta] bundle_identifier option is empty");
+      exit(1);
+    }
+
     String argvForward = "";
     String targetPlatform = optionsWithValue["--platform"];
     String additionalBuildArgs = "";

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1453,6 +1453,7 @@ maintainer = "Beep Boop Corp."
 title = "Beep Boop"
 
 ; Builds an extension when set to "extension".
+; default value: ""
 ; type = ""
 
 ; A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1394,16 +1394,19 @@ env = USER, TMPDIR, PWD
 flags = -O3
 
 ; If true, the window will never be displayed.
+; default value: false
 headless = false
 
 ; The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
 name = "beepboop"
 
 ; The binary output path. It's recommended to add this path to .gitignore.
+; default value: "build"
 output = "build"
 
 ; The build script
 ; script = "npm run build"
+
 
 [build.watch]
 sources = "src"
@@ -1411,7 +1414,11 @@ sources = "src"
 
 [webview]
 ; Make root open index.html
+; default value: "/"
 root = "/"
+
+; Enable watch mode
+; default value: false
 watch = false
 
 
@@ -1422,7 +1429,7 @@ flags = "-g"
 
 [meta]
 
-; A unique ID that identifies the bundle (used by all app stores).
+; A unique ID that identifies the bundle (used by all app stores). Required field.
 bundle_identifier = "com.beepboop"
 
 ; A string that gets used in the about dialog and package meta info.

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1429,7 +1429,7 @@ flags = "-g"
 
 [meta]
 
-; A unique ID that identifies the bundle (used by all app stores). Required field.
+; A unique ID that identifies the bundle (used by all app stores). It's required when `[meta] type` is not `"extension"`.
 bundle_identifier = "com.beepboop"
 
 ; A string that gets used in the about dialog and package meta info.
@@ -1449,6 +1449,9 @@ maintainer = "Beep Boop Corp."
 
 ; The title of the app used in metadata files. This is NOT a window title. Can contain spaces and special characters. Defaults to name in a [build] section.
 title = "Beep Boop"
+
+; Builds an extension when set to "extension".
+; type = ""
 
 ; A string that indicates the version of the application. It should be a semver triple like 1.2.3. Defaults to 1.0.0.
 version = 1.0.0

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1429,7 +1429,9 @@ flags = "-g"
 
 [meta]
 
-; A unique ID that identifies the bundle (used by all app stores). It's required when `[meta] type` is not `"extension"`.
+; A unique ID that identifies the bundle (used by all app stores).
+; It's required when `[meta] type` is not `"extension"`.
+; It should be in a reverse DNS notation https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier#discussion
 bundle_identifier = "com.beepboop"
 
 ; A string that gets used in the about dialog and package meta info.


### PR DESCRIPTION
TODO:
- [x] check that `build_identifier` is a valid string
- [x] check for other required fields (checks are there already)

Bonus:
- [x] more config docs