### PR TITLE
fix(ipc): stringify the value passed to `process.write`

### DIFF
--- a/api/window.js
+++ b/api/window.js
@@ -288,7 +288,7 @@ export class ApplicationWindow {
       return await ipc.send('process.write', {
         index: this.#senderWindowIndex,
         event: options.event,
-        value: value ?? ''
+        value: value !== undefined ? JSON.stringify(value) : null
       })
     }
 


### PR DESCRIPTION
The value is expected by socket-node to be valid JSON:
  https://github.com/socketsupply/socket/blob/7bcf246bbaf96d93447df41e3c851d36ec3fd65b/npm/packages/@socketsupply/socket-node/index.js#L123
