### PR TITLE
Fix missing absolute path separator

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1319,7 +1319,7 @@ Joins path components. This function may not return an absolute path.
 | :---         | :--- | :---        |
 | Not specified | string |  |
 
-## [`dirname(options, components)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L200)
+## [`dirname(options, components)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L206)
 
 Computes directory name of path.
 
@@ -1332,7 +1332,7 @@ Computes directory name of path.
 | :---         | :--- | :---        |
 | Not specified | string |  |
 
-## [`basename(options, components)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L236)
+## [`basename(options, components)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L242)
 
 Computes base name of path.
 
@@ -1345,7 +1345,7 @@ Computes base name of path.
 | :---         | :--- | :---        |
 | Not specified | string |  |
 
-## [`extname(options, path)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L248)
+## [`extname(options, path)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L254)
 
 Computes extension name of path.
 
@@ -1358,7 +1358,7 @@ Computes extension name of path.
 | :---         | :--- | :---        |
 | Not specified | string |  |
 
-## [`normalize(options, path)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L259)
+## [`normalize(options, path)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L265)
 
 Computes normalized path
 
@@ -1371,7 +1371,7 @@ Computes normalized path
 | :---         | :--- | :---        |
 | Not specified | string |  |
 
-## [`format(options, path)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L309)
+## [`format(options, path)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L315)
 
 Formats `Path` object into a string.
 
@@ -1384,7 +1384,7 @@ Formats `Path` object into a string.
 | :---         | :--- | :---        |
 | Not specified | string |  |
 
-## [`parse(path)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L325)
+## [`parse(path)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L331)
 
 Parses input `path` into a `Path` instance.
 
@@ -1396,11 +1396,11 @@ Parses input `path` into a `Path` instance.
 | :---         | :--- | :---        |
 | Not specified | object |  |
 
-## [Path](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L353)
+## [Path](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L359)
 
 A container for a parsed Path.
 
-### [`from(input, cwd)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L375)
+### [`from(input, cwd)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L381)
 
 Creates a `Path` instance from `input` and optional `cwd`.
 
@@ -1409,7 +1409,7 @@ Creates a `Path` instance from `input` and optional `cwd`.
 | input | PathComponent |  | false |  |
 | cwd | string |  | true |  |
 
-### [`constructor(pathname, cwd)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L398)
+### [`constructor(pathname, cwd)`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L404)
 
 `Path` class constructor.
 
@@ -1418,47 +1418,47 @@ Creates a `Path` instance from `input` and optional `cwd`.
 | pathname | string |  | false |  |
 | cwd | string | Path.cwd() | true |  |
 
-### [`isRelative()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L467)
+### [`isRelative()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L473)
 
 `true` if the path is relative, otherwise `false.
 
-### [`value()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L474)
+### [`value()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L480)
 
 The working value of this path.
 
-### [`source()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L508)
+### [`source()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L514)
 
 The original source, unresolved.
 
-### [`parent()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L516)
+### [`parent()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L522)
 
 Computed parent path.
 
-### [`root()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L535)
+### [`root()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L541)
 
 Computed root in path.
 
-### [`dir()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L556)
+### [`dir()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L562)
 
 Computed directory name in path.
 
-### [`base()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L591)
+### [`base()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L597)
 
 Computed base name in path.
 
-### [`name()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L603)
+### [`name()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L609)
 
 Computed base name in path without path extension.
 
-### [`ext()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L611)
+### [`ext()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L617)
 
 Computed extension name in path.
 
-### [`drive()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L629)
+### [`drive()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L637)
 
 The computed drive, if given in the path.
 
-### [`toURL()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L636)
+### [`toURL()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L644)
 
 
 
@@ -1466,7 +1466,7 @@ The computed drive, if given in the path.
 | :---         | :--- | :---        |
 | Not specified | URL |  |
 
-### [`toString()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L644)
+### [`toString()`](https://github.com/socketsupply/socket/blob/master/api/path/path.js#L652)
 
 Converts this `Path` instance to a string.
 

--- a/api/path/path.js
+++ b/api/path/path.js
@@ -153,8 +153,10 @@ export function relative (options, from, to) {
 export function join (options, ...components) {
   const { sep } = options
   const queries = []
-  const joined = []
+  const resolved = []
   let protocol = null
+
+  const isAbsolute = components[0].trim().startsWith(sep)
 
   while (components.length) {
     let component = String(components.shift() || '')
@@ -175,20 +177,24 @@ export function join (options, ...components) {
   }
 
   for (const query of queries) {
-    if (query === '..' && joined.length > 1 && joined[0] !== '..') {
-      joined.pop()
+    if (query === '..' && resolved.length > 1 && resolved[0] !== '..') {
+      resolved.pop()
     } else if (query !== '.') {
       if (query.startsWith(sep)) {
-        joined.push(query.slice(1))
+        resolved.push(query.slice(1))
       } else if (query.endsWith(sep)) {
-        joined.push(query.slice(0, query.length - 1))
+        resolved.push(query.slice(0, query.length - 1))
       } else {
-        joined.push(query)
+        resolved.push(query)
       }
     }
   }
 
-  return joined.join(sep)
+  const joined = resolved.join(sep)
+
+  return isAbsolute
+    ? sep + joined
+    : joined
 }
 
 /**

--- a/api/path/path.js
+++ b/api/path/path.js
@@ -621,8 +621,10 @@ export class Path {
       i = this.pathname.lastIndexOf('\\')
     }
 
-    if (i === -1) return ''
-    const pathname = this.pathname.slice(i)
+    const pathname = (i > -1)
+      ? this.pathname.slice(i)
+      : this.pathname
+
     i = pathname.lastIndexOf('.')
     if (i === -1) return ''
     return pathname.slice(i >= 0 ? i : undefined)

--- a/test/src/path.js
+++ b/test/src/path.js
@@ -34,7 +34,6 @@ test('path.posix.join', (t) => {
   t.equal(path.posix.join('/a', 'b', 'c'), '/a/b/c', 'join(/a, b, c)')
 })
 
-/*
 test('path.posix.dirname', (t) => {
   t.equal(path.posix.dirname('a/b/c'), 'a/b', 'a/b')
   t.equal(path.posix.dirname('a/b/c/d.js'), 'a/b/c', 'a/b/c')
@@ -64,7 +63,6 @@ test('path.posix.extname', (t) => {
   t.equal(path.posix.extname('/a.js'), '.js', '.js')
   t.equal(path.posix.extname('a.js'), '.js', '.js')
 })
-*/
 
 test('path.win32.resolve', (t) => {
   const cwd = '\\'

--- a/test/src/path.js
+++ b/test/src/path.js
@@ -80,7 +80,6 @@ test('path.win32.resolve', (t) => {
   t.equal(a___, cwd + 'a', 'path.win32.resolve() resolves path with 5 component')
 })
 
-/*
 test('path.win32.join', (t) => {
   t.equal(path.win32.join('a', 'b', 'c'), 'a\\b\\c', 'join(a, b, c)')
   t.equal(path.win32.join('a', 'b', 'c', '..\\d'), 'a\\b\\d', 'join(a, b, c, ..\\d)')
@@ -262,4 +261,3 @@ test('path.relative', (t) => {
   t.equal(path.win32.relative('\\a\\b\\c', '\\a\\b\\c\\d'), 'd', 'd')
   t.equal(path.win32.relative('\\a\\b\\c', '\\a\\b\\c\\d\\e'), 'd\\e', 'd\\e')
 })
-*/

--- a/test/src/path.js
+++ b/test/src/path.js
@@ -31,6 +31,7 @@ test('path.posix.join', (t) => {
   t.equal(path.posix.join('a', 'b', 'c'), 'a/b/c', 'join(a, b, c)')
   t.equal(path.posix.join('a', 'b', 'c', '../d'), 'a/b/d', 'join(a, b, c, ../d)')
   t.equal(path.posix.join('a', 'b', 'c', '../d', '../../b'), 'a/b', 'join(a, b, c, ../d, ../../b)')
+  t.equal(path.posix.join('/a', 'b', 'c'), '/a/b/c', 'join(/a, b, c)')
 })
 
 /*


### PR DESCRIPTION
Closes https://github.com/socketsupply/socket/issues/706

Also fixes and re-enables some disabled tests. 