### PR TITLE
feat(extension): add `sapi_ipc_send_chunk` and `sapi_ipc_send_event`

### DIFF
--- a/include/socket/extension.h
+++ b/include/socket/extension.h
@@ -1097,6 +1097,51 @@ extern "C" {
   );
 
   /**
+   * Write a chunk to the HTTP response associated with the IPC result.
+   *
+   * ⚠️ You must have called `sapi_ipc_result_set_header` with a `Transfer-Encoding`
+   * header of `chunked` to use this function.
+   *
+   * ⚠️ You must call `sapi_ipc_reply` before calling this function.
+   *
+   * @param result      - An IPC request result
+   * @param chunk       - The chunk to write
+   * @param chunk_size  - The size of the chunk
+   * @param finished    - `true` if this is the last chunk to write
+   */
+  SOCKET_RUNTIME_EXTENSION_EXPORT
+  bool sapi_ipc_send_chunk (
+    sapi_ipc_result_t* result,
+    const char* chunk,
+    size_t chunk_size,
+    bool finished
+  );
+
+  /**
+   * Write an event to the HTTP response associated with the IPC result.
+   *
+   * ⚠️ You must have called `sapi_ipc_result_set_header` with a `Content-Type`
+   * header of `text/event-stream` to use this function.
+   *
+   * ⚠️ You must call `sapi_ipc_reply` before calling this function.
+   *
+   * ⚠️ The `name` and `data` arguments must be null-terminated strings. Either
+   * can be empty as long as it's null-terminated and the other is not empty.
+   *
+   * @param result   - An IPC request result
+   * @param name     - The event name
+   * @param data     - The event data
+   * @param finished - `true` if this is the last event to write
+   */
+  SOCKET_RUNTIME_EXTENSION_EXPORT
+  bool sapi_ipc_send_event (
+    sapi_ipc_result_t* result,
+    const char* name,
+    const char* data,
+    bool finished
+  );
+
+  /**
    * Creates a "reply" for an IPC route request.
    * @param result - An IPC request result
    * @return `true` if successful, otherwise `false`

--- a/include/socket/extension.h
+++ b/include/socket/extension.h
@@ -1104,6 +1104,8 @@ extern "C" {
    *
    * ⚠️ You must call `sapi_ipc_reply` before calling this function.
    *
+   * Supported on iOS/macOS only.
+   *
    * @param result      - An IPC request result
    * @param chunk       - The chunk to write
    * @param chunk_size  - The size of the chunk
@@ -1127,6 +1129,8 @@ extern "C" {
    *
    * ⚠️ The `name` and `data` arguments must be null-terminated strings. Either
    * can be empty as long as it's null-terminated and the other is not empty.
+   *
+   * Supported on iOS/macOS only.
    *
    * @param result   - An IPC request result
    * @param name     - The event name

--- a/src/core/core.hh
+++ b/src/core/core.hh
@@ -126,6 +126,8 @@ namespace SSC {
     char* body = nullptr;
     size_t length = 0;
     String headers = "";
+    std::shared_ptr<std::function<bool(const char*, const char*, bool)>> event_stream;
+    std::shared_ptr<std::function<bool(const char*, size_t, bool)>> chunk_stream;
   };
 
   using Posts = std::map<uint64_t, Post>;

--- a/src/ipc/bridge.cc
+++ b/src/ipc/bridge.cc
@@ -2731,7 +2731,7 @@ namespace SSC::IPC {
     size_t size,
     ResultCallback callback
   ) {
-    auto message = Message { uri };
+    auto message = Message(uri, true);
     return this->invoke(message, bytes, size, callback);
   }
 

--- a/src/ipc/bridge.cc
+++ b/src/ipc/bridge.cc
@@ -2155,10 +2155,15 @@ static void registerSchemeHandler (Router *router) {
     if (result.post.event_stream != nullptr) {
       *result.post.event_stream = [task](const char* name, const char* data,
                                          bool finished) {
+        auto event_name = [NSString stringWithUTF8String:name];
+        auto event_data = [NSString stringWithUTF8String:data];
         auto event =
-            [NSString stringWithFormat:@"event: %@\ndata: %@\n\n",
-                                       [NSString stringWithUTF8String:name],
-                                       [NSString stringWithUTF8String:data]];
+            event_name.length > 0 && event_data.length > 0
+                ? [NSString stringWithFormat:@"event: %@\ndata: %@\n\n",
+                                             event_name, event_data]
+            : event_data.length > 0
+                ? [NSString stringWithFormat:@"data: %@\n\n", event_data]
+                : [NSString stringWithFormat:@"event: %@\n\n", event_name];
 
         [task didReceiveData:[event dataUsingEncoding:NSUTF8StringEncoding]];
         if (finished) {

--- a/src/ipc/ipc.cc
+++ b/src/ipc/ipc.cc
@@ -32,6 +32,7 @@ namespace SSC::IPC {
     this->seq = message.seq;
     this->uri = message.uri;
     this->args = message.args;
+    this->isHTTP = message.isHTTP;
   }
 
   Message::Message (const String& source, char *bytes, size_t size)

--- a/src/ipc/ipc.hh
+++ b/src/ipc/ipc.hh
@@ -134,6 +134,7 @@ namespace SSC::IPC {
       int index = -1;
       Seq seq = "";
       Map args;
+      bool isHTTP = false;
 
       Message () = default;
       Message (const Message& message);
@@ -259,6 +260,12 @@ namespace SSC::IPC {
       bool invoke (const String& msg, const char *bytes, size_t size);
       bool invoke (
         const String& msg,
+        const char *bytes,
+        size_t size,
+        ResultCallback callback
+      );
+      bool invoke (
+        const Message& msg,
         const char *bytes,
         size_t size,
         ResultCallback callback

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -853,6 +853,7 @@ namespace SSC {
                             DWORD actual;
                             HRESULT r;
                             auto msg = IPC::Message(uri);
+                            msg.isHTTP = true;
                             // TODO(trevnorris): Make sure index and seq are set.
                             if (w->bridge->router.hasMappedBuffer(msg.index, msg.seq)) {
                               IPC::MessageBuffer buf = w->bridge->router.getMappedBuffer(msg.index, msg.seq);


### PR DESCRIPTION
### ⚠️ Only MacOS and iOS are supported by this PR. I don't have time to implement the other platforms at the moment.

- Before calling sapi_ipc_send_chunk, you must first set the Transfer-Encoding header to `chunked` and then call sapi_ipc_reply.
- When using sapi_ipc_send_chunk, the frontend should use XMLHttpRequest. Currently, the Fetch API does not support response streaming in WebKit.
- Before calling sapi_ipc_send_event, you must first set the Content-Type header to `text/event-stream` and then call sapi_ipc_reply.
- When using sapi_ipc_send_event, the frontend should use EventSource.
