### PR TITLE
feat(cli): respect NO_ANDROID=1 in `ssc build`

### DIFF
--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -558,6 +558,10 @@ function first_time_experience_setup() {
   export BUILD_ANDROID="1"
   local target="$1"
 
+  if [[ -n "$NO_ANDROID" ]]; then
+    unset BUILD_ANDROID
+  fi
+
   if [ -z "$target" ] || [[ "$target" == "linux" ]]; then
     if [[ "$(host_os)" == "Linux" ]]; then
       local package_manager="$(determine_package_manager)"


### PR DESCRIPTION
This skips the Android download prompt when running `NO_ANDROID=1 ssc build`