### PR TITLE
fix(socket-node): avoid resolving `send` promise with Error object

### DIFF
--- a/npm/packages/@socketsupply/socket-node/API.md
+++ b/npm/packages/@socketsupply/socket-node/API.md
@@ -1,4 +1,4 @@
-### [`send(options)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L190)
+### [`send(options)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L191)
 
 Send event to webview via IPC
 
@@ -11,17 +11,17 @@ Send event to webview via IPC
 
 | Return Value | Type | Description |
 | :---         | :--- | :---        |
-| Not specified | Promise<Error \| undefined> |  |
+| Not specified | Promise<void> |  |
 
-### [`heartbeat()`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L220)
+### [`heartbeat()`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L221)
 
 Send the heartbeat event to the webview.
 
 | Return Value | Type | Description |
 | :---         | :--- | :---        |
-| Not specified | Promise<Error \| undefined> |  |
+| Not specified | Promise<void> |  |
 
-### [`addListener(event, cb)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L231)
+### [`addListener(event, cb)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L232)
 
 Adds a listener to the window.
 
@@ -30,7 +30,7 @@ Adds a listener to the window.
 | event | string |  | false | the event to listen to |
 | cb | function(*): void |  | false | the callback to call |
 
-### [`on(event, cb)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L242)
+### [`on(event, cb)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L243)
 
 Adds a listener to the window. An alias for `addListener`.
 
@@ -39,7 +39,7 @@ Adds a listener to the window. An alias for `addListener`.
 | event | string |  | false | the event to listen to |
 | cb | function(*): void |  | false | the callback to call |
 
-### [`once(event, cb)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L252)
+### [`once(event, cb)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L253)
 
 Adds a listener to the window. The listener is removed after the first call.
 
@@ -48,7 +48,7 @@ Adds a listener to the window. The listener is removed after the first call.
 | event | string |  | false | the event to listen to |
 | cb | function(*): void |  | false | the callback to call |
 
-### [`removeListener(event, cb)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L262)
+### [`removeListener(event, cb)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L263)
 
 Removes a listener from the window.
 
@@ -57,7 +57,7 @@ Removes a listener from the window.
 | event | string |  | false | the event to remove the listener from |
 | cb | function(*): void |  | false | the callback to remove |
 
-### [`removeAllListeners(event)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L271)
+### [`removeAllListeners(event)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L272)
 
 Removes all listeners from the window.
 
@@ -65,7 +65,7 @@ Removes all listeners from the window.
 | :---     | :--- | :---:   | :---:    | :---        |
 | event | string |  | false | the event to remove the listeners from |
 
-### [`off(event, cb)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L282)
+### [`off(event, cb)`](https://github.com/socketsupply/socket/blob/master/npm/packages/@socketsupply/socket-node/index.js#L283)
 
 Removes a listener from the window. An alias for `removeListener`.
 

--- a/npm/packages/@socketsupply/socket-node/index.js
+++ b/npm/packages/@socketsupply/socket-node/index.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { EventEmitter } from 'node:events'
+import { promisify } from 'node:util'
 
 const MAX_MESSAGE_KB = 512 * 1024
 
@@ -33,7 +34,7 @@ class API {
     function overrideStreamWrite (stream, write) {
       const protoWrite = Object.getPrototypeOf(stream).write
       stream.write = write
-      return protoWrite.bind(stream)
+      return promisify(protoWrite.bind(stream))
     }
 
     this.#writeStdout = overrideStreamWrite(
@@ -155,7 +156,7 @@ class API {
 
   /**
    * @param {string} s
-   * @returns {Promise<Error | undefined>}
+   * @returns {Promise<void>}
    * @throws {Error}
    * @ignore
    */
@@ -172,7 +173,7 @@ class API {
       this.#writeStderr('RAW MESSAGE: ' + s.slice(0, 512) + '...\n')
     }
 
-    return new Promise((resolve) => this.#writeStdout(s + '\n', resolve))
+    return this.#writeStdout(s + '\n')
   }
 
   //
@@ -184,7 +185,7 @@ class API {
    * @param {number} options.window - window index to send event to
    * @param {string} options.event - event name
    * @param {any=} options.value - data to send
-   * @returns {Promise<Error | undefined>}
+   * @returns {Promise<void>}
    * @throws {Error}
    */
   async send (options) {
@@ -214,7 +215,7 @@ class API {
 
   /**
    * Send the heartbeat event to the webview.
-   * @returns {Promise<Error | undefined>}
+   * @returns {Promise<void>}
    * @throws {Error}
    */
   async heartbeat () {


### PR DESCRIPTION
It seemed odd to need to handle errors as a promise result, rather than through a catch callback.
