### PR TITLE
feat: write backend logs to std::cout/std::cerr and forward them to Console.app on macOS

### DIFF
--- a/src/desktop/main.cc
+++ b/src/desktop/main.cc
@@ -279,6 +279,8 @@ MAIN {
   }
 
   auto onStdErr = [&](auto err) {
+    std::cerr << "\033[31m" + err + "\033[0m";
+
     for (auto w : windowManager.windows) {
       if (w != nullptr) {
         auto window = windowManager.getWindow(w->opts.index);
@@ -374,6 +376,16 @@ MAIN {
             window->resolvePromise(message.seq, OK_STATE, value);
           }
         }
+        return;
+      }
+
+      if (message.name == "stdout") {
+        std::cout << value;
+        return;
+      }
+
+      if (message.name == "stderr") {
+        std::cerr << "\033[31m" + value + "\033[0m";
         return;
       }
     });


### PR DESCRIPTION
This PR is useful when running `./path/to/MyApp.app/Contents/MacOS/MyApp` from the terminal, as it lets you view the backend logs without opening up Console.app (which wasn't possible before this PR) or, worse, saving to a logfile that you tail manually. The reason I added Console.app support anyway is for viewing logs when running the app via `open ./path/to/MyApp.app` or clicking the app icon from the Dock.

Before this PR, saving to a logfile was your only choice.

- feat: write backend logs to stdout/stderr
- feat(mac): forward backend logs to Console.app
- fix(backend): move stdout/stderr handling off of main thread
  *This also moves IPC message parsing off the main thread.*
