### PR TITLE
fix(mac): avoid "This task has already been stopped" exceptions

### DIFF
--- a/include/socket/extension.h
+++ b/include/socket/extension.h
@@ -1148,6 +1148,8 @@ extern "C" {
    *
    * ⚠️ You must call `sapi_ipc_reply` before calling this function.
    *
+   * ⚠️ This must be called on the main thread (using `sapi_context_dispatch` if necessary).
+   *
    * Supported on iOS/macOS only.
    *
    * @param result      - An IPC request result
@@ -1173,6 +1175,8 @@ extern "C" {
    *
    * ⚠️ The `name` and `data` arguments must be null-terminated strings. Either
    * can be empty as long as it's null-terminated and the other is not empty.
+   *
+   * ⚠️ This must be called on the main thread (using `sapi_context_dispatch` if necessary).
    *
    * Supported on iOS/macOS only.
    *

--- a/src/ipc/bridge.cc
+++ b/src/ipc/bridge.cc
@@ -2646,7 +2646,7 @@ static void registerSchemeHandler (Router *router) {
 
     NSData* data = nullptr;
     if (result.post.event_stream != nullptr) {
-      *result.post.event_stream = [task](const char* name, const char* data,
+      *result.post.event_stream = [task, tasks](const char* name, const char* data,
                                          bool finished) {
         if (![tasks containsObject: task]) {
           return false;
@@ -2673,7 +2673,7 @@ static void registerSchemeHandler (Router *router) {
       headers[@"content-type"] = @"text/event-stream";
       headers[@"cache-control"] = @"no-store";
     } else if (result.post.chunk_stream != nullptr) {
-      *result.post.chunk_stream = [task](const char* chunk, size_t chunk_size,
+      *result.post.chunk_stream = [task, tasks](const char* chunk, size_t chunk_size,
                                          bool finished) {
         if (![tasks containsObject: task]) {
           return false;


### PR DESCRIPTION
**Status:** Seems to work


### Context
macOS does not allow `didReceiveResponse` or `didReceiveData` calls if a URL scheme task is cancelled.