### PR TITLE
fix(scr/cli/cli.cc): make `[build] script` phase run before `[build] copy` phase

### DIFF
--- a/api/CONFIG.md
+++ b/api/CONFIG.md
@@ -43,7 +43,7 @@ flags |  |  Advanced Compiler Settings (ie C++ compiler -02, -03, etc).
 headless | false |  If true, the window will never be displayed.
 name |  |  The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
 output | "build" |  The binary output path. It's recommended to add this path to .gitignore.
-script |  |  The build script
+script |  |  The build script. It runs before the `[build] copy` phase.
 
 # Section `build.watch`
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2640,12 +2640,6 @@ int main (const int argc, const char* argv[]) {
       additionalBuildArgs += " --test=true";
     }
 
-    auto copyMapFiles = handleBuildPhaseForCopyMappedFiles(
-      settings,
-      targetPlatform,
-      pathResourcesRelativeToUserBuild
-    );
-
     handleBuildPhaseForUserScript(
       settings,
       targetPlatform,
@@ -2653,6 +2647,12 @@ int main (const int argc, const char* argv[]) {
       oldCwd,
       additionalBuildArgs,
       true
+    );
+
+    auto copyMapFiles = handleBuildPhaseForCopyMappedFiles(
+      settings,
+      targetPlatform,
+      pathResourcesRelativeToUserBuild
     );
 
     String flags;

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1413,7 +1413,7 @@ name = "{{project_name}}"
 ; default value: "build"
 output = "build"
 
-; The build script
+; The build script. It runs before the `[build] copy` phase.
 ; script = "npm run build"
 
 


### PR DESCRIPTION
This is important so `vite` or `create-react-app` build step (`[build] script = "npm run build"`) can create a build and then `[build] copy = "<dist>"` will move the built app to the Socket app resources