### PR TITLE
fix(ipc): omit `value` parameter if value is undefined

### DIFF
--- a/api/ipc.js
+++ b/api/ipc.js
@@ -1011,11 +1011,13 @@ class IPCSearchParams extends URLSearchParams {
       params = null
     }
     super({
-      value,
       index: globalThis.__args?.index ?? 0,
       ...params,
       seq: 'R' + nextSeq++
     })
+    if (value !== undefined) {
+      this.set('value', value)
+    }
     if (nonce) {
       this.set('nonce', nonce)
     }


### PR DESCRIPTION
I've seen instances where `value=undefined` was included, which isn't a huge deal, but also not intended behavior.