### PR TITLE
feat(extension): add `sapi_ipc_reply_with_error` function

### DIFF
--- a/include/socket/extension.h
+++ b/include/socket/extension.h
@@ -1105,6 +1105,15 @@ extern "C" {
   bool sapi_ipc_reply (const sapi_ipc_result_t* result);
 
   /**
+   * Convenience method for replying with an error message.
+    * @param result - An IPC request result
+    * @param error  - An error message to include in the result
+    * @return `true` if successful, otherwise `false`
+    */
+  SOCKET_RUNTIME_EXTENSION_EXPORT
+  bool sapi_ipc_reply_with_error (sapi_ipc_result_t* result, const char* error);
+
+  /**
    * Send JSON to the bridge to propagate to the WebView.
    * @param context - An extension context
    * @param message - The IPC message this send request sources from

--- a/src/extension/ipc.cc
+++ b/src/extension/ipc.cc
@@ -112,6 +112,15 @@ bool sapi_ipc_router_unlisten (
   return ctx->router->unlisten(name, token);
 }
 
+bool sapi_ipc_reply_with_error (sapi_ipc_result_t* result, const char* error) {
+  sapi_context* context = sapi_ipc_result_get_context(result);
+  sapi_json_string* errorJson = sapi_json_string_create(context, error);
+  sapi_json_object* errorObject = sapi_json_object_create(context);
+  sapi_json_object_set(errorObject, "message", errorJson);
+  sapi_ipc_result_set_json_error(result, ((sapi_json_any*)errorObject));
+  return sapi_ipc_reply(result);
+}
+
 bool sapi_ipc_reply (const sapi_ipc_result_t* result) {
   if (result == nullptr) return false;
   if (result->context == nullptr) return false;


### PR DESCRIPTION
```c++
#include <socket/extension.h>

bool my_extension_function(sapi_ipc_result_t* result) {
  // Do some work...

  if (error_occurred) {
    const char* error_message = "An error occurred";
    return sapi_ipc_reply_with_error(result, error_message);
  } else {
    // Send the result...
    return sapi_ipc_reply(result);
  }
}
```