### PR TITLE
fix: encode uncaught exception before writing to ipc

### DIFF
--- a/npm/packages/@socketsupply/socket-node/index.js
+++ b/npm/packages/@socketsupply/socket-node/index.js
@@ -26,7 +26,7 @@ class API {
       this.#write(`ipc://process.exit?value=${exitCode}`)
     })
     process.on('uncaughtException', (err) => {
-      this.#write(`ipc://stderr?value=${err}`)
+      this.#write(`ipc://stderr?value=${encodeURIComponent(String(err))}`)
     })
 
     // redirect console


### PR DESCRIPTION
This fix encodes any `\n` characters for the ipc://stderr message.

The `String(…)` call is not strictly necessary, but keeps tsc satisfied.
