### PR TITLE
Introduce 'fs.watch' and 'fs.Watcher'

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -868,7 +868,7 @@ Chages ownership of link at `path` with `uid` and `gid.
 
 ## [`link(src, dest, )`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L368)
 
-Creates a link to `dest` from `dest`.
+Creates a link to `dest` from `src`.
 
 | Argument | Type | Default | Optional | Description |
 | :---     | :--- | :---:   | :---:    | :---        |

--- a/api/README.md
+++ b/api/README.md
@@ -1025,7 +1025,7 @@ Unlinks (removes) file at `path`.
 | options.signal | AbortSignal? |  | true |  |
 | callback | function(Error?) |  | false |  |
 
-## [`watch(, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L860)
+## [`watch(, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L861)
 
 Watch for changes at `path` calling `callback`
 
@@ -1033,6 +1033,7 @@ Watch for changes at `path` calling `callback`
 | :---     | :--- | :---:   | :---:    | :---        |
 | (Position 0) | string |  | false |  |
 | options | function \| object |  | true |  |
+| options.encoding | string | utf8 | true |  |
 | callback | ?function |  | true |  |
 
 | Return Value | Type | Description |
@@ -1330,7 +1331,7 @@ External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromisesw
 | :---         | :--- | :---        |
 | Not specified | Promise<void> |  |
 
-## [`watch(, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L496)
+## [`watch(, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L497)
 
 Watch for changes at `path` calling `callback`
 
@@ -1338,6 +1339,7 @@ Watch for changes at `path` calling `callback`
 | :---     | :--- | :---:   | :---:    | :---        |
 | (Position 0) | string |  | false |  |
 | options | function \| object |  | true |  |
+| options.encoding | string | utf8 | true |  |
 | options.signal | AbortSignal |  | true |  |
 
 | Return Value | Type | Description |

--- a/api/README.md
+++ b/api/README.md
@@ -754,7 +754,7 @@ External docs: https://nodejs.org/api/events.html
  import * as fs from 'socket:fs';
  ```
 
-## [`access(path, mode, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L84)
+## [`access(path, mode, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L85)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fsopenpath-flags-mode-callback
 Asynchronously check access a file for a given mode calling `callback`
@@ -766,7 +766,7 @@ Asynchronously check access a file for a given mode calling `callback`
 | mode | string? \| function(Error?)? | F_OK(0) | true |  |
 | callback | function(Error?)? |  | true |  |
 
-## [`chmod(path, mode, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L117)
+## [`chmod(path, mode, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L118)
 
 External docs: https://nodejs.org/api/fs.html#fschmodpath-mode-callback
 Asynchronously changes the permissions of a file.
@@ -780,7 +780,18 @@ Asynchronously changes the permissions of a file.
 | mode | number |  | false |  |
 | callback | function(Error?) |  | false |  |
 
-## [`close(fd, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L166)
+## [`chown(path, uid, gid, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L143)
+
+Changes ownership of file or directory at `path` with `uid` and `gid`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+| uid | number |  | false |  |
+| gid | number |  | false |  |
+| callback | function |  | false |  |
+
+## [`close(fd, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L171)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fsclosefd-callback
 Asynchronously close a file descriptor calling `callback` upon success or error.
@@ -790,7 +801,7 @@ Asynchronously close a file descriptor calling `callback` upon success or error.
 | fd | number |  | false |  |
 | callback | function(Error?)? |  | true |  |
 
-## [`copyFile(src, dest, flags, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L190)
+## [`copyFile(src, dest, flags, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L195)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fscopyfilesrc-dest-mode-callback
 Asynchronously copies `src` to `dest` calling `callback` upon success or error.
@@ -802,7 +813,7 @@ Asynchronously copies `src` to `dest` calling `callback` upon success or error.
 | flags | number |  | false | Modifiers for copy operation. |
 | callback | function(Error=) |  | true | The function to call after completion. |
 
-## [`createReadStream(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L218)
+## [`createReadStream(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L223)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fscreatewritestreampath-options
 
@@ -816,7 +827,7 @@ External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fscreatewri
 | :---         | :--- | :---        |
 | Not specified | ReadStream |  |
 
-## [`createWriteStream(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L258)
+## [`createWriteStream(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L266)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fscreatewritestreampath-options
 
@@ -830,7 +841,7 @@ External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fscreatewri
 | :---         | :--- | :---        |
 | Not specified | WriteStream |  |
 
-## [`fstat(fd, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L302)
+## [`fstat(fd, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L312)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fsfstatfd-options-callback
 Invokes the callback with the <fs.Stats> for the file descriptor. See
@@ -844,7 +855,28 @@ Invokes the callback with the <fs.Stats> for the file descriptor. See
 | options | object? \| function? |  | true | An options object. |
 | callback | function? |  | true | The function to call after completion. |
 
-## [`open(path, flags, mode, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L407)
+## [`lchown(path, uid, gid, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L340)
+
+Chages ownership of link at `path` with `uid` and `gid.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+| uid | number |  | false |  |
+| gid | number |  | false |  |
+| callback | function |  | false |  |
+
+## [`link(src, dest, )`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L368)
+
+Creates a link to `dest` from `dest`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| src | string |  | false |  |
+| dest | string |  | false |  |
+| (Position 0) | function |  | false |  |
+
+## [`open(path, flags, mode, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L424)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fsopenpath-flags-mode-callback
 Asynchronously open a file calling `callback` upon success or error.
@@ -857,7 +889,7 @@ Asynchronously open a file calling `callback` upon success or error.
 | options | object? \| function? |  | true |  |
 | callback | function(Error?, number?)? |  | true |  |
 
-## [`opendir(path, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L460)
+## [`opendir(path, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L477)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fsreaddirpath-options-callback
 Asynchronously open a directory calling `callback` upon success or error.
@@ -870,7 +902,7 @@ Asynchronously open a directory calling `callback` upon success or error.
 | options.withFileTypes | boolean? | false | true |  |
 | callback | function(Error?, Dir?)? |  | false |  |
 
-## [`read(fd, buffer, offset, length, position, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L486)
+## [`read(fd, buffer, offset, length, position, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L503)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fsreadfd-buffer-offset-length-position-callback
 Asynchronously read from an open file descriptor.
@@ -884,7 +916,7 @@ Asynchronously read from an open file descriptor.
 | position | number \| BigInt \| null |  | false | Specifies where to begin reading from in the file. If position is null or -1 , data will be read from the current file position, and the file position will be updated. If position is an integer, the file position will be unchanged. |
 | callback | function(Error?, number?, Buffer?) |  | false |  |
 
-## [`readdir(path, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L520)
+## [`readdir(path, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L537)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fsreaddirpath-options-callback
 Asynchronously read all entries in a directory.
@@ -897,7 +929,7 @@ Asynchronously read all entries in a directory.
 | options.withFileTypes ? false | boolean? |  | true |  |
 | callback | function(Error?, object) |  | false |  |
 
-## [`readFile(path, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L571)
+## [`readFile(path, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L588)
 
 
 
@@ -910,7 +942,44 @@ Asynchronously read all entries in a directory.
 | options.signal | AbortSignal? |  | true |  |
 | callback | function(Error?, Buffer?) |  | false |  |
 
-## [`stat(path, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L690)
+## [`readlink(path, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L631)
+
+Reads link at `path`
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+| callback | function(err, string) |  | false |  |
+
+## [`realpath(path, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L650)
+
+Computes real path for `path`
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+| callback | function(err, string) |  | false |  |
+
+## [`rename(src, dest, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L670)
+
+Renames file or directory at `src` to `dest`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| src | string |  | false |  |
+| dest | string |  | false |  |
+| callback | function |  | false |  |
+
+## [`rmdir(path, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L693)
+
+Removes directory at `path`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+| callback | function |  | false |  |
+
+## [`stat(path, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L716)
 
 
 
@@ -923,7 +992,25 @@ Asynchronously read all entries in a directory.
 | options.signal | AbortSignal? |  | true |  |
 | callback | function(Error?, Stats?) |  | false |  |
 
-## [`writeFile(path, data, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L786)
+## [`symlink(src, dest)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L750)
+
+Creates a symlink of `src` at `dest`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| src | string |  | false |  |
+| dest | string |  | false |  |
+
+## [`unlink(path, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L791)
+
+Unlinks (removes) file at `path`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+| callback | function |  | false |  |
+
+## [`writeFile(path, data, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L816)
 
 
 
@@ -937,6 +1024,20 @@ Asynchronously read all entries in a directory.
 | options.flag ? w | string? |  | true |  |
 | options.signal | AbortSignal? |  | true |  |
 | callback | function(Error?) |  | false |  |
+
+## [`watch(, options, callback)`](https://github.com/socketsupply/socket/blob/master/api/fs/index.js#L860)
+
+Watch for changes at `path` calling `callback`
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| (Position 0) | string |  | false |  |
+| options | function \| object |  | true |  |
+| callback | ?function |  | true |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Watcher |  |
 
 
 <!-- This file is generated by bin/docs-generator/api-module.js -->
@@ -966,7 +1067,7 @@ Asynchronously read all entries in a directory.
  import fs from 'socket:fs/promises'
  ```
 
-## [`access(path, mode, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L86)
+## [`access(path, mode, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L88)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromisesaccesspath-mode
 Asynchronously check access a file.
@@ -977,7 +1078,7 @@ Asynchronously check access a file.
 | mode | string? |  | true |  |
 | options | object? |  | true |  |
 
-## [`chmod(path, mode)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L96)
+## [`chmod(path, mode)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L98)
 
 External docs: https://nodejs.org/api/fs.html#fspromiseschmodpath-mode
 
@@ -991,7 +1092,62 @@ External docs: https://nodejs.org/api/fs.html#fspromiseschmodpath-mode
 | :---         | :--- | :---        |
 | Not specified | Promise<void> |  |
 
-## [`mkdir(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L208)
+## [`chown(path, uid, gid)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L121)
+
+Changes ownership of file or directory at `path` with `uid` and `gid`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+| uid | number |  | false |  |
+| gid | number |  | false |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Promise |  |
+
+## [`copyFile(src, dest, flags)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L148)
+
+Asynchronously copies `src` to `dest` calling `callback` upon success or error.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| src | string |  | false | The source file path. |
+| dest | string |  | false | The destination file path. |
+| flags | number |  | false | Modifiers for copy operation. |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Promise |  |
+
+## [`lchown(path, uid, gid)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L175)
+
+Chages ownership of link at `path` with `uid` and `gid.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+| uid | number |  | false |  |
+| gid | number |  | false |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Promise |  |
+
+## [`link(src, dest)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L201)
+
+Creates a link to `dest` from `dest`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| src | string |  | false |  |
+| dest | string |  | false |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Promise |  |
+
+## [`mkdir(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L225)
 
 Asynchronously creates a directory.
 
@@ -1005,7 +1161,7 @@ Asynchronously creates a directory.
 | :---         | :--- | :---        |
 | Not specified | Promise<any> | Upon success, fulfills with undefined if recursive is false, or the first directory path created if recursive is true. |
 
-## [`open(path, flags, mode)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L236)
+## [`open(path, flags, mode)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L253)
 
 External docs: https://nodejs.org/api/fs.html#fspromisesopenpath-flags-mode
 Asynchronously open a file.
@@ -1021,7 +1177,7 @@ Asynchronously open a file.
 | :---         | :--- | :---        |
 | Not specified | Promise<FileHandle> |  |
 
-## [`opendir(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L248)
+## [`opendir(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L265)
 
 External docs: https://nodejs.org/api/fs.html#fspromisesopendirpath-options
 
@@ -1037,7 +1193,7 @@ External docs: https://nodejs.org/api/fs.html#fspromisesopendirpath-options
 | :---         | :--- | :---        |
 | Not specified | Promise<Dir> |  |
 
-## [`readdir(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L260)
+## [`readdir(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L277)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromisesreaddirpath-options
 
@@ -1049,7 +1205,7 @@ External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromisesr
 | options.encoding | string? | utf8 | true |  |
 | options.withFileTypes | boolean? | false | true |  |
 
-## [`readFile(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L293)
+## [`readFile(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L310)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromisesreadfilepath-options
 
@@ -1066,7 +1222,56 @@ External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromisesr
 | :---         | :--- | :---        |
 | Not specified | Promise<Buffer \| string> |  |
 
-## [`stat(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L380)
+## [`readlink(path)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L327)
+
+Reads link at `path`
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Promise<string> |  |
+
+## [`realpath(path)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L346)
+
+Computes real path for `path`
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Promise<string> |  |
+
+## [`rename(src, dest)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L366)
+
+Renames file or directory at `src` to `dest`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| src | string |  | false |  |
+| dest | string |  | false |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Promise |  |
+
+## [`rmdir(path)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L387)
+
+Removes directory at `path`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Promise |  |
+
+## [`stat(path, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L406)
 
 External docs: https://nodejs.org/api/fs.html#fspromisesstatpath-options
 
@@ -1081,7 +1286,32 @@ External docs: https://nodejs.org/api/fs.html#fspromisesstatpath-options
 | :---         | :--- | :---        |
 | Not specified | Promise<Stats> |  |
 
-## [`writeFile(path, data, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L446)
+## [`symlink(src, dest)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L418)
+
+Creates a symlink of `src` at `dest`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| src | string |  | false |  |
+| dest | string |  | false |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Promise |  |
+
+## [`unlink(path)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L453)
+
+Unlinks (removes) file at `path`.
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| path | string |  | false |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Promise |  |
+
+## [`writeFile(path, data, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L477)
 
 External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromiseswritefilefile-data-options
 
@@ -1099,6 +1329,20 @@ External docs: https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromisesw
 | Return Value | Type | Description |
 | :---         | :--- | :---        |
 | Not specified | Promise<void> |  |
+
+## [`watch(, options)`](https://github.com/socketsupply/socket/blob/master/api/fs/promises.js#L496)
+
+Watch for changes at `path` calling `callback`
+
+| Argument | Type | Default | Optional | Description |
+| :---     | :--- | :---:   | :---:    | :---        |
+| (Position 0) | string |  | false |  |
+| options | function \| object |  | true |  |
+| options.signal | AbortSignal |  | true |  |
+
+| Return Value | Type | Description |
+| :---         | :--- | :---        |
+| Not specified | Watcher |  |
 
 
 <!-- This file is generated by bin/docs-generator/api-module.js -->

--- a/api/fs/dir.js
+++ b/api/fs/dir.js
@@ -61,11 +61,29 @@ export class Dir {
   }
 
   /**
+   * `true` if closed, otherwise `false`.
+   * @ignore
+   * @type {boolean}
+   */
+  get closed () {
+    return Boolean(this.handle?.closed)
+  }
+
+  /**
+   * `true` if closeing, otherwise `false`.
+   * @ignore
+   * @type {boolean}
+   */
+  get closing () {
+    return Boolean(this.handle?.closig)
+  }
+
+  /**
    * Closes container and underlying handle.
    * @param {object|function} options
    * @param {function=} callback
    */
-  async close (options, callback) {
+  async close (options = null, callback) {
     if (typeof options === 'function') {
       callback = options
       options = {}

--- a/api/fs/dir.js
+++ b/api/fs/dir.js
@@ -70,12 +70,12 @@ export class Dir {
   }
 
   /**
-   * `true` if closeing, otherwise `false`.
+   * `true` if closing, otherwise `false`.
    * @ignore
    * @type {boolean}
    */
   get closing () {
-    return Boolean(this.handle?.closig)
+    return Boolean(this.handle?.closing)
   }
 
   /**

--- a/api/fs/handle.js
+++ b/api/fs/handle.js
@@ -85,7 +85,7 @@ export class FileHandle extends EventEmitter {
    * @param {string} path
    * @param {number} [mode = 0o666]
    * @param {object=} [options]
-   * @return {boolean}
+   * @return {Promise<boolean>}
    */
   static async access (path, mode, options) {
     if (mode !== null && typeof mode === 'object') {
@@ -112,7 +112,7 @@ export class FileHandle extends EventEmitter {
    * @see {@link https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromisesopenpath-flags-mode}
    * @param {string | Buffer | URL} path
    * @param {string=} [flags = 'r']
-   * @param {string=} [mode = 0o666]
+   * @param {string|number=} [mode = 0o666]
    * @param {object=} [options]
    */
   static async open (path, flags, mode, options) {
@@ -137,7 +137,7 @@ export class FileHandle extends EventEmitter {
 
   /**
    * `FileHandle` class constructor
-   * @private
+   * @ignore
    * @param {object} options
    */
   constructor (options) {
@@ -207,7 +207,7 @@ export class FileHandle extends EventEmitter {
       args: [this.id, options],
       async handle (id) {
         if (fds.has(id)) {
-          console.warn('Closing FileHandle on garbage collection')
+          console.warn('Closing fs.FileHandle on garbage collection')
           await ipc.send('fs.close', { id }, options)
           fds.release(id, false)
         }
@@ -420,9 +420,9 @@ export class FileHandle extends EventEmitter {
    * Reads `length` bytes starting from `position` into `buffer` at
    * `offset`.
    * @param {Buffer|object} buffer
-   * @param {number} offset
-   * @param {number} length
-   * @param {number} position
+   * @param {number=} [offset]
+   * @param {number=} [length]
+   * @param {number=} [position]
    * @param {object=} [options]
    */
   async read (buffer, offset, length, position, options) {
@@ -914,7 +914,7 @@ export class DirectoryHandle extends EventEmitter {
       args: [this.id, options],
       async handle (id) {
         if (fds.has(id)) {
-          console.warn('Closing DirectoryHandle on garbage collection')
+          console.warn('Closing fs.DirectoryHandle on garbage collection')
           await ipc.send('fs.closedir', { id }, options)
           fds.release(id, false)
         }

--- a/api/fs/index.js
+++ b/api/fs/index.js
@@ -854,6 +854,7 @@ export function writeFile (path, data, options, callback) {
  * Watch for changes at `path` calling `callback`
  * @param {string}
  * @param {function|object=} [options]
+ * @param {string=} [options.encoding = 'utf8']
  * @param {?function} [callback]
  * @return {Watcher}
  */

--- a/api/fs/index.js
+++ b/api/fs/index.js
@@ -360,7 +360,7 @@ export function lchown (path, uid, gid, callback) {
 }
 
 /**
- * Creates a link to `dest` from `dest`.
+ * Creates a link to `dest` from `src`.
  * @param {string} src
  * @param {string} dest
  * @param {function}

--- a/api/fs/promises.js
+++ b/api/fs/promises.js
@@ -490,6 +490,7 @@ export async function writeFile (path, data, options) {
  * Watch for changes at `path` calling `callback`
  * @param {string}
  * @param {function|object=} [options]
+ * @param {string=} [options.encoding = 'utf8']
  * @param {AbortSignal=} [options.signal]
  * @return {Watcher}
  */

--- a/api/fs/promises.js
+++ b/api/fs/promises.js
@@ -29,6 +29,7 @@ import { Dir, Dirent, sortDirectoryEntries } from './dir.js'
 import { DirectoryHandle, FileHandle } from './handle.js'
 import { ReadStream, WriteStream } from './stream.js'
 import * as constants from './constants.js'
+import { Watcher } from './watcher.js'
 import { Stats } from './stats.js'
 import fds from './fds.js'
 
@@ -44,6 +45,7 @@ export {
   FileHandle,
   ReadStream,
   Stats,
+  Watcher,
   WriteStream
 }
 
@@ -110,7 +112,11 @@ export async function chmod (path, mode) {
 }
 
 /**
- * @ignore
+ * Changes ownership of file or directory at `path` with `uid` and `gid`.
+ * @param {string} path
+ * @param {number} uid
+ * @param {number} gid
+ * @return {Promise}
  */
 export async function chown (path, uid, gid) {
   if (typeof path !== 'string') {
@@ -133,7 +139,11 @@ export async function chown (path, uid, gid) {
 }
 
 /**
- * @ignore
+ * Asynchronously copies `src` to `dest` calling `callback` upon success or error.
+ * @param {string} src - The source file path.
+ * @param {string} dest - The destination file path.
+ * @param {number} flags - Modifiers for copy operation.
+ * @return {Promise}
  */
 export async function copyFile (src, dest, flags) {
   if (typeof src !== 'string') {
@@ -156,7 +166,11 @@ export async function copyFile (src, dest, flags) {
 }
 
 /**
- * @ignore
+ * Chages ownership of link at `path` with `uid` and `gid.
+ * @param {string} path
+ * @param {number} uid
+ * @param {number} gid
+ * @return {Promise}
  */
 export async function lchown (path, uid, gid) {
   if (typeof path !== 'string') {
@@ -179,7 +193,10 @@ export async function lchown (path, uid, gid) {
 }
 
 /**
- * @ignore
+ * Creates a link to `dest` from `dest`.
+ * @param {string} src
+ * @param {string} dest
+ * @return {Promise}
  */
 export async function link (src, dest) {
   if (typeof src !== 'string') {
@@ -303,7 +320,9 @@ export async function readFile (path, options) {
 }
 
 /**
- * @ignore
+ * Reads link at `path`
+ * @param {string} path
+ * @return {Promise<string>}
  */
 export async function readlink (path) {
   if (typeof path !== 'string') {
@@ -320,7 +339,9 @@ export async function readlink (path) {
 }
 
 /**
- * @ignore
+ * Computes real path for `path`
+ * @param {string} path
+ * @return {Promise<string>}
  */
 export async function realpath (path) {
   if (typeof path !== 'string') {
@@ -337,18 +358,21 @@ export async function realpath (path) {
 }
 
 /**
- * @ignore
+ * Renames file or directory at `src` to `dest`.
+ * @param {string} src
+ * @param {string} dest
+ * @return {Promise}
  */
-export async function rename (oldPath, newPath) {
-  if (typeof oldPath !== 'string') {
+export async function rename (src, dest) {
+  if (typeof src !== 'string') {
     throw new TypeError('The argument \'path\' must be a string')
   }
 
-  if (typeof newPath !== 'string') {
+  if (typeof dest !== 'string') {
     throw new TypeError('The argument \'path\' must be a string')
   }
 
-  const result = await ipc.send('fs.rename', { oldPath, newPath })
+  const result = await ipc.send('fs.rename', { src, dest })
 
   if (result.err) {
     throw result.err
@@ -356,7 +380,9 @@ export async function rename (oldPath, newPath) {
 }
 
 /**
- * @ignore
+ * Removes directory at `path`.
+ * @param {string} path
+ * @return {Promise}
  */
 export async function rmdir (path) {
   if (typeof path !== 'string') {
@@ -384,7 +410,10 @@ export async function stat (path, options) {
 }
 
 /**
- * @ignore
+ * Creates a symlink of `src` at `dest`.
+ * @param {string} src
+ * @param {string} dest
+ * @return {Promise}
  */
 export async function symlink (src, dest, type = null) {
   let flags = 0
@@ -417,7 +446,9 @@ export async function symlink (src, dest, type = null) {
 }
 
 /**
- * @ignore
+ * Unlinks (removes) file at `path`.
+ * @param {string} path
+ * @return {Promise}
  */
 export async function unlink (path) {
   if (typeof path !== 'string') {
@@ -453,6 +484,17 @@ export async function writeFile (path, data, options) {
   return await visit(path, options, async (handle) => {
     return await handle.writeFile(data, options)
   })
+}
+
+/**
+ * Watch for changes at `path` calling `callback`
+ * @param {string}
+ * @param {function|object=} [options]
+ * @param {AbortSignal=} [options.signal]
+ * @return {Watcher}
+ */
+export function watch (path, options) {
+  return new Watcher(path, options)
 }
 
 export default exports

--- a/api/fs/stream.js
+++ b/api/fs/stream.js
@@ -18,7 +18,7 @@ export const DEFAULT_STREAM_HIGH_WATER_MARK = 64 * 1024
 export class ReadStream extends Readable {
   /**
    * `ReadStream` class constructor
-   * @private
+   * @ignore
    */
   constructor (options) {
     super(options)
@@ -170,7 +170,7 @@ export class ReadStream extends Readable {
 export class WriteStream extends Writable {
   /**
    * `WriteStream` class constructor
-   * @private
+   * @ignore
    */
   constructor (options) {
     super(options)

--- a/api/fs/watcher.js
+++ b/api/fs/watcher.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from '../events.js'
+import { FileHandle } from './handle.js'
 import { AbortError } from '../errors.js'
 import { rand64 } from '../crypto.js'
 import { Buffer } from '../buffer.js'
@@ -32,6 +33,13 @@ function encodeFilename (watcher, filename) {
  * @return {Promise}
  */
 async function start (watcher) {
+  // throws if not accessible
+  await FileHandle.access(watcher.path)
+
+  if (!watcher.id || typeof watcher.id !== 'string') {
+    throw new TypeError('Expectig fs.Watcher to have a id.')
+  }
+
   const result = await ipc.send('fs.watch', {
     path: watcher.path,
     id: watcher.id

--- a/api/fs/watcher.js
+++ b/api/fs/watcher.js
@@ -1,0 +1,176 @@
+import { EventEmitter } from '../events.js'
+import { rand64 } from '../crypto.js'
+import hooks from '../hooks.js'
+import ipc from '../ipc.js'
+import gc from '../gc.js'
+
+/**
+ * Starts the `fs.Watcher`
+ * @ignore
+ * @param {Watcher} watcher
+ * @return {Promise}
+ */
+async function start (watcher) {
+  const result = await ipc.send('fs.watch', {
+    path: watcher.path,
+    id: watcher.id
+  })
+
+  if (result.err) {
+    throw result.err
+  }
+}
+
+/**
+ * Internal watcher data event listeer.
+ * @ignore
+ * @param {Watcher}
+ * @return {function}
+ */
+function listen (watcher) {
+  return hooks.onData((event) => {
+    const { data, source } = event.detail.params
+    if (source !== 'fs.watch') {
+      return
+    }
+
+    if (BigInt(data.id) !== BigInt(watcher.id)) {
+      return
+    }
+
+    const { path, events } = data
+
+    watcher.emit('change', events[0], path)
+  })
+}
+
+/**
+ * A container for a file system path watcher.
+ */
+export class Watcher extends EventEmitter {
+  /**
+   * The underlying `fs.Watcher` resource id.
+   * @ignore
+   * @type {string}
+   */
+  id = null
+
+  /**
+   * The path the `fs.Watcher` is watching
+   * @type {string}
+   */
+  path = null
+
+  /**
+   * `true` if closed, otherwise `false.
+   * @type {boolean}
+   */
+  closed = false
+
+  /**
+   * Internal event listener cancellation.
+   * @ignore
+   * @type {function?}
+   */
+  stopListening = null
+
+  /**
+   * `Watcher` class constructor.
+   * @ignore
+   * @param {string} path
+   * @param {object=} [options]
+   * @param {string|number|bigint=} [options.id]
+   */
+  constructor (path, options = {}) {
+    super()
+
+    this.id = options?.id || String(rand64())
+    this.path = path
+
+    gc.ref(this)
+
+    // internal
+    if (options?.start !== false) {
+      this.start()
+    }
+  }
+
+  /**
+   * Internal starter for watcher.
+   * @ignore
+   */
+  async start () {
+    try {
+      await start(this)
+
+      if (typeof this.stopListening === 'function') {
+        this.stopListening()
+      }
+
+      this.stopListening = listen(this)
+    } catch (err) {
+      this.emit('err', err)
+    }
+  }
+
+  /**
+   * Closes watcher and stops listening for changes.
+   * @return {Promise}
+   */
+  async close () {
+    if (typeof this.stopListening === 'function') {
+      this.stopListening()
+      this.stopListening = null
+    }
+
+    this.closed = true
+    const result = await ipc.send('fs.stopWatch', { id: this.id })
+    if (result.err) {
+      throw result.err
+    }
+  }
+
+  /**
+   * Implements `gc.finalizer` for gc'd resource cleanup.
+   * @ignore
+   * @return {gc.Finalizer}
+   */
+  [gc.finalizer] (options) {
+    return {
+      args: [this.id, this.stopListening, options],
+      handle (id, stopListening) {
+        if (typeof stopListening === 'function') {
+          stopListening()
+        }
+
+        console.warn('Closing fs.Watcher on garbage collection')
+        ipc.send('fs.stopWatch', { id }, options)
+      }
+    }
+  }
+
+  /**
+   * Implements the `AsyncIterator` (`Symbol.asyncIterator`) iterface.
+   * @ignore
+   * @return {AsyncIterator<{ eventType: string, filename: string }>}
+   */
+  [Symbol.asyncIterator] () {
+    return {
+      async next () {
+        if (this.closed) {
+          return { done: true, value: null }
+        }
+
+        const event = await new Promise((resolve) => {
+          this.once('change', (eventType, filename) => {
+            resolve({ eventType, filename })
+          })
+        })
+
+        return { done: false, value: event }
+      }
+    }
+  }
+}
+
+export default Watcher

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -2004,24 +2004,24 @@ declare module "socket:fs/handle" {
          * @param {string} path
          * @param {number} [mode = 0o666]
          * @param {object=} [options]
-         * @return {boolean}
+         * @return {Promise<boolean>}
          */
-        static access(path: string, mode?: number, options?: object | undefined): boolean;
+        static access(path: string, mode?: number, options?: object | undefined): Promise<boolean>;
         /**
          * Asynchronously open a file.
          * @see {@link https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromisesopenpath-flags-mode}
          * @param {string | Buffer | URL} path
          * @param {string=} [flags = 'r']
-         * @param {string=} [mode = 0o666]
+         * @param {string|number=} [mode = 0o666]
          * @param {object=} [options]
          */
-        static open(path: string | Buffer | URL, flags?: string | undefined, mode?: string | undefined, options?: object | undefined): Promise<exports.FileHandle>;
+        static open(path: string | Buffer | URL, flags?: string | undefined, mode?: (string | number) | undefined, options?: object | undefined): Promise<exports.FileHandle>;
         /**
          * `FileHandle` class constructor
-         * @private
+         * @ignore
          * @param {object} options
          */
-        private constructor();
+        constructor(options: object);
         flags: any;
         path: any;
         mode: any;
@@ -2077,12 +2077,12 @@ declare module "socket:fs/handle" {
          * Creates a `ReadStream` for the underlying file.
          * @param {object=} [options] - An options object
          */
-        createReadStream(options?: object | undefined): any;
+        createReadStream(options?: object | undefined): ReadStream;
         /**
          * Creates a `WriteStream` for the underlying file.
          * @param {object=} [options] - An options object
          */
-        createWriteStream(options?: object | undefined): any;
+        createWriteStream(options?: object | undefined): WriteStream;
         /**
          * @param {object=} [options]
          */
@@ -2096,12 +2096,12 @@ declare module "socket:fs/handle" {
          * Reads `length` bytes starting from `position` into `buffer` at
          * `offset`.
          * @param {Buffer|object} buffer
-         * @param {number} offset
-         * @param {number} length
-         * @param {number} position
+         * @param {number=} [offset]
+         * @param {number=} [length]
+         * @param {number=} [position]
          * @param {object=} [options]
          */
-        read(buffer: Buffer | object, offset: number, length: number, position: number, options?: object | undefined): Promise<{
+        read(buffer: Buffer | object, offset?: number | undefined, length?: number | undefined, position?: number | undefined, options?: object | undefined): Promise<{
             bytesRead: number;
             buffer: any;
         }>;
@@ -2247,6 +2247,8 @@ declare module "socket:fs/handle" {
     import { EventEmitter } from "socket:events";
     import { Buffer } from "socket:buffer";
     import * as exports from "socket:fs/handle";
+    import { ReadStream } from "socket:fs/stream";
+    import { WriteStream } from "socket:fs/stream";
     import { Stats } from "socket:fs/stats";
     
 }
@@ -2278,11 +2280,23 @@ declare module "socket:fs/dir" {
         encoding: any;
         withFileTypes: boolean;
         /**
+         * `true` if closed, otherwise `false`.
+         * @ignore
+         * @type {boolean}
+         */
+        get closed(): boolean;
+        /**
+         * `true` if closeing, otherwise `false`.
+         * @ignore
+         * @type {boolean}
+         */
+        get closing(): boolean;
+        /**
          * Closes container and underlying handle.
          * @param {object|function} options
          * @param {function=} callback
          */
-        close(options: object | Function, callback?: Function | undefined): Promise<any>;
+        close(options?: object | Function, callback?: Function | undefined): Promise<any>;
         /**
          * Reads and returns directory entry.
          * @param {object|function} options
@@ -2365,6 +2379,303 @@ declare module "socket:fs/dir" {
     import * as exports from "socket:fs/dir";
     
 }
+declare module "socket:hooks" {
+    /**
+     * Wait for the global Window, Document, and Runtime to be ready.
+     * The callback function is called exactly once.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onReady(callback: Function): Function;
+    /**
+     * Wait for the global Window and Document to be ready. The callback
+     * function is called exactly once.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onLoad(callback: Function): Function;
+    /**
+     * Wait for the runtime to be ready. The callback
+     * function is called exactly once.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onInit(callback: Function): Function;
+    /**
+     * Calls callback when a global exception occurs.
+     * 'error', 'messageerror', and 'unhandledrejection' events are handled here.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onError(callback: Function): Function;
+    /**
+     * Subscribes to the global data pipe calling callback when
+     * new data is emitted on the global Window.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onData(callback: Function): Function;
+    /**
+     * Subscribes to global messages likely from an external `postMessage`
+     * invocation.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onMessage(callback: Function): Function;
+    /**
+     * Calls callback when runtime is working online.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onOnline(callback: Function): Function;
+    /**
+     * Calls callback when runtime is not working online.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onOffline(callback: Function): Function;
+    /**
+     * Calls callback when runtime user preferred language has changed.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onLanguageChange(callback: Function): Function;
+    /**
+     * Calls callback when an application permission has changed.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onPermissionChange(callback: Function): Function;
+    /**
+     * Calls callback in response to a presented `Notification`.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onNotificationResponse(callback: Function): Function;
+    /**
+     * Calls callback when a `Notification` is presented.
+     * @param {function} callback
+     * @return {function}
+     */
+    export function onNotificationPresented(callback: Function): Function;
+    /**
+     * An event dispatched when the runtime has been initialized.
+     */
+    export class InitEvent {
+        constructor();
+    }
+    /**
+     * An event dispatched when the runtime global has been loaded.
+     */
+    export class LoadEvent {
+        constructor();
+    }
+    /**
+     * An event dispatched when the runtime is considered ready.
+     */
+    export class ReadyEvent {
+        constructor();
+    }
+    /**
+     * An interface for registering callbacks for various hooks in
+     * the runtime.
+     */
+    export class Hooks extends EventTarget {
+        /**
+         * Reference to global object
+         * @type {object}
+         */
+        get global(): any;
+        /**
+         * Returns `document` in global.
+         * @type {Document}
+         */
+        get document(): Document;
+        /**
+         * Returns `document` in global.
+         * @type {Window}
+         */
+        get window(): Window;
+        /**
+         * Predicate for determining if the global document is ready.
+         * @type {boolean}
+         */
+        get isDocumentReady(): boolean;
+        /**
+         * Predicate for determining if the global object is ready.
+         * @type {boolean}
+         */
+        get isGlobalReady(): boolean;
+        /**
+         * Predicate for determining if the runtime is ready.
+         * @type {boolean}
+         */
+        get isRuntimeReady(): boolean;
+        /**
+         * Predicate for determining if everything is ready.
+         * @type {boolean}
+         */
+        get isReady(): boolean;
+        /**
+         * Predicate for determining if the runtime is working online.
+         * @type {boolean}
+         */
+        get isOnline(): boolean;
+        /**
+         * Predicate for determining if the runtime is in a Worker context.
+         * @type {boolean}
+         */
+        get isWorkerContext(): boolean;
+        /**
+         * Predicate for determining if the runtime is in a Window context.
+         * @type {boolean}
+         */
+        get isWindowContext(): boolean;
+        /**
+         * Wait for the global Window, Document, and Runtime to be ready.
+         * The callback function is called exactly once.
+         * @param {function} callback
+         * @return {function}
+         */
+        onReady(callback: Function): Function;
+        /**
+         * Wait for the global Window and Document to be ready. The callback
+         * function is called exactly once.
+         * @param {function} callback
+         * @return {function}
+         */
+        onLoad(callback: Function): Function;
+        /**
+         * Wait for the runtime to be ready. The callback
+         * function is called exactly once.
+         * @param {function} callback
+         * @return {function}
+         */
+        onInit(callback: Function): Function;
+        /**
+         * Calls callback when a global exception occurs.
+         * 'error', 'messageerror', and 'unhandledrejection' events are handled here.
+         * @param {function} callback
+         * @return {function}
+         */
+        onError(callback: Function): Function;
+        /**
+         * Subscribes to the global data pipe calling callback when
+         * new data is emitted on the global Window.
+         * @param {function} callback
+         * @return {function}
+         */
+        onData(callback: Function): Function;
+        /**
+         * Subscribes to global messages likely from an external `postMessage`
+         * invocation.
+         * @param {function} callback
+         * @return {function}
+         */
+        onMessage(callback: Function): Function;
+        /**
+         * Calls callback when runtime is working online.
+         * @param {function} callback
+         * @return {function}
+         */
+        onOnline(callback: Function): Function;
+        /**
+         * Calls callback when runtime is not working online.
+         * @param {function} callback
+         * @return {function}
+         */
+        onOffline(callback: Function): Function;
+        /**
+         * Calls callback when runtime user preferred language has changed.
+         * @param {function} callback
+         * @return {function}
+         */
+        onLanguageChange(callback: Function): Function;
+        /**
+         * Calls callback when an application permission has changed.
+         * @param {function} callback
+         * @return {function}
+         */
+        onPermissionChange(callback: Function): Function;
+        /**
+         * Calls callback in response to a displayed `Notification`.
+         * @param {function} callback
+         * @return {function}
+         */
+        onNotificationResponse(callback: Function): Function;
+        /**
+         * Calls callback when a `Notification` is presented.
+         * @param {function} callback
+         * @return {function}
+         */
+        onNotificationPresented(callback: Function): Function;
+        #private;
+    }
+    export default hooks;
+    /**
+     * `Hooks` single instance.
+     * @ignore
+     */
+    const hooks: Hooks;
+}
+declare module "socket:fs/watcher" {
+    /**
+     * A container for a file system path watcher.
+     */
+    export class Watcher extends EventEmitter {
+        /**
+         * `Watcher` class constructor.
+         * @ignore
+         * @param {string} path
+         * @param {object=} [options]
+         * @param {string|number|bigint=} [options.id]
+         */
+        constructor(path: string, options?: object | undefined);
+        /**
+         * The underlying `fs.Watcher` resource id.
+         * @ignore
+         * @type {string}
+         */
+        id: string;
+        /**
+         * The path the `fs.Watcher` is watching
+         * @type {string}
+         */
+        path: string;
+        /**
+         * `true` if closed, otherwise `false.
+         * @type {boolean}
+         */
+        closed: boolean;
+        /**
+         * Internal event listener cancellation.
+         * @ignore
+         * @type {function?}
+         */
+        stopListening: Function | null;
+        /**
+         * Internal starter for watcher.
+         * @ignore
+         */
+        start(): Promise<void>;
+        /**
+         * Closes watcher and stops listening for changes.
+         * @return {Promise}
+         */
+        close(): Promise<any>;
+        /**
+         * Implements the `AsyncIterator` (`Symbol.asyncIterator`) iterface.
+         * @ignore
+         * @return {AsyncIterator<{ eventType: string, filename: string }>}
+         */
+        [Symbol.asyncIterator](): AsyncIterator<{
+            eventType: string;
+            filename: string;
+        }>;
+    }
+    export default Watcher;
+    import { EventEmitter } from "socket:events";
+}
 declare module "socket:fs/promises" {
     /**
      * Asynchronously check access a file.
@@ -2382,21 +2693,36 @@ declare module "socket:fs/promises" {
      */
     export function chmod(path: string | Buffer | URL, mode: number): Promise<void>;
     /**
-     * @ignore
+     * Changes ownership of file or directory at `path` with `uid` and `gid`.
+     * @param {string} path
+     * @param {number} uid
+     * @param {number} gid
+     * @return {Promise}
      */
-    export function chown(path: any, uid: any, gid: any): Promise<void>;
+    export function chown(path: string, uid: number, gid: number): Promise<any>;
     /**
-     * @ignore
+     * Asynchronously copies `src` to `dest` calling `callback` upon success or error.
+     * @param {string} src - The source file path.
+     * @param {string} dest - The destination file path.
+     * @param {number} flags - Modifiers for copy operation.
+     * @return {Promise}
      */
-    export function copyFile(src: any, dest: any, flags: any): Promise<void>;
+    export function copyFile(src: string, dest: string, flags: number): Promise<any>;
     /**
-     * @ignore
+     * Chages ownership of link at `path` with `uid` and `gid.
+     * @param {string} path
+     * @param {number} uid
+     * @param {number} gid
+     * @return {Promise}
      */
-    export function lchown(path: any, uid: any, gid: any): Promise<void>;
+    export function lchown(path: string, uid: number, gid: number): Promise<any>;
     /**
-     * @ignore
+     * Creates a link to `dest` from `dest`.
+     * @param {string} src
+     * @param {string} dest
+     * @return {Promise}
      */
-    export function link(src: any, dest: any): Promise<void>;
+    export function link(src: string, dest: string): Promise<any>;
     /**
      * Asynchronously creates a directory.
      * @todo recursive option is not implemented yet.
@@ -2444,21 +2770,30 @@ declare module "socket:fs/promises" {
      */
     export function readFile(path: string, options?: object | null): Promise<Buffer | string>;
     /**
-     * @ignore
+     * Reads link at `path`
+     * @param {string} path
+     * @return {Promise<string>}
      */
-    export function readlink(path: any): Promise<any>;
+    export function readlink(path: string): Promise<string>;
     /**
-     * @ignore
+     * Computes real path for `path`
+     * @param {string} path
+     * @return {Promise<string>}
      */
-    export function realpath(path: any): Promise<any>;
+    export function realpath(path: string): Promise<string>;
     /**
-     * @ignore
+     * Renames file or directory at `src` to `dest`.
+     * @param {string} src
+     * @param {string} dest
+     * @return {Promise}
      */
-    export function rename(oldPath: any, newPath: any): Promise<void>;
+    export function rename(src: string, dest: string): Promise<any>;
     /**
-     * @ignore
+     * Removes directory at `path`.
+     * @param {string} path
+     * @return {Promise}
      */
-    export function rmdir(path: any): Promise<void>;
+    export function rmdir(path: string): Promise<any>;
     /**
      * @see {@link https://nodejs.org/api/fs.html#fspromisesstatpath-options}
      * @param {string | Buffer | URL} path
@@ -2468,13 +2803,18 @@ declare module "socket:fs/promises" {
      */
     export function stat(path: string | Buffer | URL, options?: object | null): Promise<Stats>;
     /**
-     * @ignore
+     * Creates a symlink of `src` at `dest`.
+     * @param {string} src
+     * @param {string} dest
+     * @return {Promise}
      */
-    export function symlink(src: any, dest: any, type?: any): Promise<void>;
+    export function symlink(src: string, dest: string, type?: any): Promise<any>;
     /**
-     * @ignore
+     * Unlinks (removes) file at `path`.
+     * @param {string} path
+     * @return {Promise}
      */
-    export function unlink(path: any): Promise<void>;
+    export function unlink(path: string): Promise<any>;
     /**
      * @see {@link https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fspromiseswritefilefile-data-options}
      * @param {string | Buffer | URL | FileHandle} path - filename or FileHandle
@@ -2487,6 +2827,14 @@ declare module "socket:fs/promises" {
      * @return {Promise<void>}
      */
     export function writeFile(path: string | Buffer | URL | FileHandle, data: string | Buffer | any[] | DataView | TypedArray, options?: object | null): Promise<void>;
+    /**
+     * Watch for changes at `path` calling `callback`
+     * @param {string}
+     * @param {function|object=} [options]
+     * @param {AbortSignal=} [options.signal]
+     * @return {Watcher}
+     */
+    export function watch(path: any, options?: (Function | object) | undefined): Watcher;
     export type Stats = any;
     export default exports;
     export type Buffer = import("socket:buffer").Buffer;
@@ -2495,6 +2843,7 @@ declare module "socket:fs/promises" {
     import { FileHandle } from "socket:fs/handle";
     import { Dir } from "socket:fs/dir";
     import { Stats } from "socket:fs/stats";
+    import { Watcher } from "socket:fs/watcher";
     import * as constants from "socket:fs/constants";
     import { DirectoryHandle } from "socket:fs/handle";
     import { Dirent } from "socket:fs/dir";
@@ -2502,7 +2851,7 @@ declare module "socket:fs/promises" {
     import { ReadStream } from "socket:fs/stream";
     import { WriteStream } from "socket:fs/stream";
     
-    export { constants, Dir, DirectoryHandle, Dirent, fds, FileHandle, ReadStream, WriteStream };
+    export { constants, Dir, DirectoryHandle, Dirent, fds, FileHandle, ReadStream, Watcher, WriteStream };
 }
 declare module "socket:fs/index" {
     /**
@@ -2531,9 +2880,13 @@ declare module "socket:fs/index" {
      */
     export function chmod(path: string | Buffer | URL, mode: number, callback: (arg0: Error | null) => any): void;
     /**
-     * @ignore
+     * Changes ownership of file or directory at `path` with `uid` and `gid`.
+     * @param {string} path
+     * @param {number} uid
+     * @param {number} gid
+     * @param {function} callback
      */
-    export function chown(path: any, uid: any, gid: any, callback: any): void;
+    export function chown(path: string, uid: number, gid: number, callback: Function): void;
     /**
      * Asynchronously close a file descriptor calling `callback` upon success or error.
      * @see {@link https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fsclosefd-callback}
@@ -2576,13 +2929,20 @@ declare module "socket:fs/index" {
      */
     export function fstat(fd: number, options: any, callback?: Function | null): void;
     /**
-     * @ignore
+     * Chages ownership of link at `path` with `uid` and `gid.
+     * @param {string} path
+     * @param {number} uid
+     * @param {number} gid
+     * @param {function} callback
      */
-    export function lchown(path: any, uid: any, gid: any, callback: any): void;
+    export function lchown(path: string, uid: number, gid: number, callback: Function): void;
     /**
-     * @ignore
+     * Creates a link to `dest` from `dest`.
+     * @param {string} src
+     * @param {string} dest
+     * @param {function}
      */
-    export function link(src: any, dest: any, callback: any): void;
+    export function link(src: string, dest: string, callback: any): void;
     /**
      * @ignore
      */
@@ -2638,21 +2998,30 @@ declare module "socket:fs/index" {
      */
     export function readFile(path: string | Buffer | URL | number, options: {}, callback: (arg0: Error | null, arg1: Buffer | null) => any): void;
     /**
-     * @ignore
+     * Reads link at `path`
+     * @param {string} path
+     * @param {function(err, string)} callback
      */
-    export function readlink(path: any, callback: any): void;
+    export function readlink(path: string, callback: (arg0: err, arg1: string) => any): void;
     /**
-     * @ignore
+     * Computes real path for `path`
+     * @param {string} path
+     * @param {function(err, string)} callback
      */
-    export function realpath(path: any, callback: any): void;
+    export function realpath(path: string, callback: (arg0: err, arg1: string) => any): void;
     /**
-     * @ignore
+     * Renames file or directory at `src` to `dest`.
+     * @param {string} src
+     * @param {string} dest
+     * @param {function} callback
      */
-    export function rename(src: any, dest: any, callback: any): void;
+    export function rename(src: string, dest: string, callback: Function): void;
     /**
-     * @ignore
+     * Removes directory at `path`.
+     * @param {string} path
+     * @param {function} callback
      */
-    export function rmdir(path: any, callback: any): void;
+    export function rmdir(path: string, callback: Function): void;
     /**
      *
      * @param {string | Buffer | URL | number } path - filename or file descriptor
@@ -2664,13 +3033,17 @@ declare module "socket:fs/index" {
      */
     export function stat(path: string | Buffer | URL | number, options: object | null, callback: (arg0: Error | null, arg1: Stats | null) => any): void;
     /**
-     * @ignore
+     * Creates a symlink of `src` at `dest`.
+     * @param {string} src
+     * @param {string} dest
      */
-    export function symlink(src: any, dest: any, type: any, callback: any): void;
+    export function symlink(src: string, dest: string, type: any, callback: any): void;
     /**
-     * @ignore
+     * Unlinks (removes) file at `path`.
+     * @param {string} path
+     * @param {function} callback
      */
-    export function unlink(path: any, callback: any): void;
+    export function unlink(path: string, callback: Function): void;
     /**
      * @see {@url https://nodejs.org/dist/latest-v20.x/docs/api/fs.html#fswritefilefile-data-options-callback}
      * @param {string | Buffer | URL | number } path - filename or file descriptor
@@ -2683,6 +3056,14 @@ declare module "socket:fs/index" {
      * @param {function(Error?)} callback
      */
     export function writeFile(path: string | Buffer | URL | number, data: string | Buffer | TypedArray | DataView | object, options: object | null, callback: (arg0: Error | null) => any): void;
+    /**
+     * Watch for changes at `path` calling `callback`
+     * @param {string}
+     * @param {function|object=} [options]
+     * @param {?function} [callback]
+     * @return {Watcher}
+     */
+    export function watch(path: any, options?: (Function | object) | undefined, callback?: Function | null): Watcher;
     export default exports;
     export type Buffer = import("socket:buffer").Buffer;
     export type TypedArray = Uint8Array | Int8Array;
@@ -2691,6 +3072,7 @@ declare module "socket:fs/index" {
     import { WriteStream } from "socket:fs/stream";
     import { Dir } from "socket:fs/dir";
     import { Stats } from "socket:fs/stats";
+    import { Watcher } from "socket:fs/watcher";
     import * as constants from "socket:fs/constants";
     import { DirectoryHandle } from "socket:fs/handle";
     import { Dirent } from "socket:fs/dir";
@@ -2698,7 +3080,7 @@ declare module "socket:fs/index" {
     import { FileHandle } from "socket:fs/handle";
     import * as promises from "socket:fs/promises";
     
-    export { constants, Dir, DirectoryHandle, Dirent, fds, FileHandle, promises, ReadStream, Stats, WriteStream };
+    export { constants, Dir, DirectoryHandle, Dirent, fds, FileHandle, promises, ReadStream, Stats, Watcher, WriteStream };
 }
 declare module "socket:fs" {
     export * from "socket:fs/index";
@@ -4243,245 +4625,6 @@ declare module "socket:fetch" {
     export * from "socket:fetch/index";
     export default fetch;
     import fetch from "socket:fetch/index";
-}
-declare module "socket:hooks" {
-    /**
-     * Wait for the global Window, Document, and Runtime to be ready.
-     * The callback function is called exactly once.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onReady(callback: Function): Function;
-    /**
-     * Wait for the global Window and Document to be ready. The callback
-     * function is called exactly once.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onLoad(callback: Function): Function;
-    /**
-     * Wait for the runtime to be ready. The callback
-     * function is called exactly once.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onInit(callback: Function): Function;
-    /**
-     * Calls callback when a global exception occurs.
-     * 'error', 'messageerror', and 'unhandledrejection' events are handled here.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onError(callback: Function): Function;
-    /**
-     * Subscribes to the global data pipe calling callback when
-     * new data is emitted on the global Window.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onData(callback: Function): Function;
-    /**
-     * Subscribes to global messages likely from an external `postMessage`
-     * invocation.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onMessage(callback: Function): Function;
-    /**
-     * Calls callback when runtime is working online.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onOnline(callback: Function): Function;
-    /**
-     * Calls callback when runtime is not working online.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onOffline(callback: Function): Function;
-    /**
-     * Calls callback when runtime user preferred language has changed.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onLanguageChange(callback: Function): Function;
-    /**
-     * Calls callback when an application permission has changed.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onPermissionChange(callback: Function): Function;
-    /**
-     * Calls callback in response to a presented `Notification`.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onNotificationResponse(callback: Function): Function;
-    /**
-     * Calls callback when a `Notification` is presented.
-     * @param {function} callback
-     * @return {function}
-     */
-    export function onNotificationPresented(callback: Function): Function;
-    /**
-     * An event dispatched when the runtime has been initialized.
-     */
-    export class InitEvent {
-        constructor();
-    }
-    /**
-     * An event dispatched when the runtime global has been loaded.
-     */
-    export class LoadEvent {
-        constructor();
-    }
-    /**
-     * An event dispatched when the runtime is considered ready.
-     */
-    export class ReadyEvent {
-        constructor();
-    }
-    /**
-     * An interface for registering callbacks for various hooks in
-     * the runtime.
-     */
-    export class Hooks extends EventTarget {
-        /**
-         * Reference to global object
-         * @type {object}
-         */
-        get global(): any;
-        /**
-         * Returns `document` in global.
-         * @type {Document}
-         */
-        get document(): Document;
-        /**
-         * Returns `document` in global.
-         * @type {Window}
-         */
-        get window(): Window;
-        /**
-         * Predicate for determining if the global document is ready.
-         * @type {boolean}
-         */
-        get isDocumentReady(): boolean;
-        /**
-         * Predicate for determining if the global object is ready.
-         * @type {boolean}
-         */
-        get isGlobalReady(): boolean;
-        /**
-         * Predicate for determining if the runtime is ready.
-         * @type {boolean}
-         */
-        get isRuntimeReady(): boolean;
-        /**
-         * Predicate for determining if everything is ready.
-         * @type {boolean}
-         */
-        get isReady(): boolean;
-        /**
-         * Predicate for determining if the runtime is working online.
-         * @type {boolean}
-         */
-        get isOnline(): boolean;
-        /**
-         * Predicate for determining if the runtime is in a Worker context.
-         * @type {boolean}
-         */
-        get isWorkerContext(): boolean;
-        /**
-         * Predicate for determining if the runtime is in a Window context.
-         * @type {boolean}
-         */
-        get isWindowContext(): boolean;
-        /**
-         * Wait for the global Window, Document, and Runtime to be ready.
-         * The callback function is called exactly once.
-         * @param {function} callback
-         * @return {function}
-         */
-        onReady(callback: Function): Function;
-        /**
-         * Wait for the global Window and Document to be ready. The callback
-         * function is called exactly once.
-         * @param {function} callback
-         * @return {function}
-         */
-        onLoad(callback: Function): Function;
-        /**
-         * Wait for the runtime to be ready. The callback
-         * function is called exactly once.
-         * @param {function} callback
-         * @return {function}
-         */
-        onInit(callback: Function): Function;
-        /**
-         * Calls callback when a global exception occurs.
-         * 'error', 'messageerror', and 'unhandledrejection' events are handled here.
-         * @param {function} callback
-         * @return {function}
-         */
-        onError(callback: Function): Function;
-        /**
-         * Subscribes to the global data pipe calling callback when
-         * new data is emitted on the global Window.
-         * @param {function} callback
-         * @return {function}
-         */
-        onData(callback: Function): Function;
-        /**
-         * Subscribes to global messages likely from an external `postMessage`
-         * invocation.
-         * @param {function} callback
-         * @return {function}
-         */
-        onMessage(callback: Function): Function;
-        /**
-         * Calls callback when runtime is working online.
-         * @param {function} callback
-         * @return {function}
-         */
-        onOnline(callback: Function): Function;
-        /**
-         * Calls callback when runtime is not working online.
-         * @param {function} callback
-         * @return {function}
-         */
-        onOffline(callback: Function): Function;
-        /**
-         * Calls callback when runtime user preferred language has changed.
-         * @param {function} callback
-         * @return {function}
-         */
-        onLanguageChange(callback: Function): Function;
-        /**
-         * Calls callback when an application permission has changed.
-         * @param {function} callback
-         * @return {function}
-         */
-        onPermissionChange(callback: Function): Function;
-        /**
-         * Calls callback in response to a displayed `Notification`.
-         * @param {function} callback
-         * @return {function}
-         */
-        onNotificationResponse(callback: Function): Function;
-        /**
-         * Calls callback when a `Notification` is presented.
-         * @param {function} callback
-         * @return {function}
-         */
-        onNotificationPresented(callback: Function): Function;
-        #private;
-    }
-    export default hooks;
-    /**
-     * `Hooks` single instance.
-     * @ignore
-     */
-    const hooks: Hooks;
 }
 declare module "socket:language" {
     /**

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -2628,7 +2628,9 @@ declare module "socket:fs/watcher" {
          * @ignore
          * @param {string} path
          * @param {object=} [options]
+         * @param {AbortSignal=} [options.signal}
          * @param {string|number|bigint=} [options.id]
+         * @param {string=} [options.encoding = 'utf8']
          */
         constructor(path: string, options?: object | undefined);
         /**
@@ -2647,6 +2649,21 @@ declare module "socket:fs/watcher" {
          * @type {boolean}
          */
         closed: boolean;
+        /**
+         * `true` if aborted, otherwise `false`.
+         * @type {boolean}
+         */
+        aborted: boolean;
+        /**
+         * The encoding of the `filename`
+         * @type {'utf8'|'buffer'}
+         */
+        encoding: 'utf8' | 'buffer';
+        /**
+         * A `AbortController` `AbortSignal` for async aborts.
+         * @type {AbortSignal?}
+         */
+        signal: AbortSignal | null;
         /**
          * Internal event listener cancellation.
          * @ignore
@@ -2831,6 +2848,7 @@ declare module "socket:fs/promises" {
      * Watch for changes at `path` calling `callback`
      * @param {string}
      * @param {function|object=} [options]
+     * @param {string=} [options.encoding = 'utf8']
      * @param {AbortSignal=} [options.signal]
      * @return {Watcher}
      */
@@ -3060,6 +3078,7 @@ declare module "socket:fs/index" {
      * Watch for changes at `path` calling `callback`
      * @param {string}
      * @param {function|object=} [options]
+     * @param {string=} [options.encoding = 'utf8']
      * @param {?function} [callback]
      * @return {Watcher}
      */

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -2286,7 +2286,7 @@ declare module "socket:fs/dir" {
          */
         get closed(): boolean;
         /**
-         * `true` if closeing, otherwise `false`.
+         * `true` if closing, otherwise `false`.
          * @ignore
          * @type {boolean}
          */
@@ -2955,7 +2955,7 @@ declare module "socket:fs/index" {
      */
     export function lchown(path: string, uid: number, gid: number, callback: Function): void;
     /**
-     * Creates a link to `dest` from `dest`.
+     * Creates a link to `dest` from `src`.
      * @param {string} src
      * @param {string} dest
      * @param {function}

--- a/src/core/core.cc
+++ b/src/core/core.cc
@@ -618,6 +618,18 @@ namespace SSC {
             this->core->fs.descriptors.erase(tuple.first);
           }
         }
+
+        #if !defined(__ANDROID__)
+        for (auto const &tuple : this->core->fs.watchers) {
+          auto watcher = tuple.second;
+          if (watcher != nullptr) {
+            watcher->stop();
+            delete watcher;
+          }
+        }
+
+        this->core->fs.watchers.clear();
+        #endif
       }
 
       auto json = JSON::Object::Entries {

--- a/src/core/core.hh
+++ b/src/core/core.hh
@@ -432,6 +432,10 @@ namespace SSC {
             uint32_t getBufferSize ();
           };
 
+        #if !defined(__ANDROID__)
+          std::map<uint64_t, FileSystemWatcher*> watchers;
+        #endif
+
           std::map<uint64_t, Descriptor*> descriptors;
           Mutex mutex;
 
@@ -566,8 +570,19 @@ namespace SSC {
             const String path,
             Module::Callback cb
           );
+          void stopWatch (
+            const String seq,
+            uint64_t id,
+            Module::Callback cb
+          );
           void unlink (
             const String seq,
+            const String path,
+            Module::Callback cb
+          );
+          void watch (
+            const String seq,
+            uint64_t id,
             const String path,
             Module::Callback cb
           );

--- a/src/core/preload.cc
+++ b/src/core/preload.cc
@@ -72,6 +72,19 @@ namespace SSC {
       }
     }
 
+    if (opts.appData.contains("webview_watch") && opts.appData.at("webview_watch") == "true") {
+      if (
+        !opts.appData.contains("webview_watch_reload") ||
+        opts.appData.at("webview_watch_reload") != "false"
+      ) {
+          preload += (
+            "  document.addEventListener('filedidchange', () => {              \n"
+            "  location.reload()                                               \n"
+            "  });                                                             \n"
+        );
+      }
+    }
+
     // fill in the config
     for (auto const &tuple : opts.appData) {
       auto key = trim(tuple.first);


### PR DESCRIPTION
This PR introduces the `fs.watch()` and `fs.Watcher` APIs. It is implemented to give as much parity as possible with node's implementation.

### Examples

`EventEmitter`:

```js
import process from 'socket:process'
import fs from 'socket:fs'

// watch resources directory
const watcher  = fs.watch(process.cwd())

watcher.on('change', (eventType, filename) => {
  console.log(eventType) // 'change' or 'rename'
  console.log(filename) // file name relative to `process.cwd()`
})
```

`AsyncIterator` (with `filename` encoding):

```js
import process from 'socket:process'
import fs from 'socket:fs/promises'

// output `filename` as `Buffer` instance
const events = fs.watch(process.cwd(), { encoding: 'buffer' })

for await (const event of events) {
  console.log(event) // { eventType: 'change' | 'rename' , filename: <Buffer ...> }
}
```

`AbortSignal`

```js
import process from 'socket:process'
import fs from 'socket:fs/promises'

const controller = new AbortController()
// output `filename` as `Buffer` instance
const events = fs.watch(process.cwd(), { signal: controller.signal })

// watch files for 5000 ms
setTimeout(() => controller.abort(), 5000)

for await (const event of events) {
  console.log(event) // { eventType: 'change' | 'rename' , filename: 'index.js' }
}
```

Closes #595 