### PR TITLE
fix(cli.cc): fix push notification permission

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -4510,7 +4510,7 @@ int main (const int argc, const char* argv[]) {
         );
       }
 
-      if (settings["permissions_allow_push_notifications"] != "false") {
+      if (settings["permissions_allow_push_notifications"] == "true") {
         entitlementSettings["configured_entitlements"] += (
           "  <key>com.apple.developer.usernotifications.filtering</key>\n"
           "  <true/>\n"

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -4510,9 +4510,14 @@ int main (const int argc, const char* argv[]) {
         );
       }
 
-      if (settings["permissions_allow_notifications"] != "false") {
+      if (settings["permissions_allow_push_notifications"] != "false") {
         entitlementSettings["configured_entitlements"] += (
           "  <key>com.apple.developer.usernotifications.filtering</key>\n"
+          "  <true/>\n"
+        );
+        
+        entitlementSettings["configured_entitlements"] += (
+          "  <key>com.apple.developer.location.push</key>\n"
           "  <true/>\n"
         );
       }
@@ -4520,11 +4525,6 @@ int main (const int argc, const char* argv[]) {
       if (settings["permissions_allow_geolocation"] != "false") {
         entitlementSettings["configured_entitlements"] += (
           "  <key>com.apple.security.personal-information.location</key>\n"
-          "  <true/>\n"
-        );
-
-        entitlementSettings["configured_entitlements"] += (
-          "  <key>com.apple.developer.location.push</key>\n"
           "  <true/>\n"
         );
       }


### PR DESCRIPTION
Enable system push notifications on iOS/macOS with correct entitlements:

- [`com.apple.developer.location.push`](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_location_push?language=objc)
- [`com.apple.developer.usernotifications.filtering`](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_usernotifications_filtering?language=objc)

These SHOULD be enabled with the `[permissions] allow_push_notifications` permission, which is `false` by default. These permissions require entitlement permissions from Apple.