### PR TITLE
feat(cli): allow subcommands, variables, and relative paths in extension compiler/linker flags

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -4617,7 +4617,9 @@ int main (const int argc, const char* argv[]) {
                     auto match = std::smatch{};
                     while (std::regex_search(value, match, std::regex("\\$\\((.*?)\\)"))) {
                       auto subcommand = match[1].str();
-                      log("Running subcommand: " + subcommand);
+                      if (getEnv("DEBUG") == "1" || getEnv("VERBOSE") == "1") {
+                        log("Running subcommand: " + subcommand);
+                      }
                       auto proc = exec(subcommand);
                       if (proc.exitCode != 0) {
                         log("ERROR: failed to run subcommand: " + subcommand);


### PR DESCRIPTION
Here's an example `socket.ini` for a native extension:
```ini
[meta]
name = "foo"
type = "extension"

[extension]
sources[] = ./src/extension.cc

[extension.compiler]
flags[] = -I./include

[extension.linker]
flags[] = $(pkg-config libsodium --libs)
flags[] = -L$PWD/node_modules/zeromq/build/libzmq/lib
flags[] = -lzmq
```

- Only values of `flags[]` are evaluated by this PR.
- Each value is searched for `./` and `../` paths to be resolved relative to the extension's root directory.
- Each value is searched for `$(…)` and replaces it with its execution result (trimmed and with `\n` replaced by spaces).
- Each value is searched for `$abc_123`-like substrings and replaces them with matching environment variables. Not sure if this is super necessary (the `exec` call when compiling/linking might already evaluate these?), but I wanted to make sure `$PWD` was replaced with the extension's root directory, instead of being transformed into the project root. I'm open to removing this though, if we feel like `$PWD` *should* point to the project root.