### PR TITLE
chore: use pnpm workspaces

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+no-lockfile=true
+ignore-workspace-root-check=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - npm/packages/@socketsupply/socket-node


### PR DESCRIPTION
- Users can decide for themselves between npm or pnpm
- Disabled lockfile generation

## Benefits of this PR
- pnpm users don't have to set up the `pnpm-workspace.yaml` file themselves (which tells pnpm to install `@socketsupply/socket-node` dependencies when `pnpm install` is used in the root directory)
- pnpm has a [changesets guide](https://pnpm.io/using-changesets) with a Github CI action that automatically releases. Adding changesets in the future will also let you more easily align the package versions of `@socketsupply/socket` and `@socketsupply/socket-node` (see [Fixed Packages](https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md) in their docs)
