### PR TITLE
Some fixes to `send_event` and `send_chunk` extension APIs

### DIFF
--- a/src/extension/context.cc
+++ b/src/extension/context.cc
@@ -15,7 +15,7 @@ sapi_context_t* sapi_context_create (
     : parent->memory.alloc<sapi_context_t>(parent, parent);
 
   if (retained || parent == nullptr) {
-    context->retained = true;
+    context->retain();
   }
 
   return context;
@@ -62,7 +62,7 @@ void sapi_context_retain (sapi_context_t* ctx) {
 
 bool sapi_context_retained (const sapi_context_t* ctx) {
   if (ctx == nullptr) return false;
-  return ctx->retained;
+  return ctx->retain_count > 0;
 }
 
 void sapi_context_release (sapi_context_t* ctx) {
@@ -71,8 +71,9 @@ void sapi_context_release (sapi_context_t* ctx) {
     sapi_debug(ctx, "'context_release' is not allowed.");
     return;
   }
-  ctx->release();
-  delete ctx;
+  if (ctx->release()) {
+    delete ctx;
+  }
 }
 
 uv_loop_t* sapi_context_get_loop (const sapi_context_t* ctx) {

--- a/src/extension/extension.cc
+++ b/src/extension/extension.cc
@@ -139,12 +139,19 @@ namespace SSC {
   }
 
   void Extension::Context::retain () {
-    this->retained = true;
+    this->retain_count++;
   }
 
-  void Extension::Context::release () {
-    this->retained = false;
-    this->memory.release();
+  bool Extension::Context::release () {
+    if (this->retain_count == 0) {
+      debug("WARN - Double release of SSC extension context");
+      return false;
+    }
+    if (--this->retain_count == 0) {
+      this->memory.release();
+      return true;
+    }
+    return false;
   }
 
   Extension::Context* Extension::getContext (const String& name) {

--- a/src/extension/extension.hh
+++ b/src/extension/extension.hh
@@ -84,7 +84,7 @@ namespace SSC {
         Memory memory;
         State state = State::None;
         Error error;
-        std::atomic<bool> retained = false;
+        std::atomic<unsigned int> retain_count = 0;
         PolicyMap policies;
         Map config;
 
@@ -96,7 +96,7 @@ namespace SSC {
         Context (const Context& context, IPC::Router* router);
 
         void retain ();
-        void release ();
+        bool release ();
 
         void setPolicy (const String& name, bool allowed);
         const Policy& getPolicy (const String& name) const;

--- a/src/extension/ipc.cc
+++ b/src/extension/ipc.cc
@@ -19,20 +19,18 @@ bool sapi_ipc_router_map (
     return false;
   }
 
-  auto router = ctx->router;
-  auto context = sapi_context_create(ctx, true);
-
-  if (context == nullptr) {
-    return false;
-  }
-
-  context->data = data;
-  ctx->router->map(name, [context, data, callback](
+  ctx->router->map(name, [ctx, data, callback](
     auto& message,
     auto router,
     auto reply
   ) mutable {
     auto msg = SSC::IPC::Message(message);
+    auto context = sapi_context_create(ctx, true);
+    if (context == nullptr) {
+      return;
+    }
+
+    context->data = data;
     context->internal = new SSC::IPC::Router::ReplyCallback(reply);
     callback(
       context,

--- a/src/extension/ipc.cc
+++ b/src/extension/ipc.cc
@@ -137,8 +137,7 @@ bool sapi_ipc_reply (const sapi_ipc_result_t* result) {
   }
 
   // if retained, then then caller must eventually call `sapi_context_release()`
-  if (!context->retained) {
-    context->release();
+  if (context->release()) {
     delete context;
   }
 

--- a/src/extension/ipc.cc
+++ b/src/extension/ipc.cc
@@ -160,6 +160,9 @@ bool sapi_ipc_send_chunk (
   }
   auto send_chunk_ptr = result->post.chunk_stream;
   if (send_chunk_ptr == nullptr) {
+    debug(
+        "Cannot use 'sapi_ipc_send_chunk' before setting the \"Transfer-Encoding\""
+        " header to \"chunked\"");
     return false;
   }
   bool success = (*send_chunk_ptr)(chunk, chunk_size, finished);
@@ -185,6 +188,9 @@ bool sapi_ipc_send_event (
   }
   auto send_event_ptr = result->post.event_stream;
   if (send_event_ptr == nullptr) {
+    debug(
+        "Cannot use 'sapi_ipc_send_event' before setting the \"Content-Type\""
+        " header to \"text/event-stream\"");
     return false;
   }
   bool success = (*send_event_ptr)(name, data, finished);


### PR DESCRIPTION
- Correctly retain the context when:
  - Transfer-Encoding header is set to `chunked`
  - Content-Type header is set to `text/event-stream`
- Add debug log for incorrect use (failure to set expected header)