### PR TITLE
fix(src/cli/cli.cc): fixes for build and run commands

### DIFF
--- a/api/CLI.md
+++ b/api/CLI.md
@@ -45,11 +45,12 @@ ssc build [options] [<project-dir>]
 | --- | --- |
 | --platform=<platform> | platform target to build application for (defaults to host):<br>- android<br>- android-emulator<br>- ios<br>- ios-simulator |
 | --port=<port> | load "index.html" from "http://localhost:<port>" |
+| --host=<host> | load "index.html" from "http://<host>" |
 | --test[=path] | indicate test mode, optionally importing a test file relative to resource files |
 | --headless | build application to run in headless mode (without frame or window) |
 | --prod | build for production (disables debugging info, inspector, etc.) |
-| --stdin | read from stdin (dispacted as 'process.stdin' event to window #0) |
 | -D, --debug | enable debug mode |
+| -E, --env | add environment variables |
 | -o, --only-build | only run build step, |
 | -p, --package | package the app for distribution |
 | -q, --quiet | hint for less log output |
@@ -65,19 +66,40 @@ ssc build [options] [<project-dir>]
 ### macOS options
 | Option | Description |
 | --- | --- |
-| -c | code sign application with 'codesign' |
-| -n | notarize application with 'notarytool' |
+| -c, --codesign | code sign application with 'codesign' |
+| -n, --notarize | notarize application with 'notarytool' |
 | -f, --package-format=<format> | package a macOS application in a specified format for distribution:<br>- zip (default)<br>- pkg |
 
 ### iOS options
 | Option | Description |
 | --- | --- |
-| -c | code sign application during xcoddbuild<br>(requires '[ios] provisioning_profile' in 'socket.ini') |
+| -c, --codesign | code sign application during xcoddbuild<br>(requires '[ios] provisioning_profile' in 'socket.ini') |
 
 ### Windows options
 | Option | Description |
 | --- | --- |
 | -f, --package-format=<format> | package a Windows application in a specified format for distribution:<br>- appx (default) |
+
+## ssc run
+Run application.
+
+### Usage
+```bash
+ssc run [options] [<project-dir>]
+```
+
+### options
+| Option | Description |
+| --- | --- |
+| --headless | run application in headless mode (without frame or window) |
+| --platform=<platform> | platform target to run application on (defaults to host):<br>- android<br>- android-emulator<br>- ios<br>- ios-simulator |
+| --port=<port> | load "index.html" from "http://localhost:<port>" |
+| --host=<host> | load "index.html" from "http://<host>" |
+| --prod | build for production (disables debugging info, inspector, etc.) |
+| --test[=path] | indicate test mode, optionally importing a test file relative to resource files |
+| -D, --debug | enable debug mode |
+| -E, --env | add environment variables |
+| -V, --verbose | enable verbose output |
 
 ## ssc list-devices
 Get the list of connected devices.
@@ -145,24 +167,6 @@ ssc print-build-dir [--platform=<platform>] [--prod] [--root] [<project-dir>]
 | --platform | platform to print build directory for (defaults to host):<br>- android<br>- android-emulator<br>- ios<br>- ios-simulator |
 | --prod | indicate production build directory |
 | --root | print the root build directory |
-
-## ssc run
-Run application.
-
-### Usage
-```bash
-ssc run [options] [<project-dir>]
-```
-
-### options
-| Option | Description |
-| --- | --- |
-| -D, --debug | enable debug mode |
-| --headless | run application in headless mode (without frame or window) |
-| --platform=<platform> | platform target to run application on (defaults to host):<br>- android<br>- android-emulator<br>- ios<br>- ios-simulator |
-| --prod | build for production (disables debugging info, inspector, etc.) |
-| --test[=path] | indicate test mode, optionally importing a test file relative to resource files |
-| -V, --verbose | enable verbose output |
 
 ## ssc setup
 Setup build tools for host or target platform.

--- a/api/CLI.md
+++ b/api/CLI.md
@@ -44,8 +44,8 @@ ssc build [options] [<project-dir>]
 | Option | Description |
 | --- | --- |
 | --platform=<platform> | platform target to build application for (defaults to host):<br>- android<br>- android-emulator<br>- ios<br>- ios-simulator |
-| --port=<port> | load "index.html" from "http://localhost:<port>" |
-| --host=<host> | load "index.html" from "http://<host>" |
+| --port=<port> | load "index.html" from a specific port (if host is not specified, defaults to localhost) |
+| --host=<host> | load "index.html" from a specific host (if port is not specified, defaults to 80) |
 | --test[=path] | indicate test mode, optionally importing a test file relative to resource files |
 | --headless | build application to run in headless mode (without frame or window) |
 | --prod | build for production (disables debugging info, inspector, etc.) |
@@ -93,8 +93,8 @@ ssc run [options] [<project-dir>]
 | --- | --- |
 | --headless | run application in headless mode (without frame or window) |
 | --platform=<platform> | platform target to run application on (defaults to host):<br>- android<br>- android-emulator<br>- ios<br>- ios-simulator |
-| --port=<port> | load "index.html" from "http://localhost:<port>" |
-| --host=<host> | load "index.html" from "http://<host>" |
+| --port=<port> | load "index.html" from a specific port (if host is not specified, defaults to localhost) |
+| --host=<host> | load "index.html" from a specific host (if port is not specified, defaults to 80) |
 | --prod | build for production (disables debugging info, inspector, etc.) |
 | --test[=path] | indicate test mode, optionally importing a test file relative to resource files |
 | -D, --debug | enable debug mode |

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2575,7 +2575,9 @@ int main (const int argc, const char* argv[]) {
     { { "--headless", "-H" }, true, false },
     { { "--debug", "-D" }, true, false },
     { { "--verbose", "-V" }, true, false },
-    { { "--env", "-E" }, true, true }
+    { { "--env", "-E" }, true, true },
+    { { "--port" }, true, true },
+    { { "--host"}, true, true }
   };
 
   Options buildOptions = {
@@ -2583,14 +2585,10 @@ int main (const int argc, const char* argv[]) {
     { { "--only-build", "-o" }, true, false },
     { { "--run", "-r" }, true, false },
     { { "--watch", "-W" }, true, false },
-    { { "--debug", "-D" }, true, false },
-    { { "--verbose", "-V" }, true, false },
-    { { "--prod", "-P" }, true, false },
     { { "--package", "-p" }, true, false },
     { { "--package-format", "-f" }, true, true },
     { { "--codesign", "-c" }, true, false },
-    { { "--notarize", "-n" }, true, false },
-    { { "--env", "-E" }, true, true }
+    { { "--notarize", "-n" }, true, false }
   };
 
   // Insert the elements of runOptions into buildOptions

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -39,11 +39,12 @@ options:
                                          - ios
                                          - ios-simulator
   --port=<port>                        load "index.html" from "http://localhost:<port>"
+  --host=<host>                        load "index.html" from "http://<host>"
   --test[=path]                        indicate test mode, optionally importing a test file relative to resource files
   --headless                           build application to run in headless mode (without frame or window)
   --prod                               build for production (disables debugging info, inspector, etc.)
-  --stdin                              read from stdin (dispacted as 'process.stdin' event to window #0)
   -D, --debug                          enable debug mode
+  -E, --env                            add environment variables
   -o, --only-build                     only run build step,
   -p, --package                        package the app for distribution
   -q, --quiet                          hint for less log output
@@ -57,19 +58,43 @@ Linux options:
                                          - zip
 
 macOS options:
-  -c                                   code sign application with 'codesign'
-  -n                                   notarize application with 'notarytool'
+  -c, --codesign                       code sign application with 'codesign'
+  -n, --notarize                       notarize application with 'notarytool'
   -f, --package-format=<format>        package a macOS application in a specified format for distribution:
                                          - zip (default)
                                          - pkg
 
 iOS options:
-  -c                                   code sign application during xcoddbuild
+  -c, --codesign                       code sign application during xcoddbuild
                                        (requires '[ios] provisioning_profile' in 'socket.ini')
 
 Windows options:
   -f, --package-format=<format>        package a Windows application in a specified format for distribution:
                                          - appx (default)
+)TEXT";
+
+constexpr auto gHelpTextRun = R"TEXT(
+ssc v{{ssc_version}}
+
+Run application.
+
+usage:
+  ssc run [options] [<project-dir>]
+
+options:
+  --headless                           run application in headless mode (without frame or window)
+  --platform=<platform>                platform target to run application on (defaults to host):
+                                         - android
+                                         - android-emulator
+                                         - ios
+                                         - ios-simulator
+  --port=<port>                        load "index.html" from "http://localhost:<port>"
+  --host=<host>                        load "index.html" from "http://<host>"
+  --prod                               build for production (disables debugging info, inspector, etc.)
+  --test[=path]                        indicate test mode, optionally importing a test file relative to resource files
+  -D, --debug                          enable debug mode
+  -E, --env                            add environment variables
+  -V, --verbose                        enable verbose output
 )TEXT";
 
 constexpr auto gHelpTextListDevices = R"TEXT(
@@ -141,27 +166,6 @@ options:
                                          - ios-simulator
   --prod                               indicate production build directory
   --root                               print the root build directory
-)TEXT";
-
-constexpr auto gHelpTextRun = R"TEXT(
-ssc v{{ssc_version}}
-
-Run application.
-
-usage:
-  ssc run [options] [<project-dir>]
-
-options:
-  -D, --debug                          enable debug mode
-  --headless                           run application in headless mode (without frame or window)
-  --platform=<platform>                platform target to run application on (defaults to host):
-                                         - android
-                                         - android-emulator
-                                         - ios
-                                         - ios-simulator
-  --prod                               build for production (disables debugging info, inspector, etc.)
-  --test[=path]                        indicate test mode, optionally importing a test file relative to resource files
-  -V, --verbose                        enable verbose output
 )TEXT";
 
 constexpr auto gHelpTextSetup = R"TEXT(

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -38,8 +38,8 @@ options:
                                          - android-emulator
                                          - ios
                                          - ios-simulator
-  --port=<port>                        load "index.html" from "http://localhost:<port>"
-  --host=<host>                        load "index.html" from "http://<host>"
+  --port=<port>                        load "index.html" from a specific port (if host is not specified, defaults to localhost)
+  --host=<host>                        load "index.html" from a specific host (if port is not specified, defaults to 80)
   --test[=path]                        indicate test mode, optionally importing a test file relative to resource files
   --headless                           build application to run in headless mode (without frame or window)
   --prod                               build for production (disables debugging info, inspector, etc.)
@@ -88,8 +88,8 @@ options:
                                          - android-emulator
                                          - ios
                                          - ios-simulator
-  --port=<port>                        load "index.html" from "http://localhost:<port>"
-  --host=<host>                        load "index.html" from "http://<host>"
+  --port=<port>                        load "index.html" from a specific port (if host is not specified, defaults to localhost)
+  --host=<host>                        load "index.html" from a specific host (if port is not specified, defaults to 80)
   --prod                               build for production (disables debugging info, inspector, etc.)
   --test[=path]                        indicate test mode, optionally importing a test file relative to resource files
   -D, --debug                          enable debug mode

--- a/src/core/preload.cc
+++ b/src/core/preload.cc
@@ -78,7 +78,7 @@ namespace SSC {
         opts.appData.at("webview_watch_reload") != "false"
       ) {
           preload += (
-            "  document.addEventListener('filedidchange', () => {              \n"
+            "  globalThis.addEventListener('filedidchange', () => {            \n"
             "  location.reload()                                               \n"
             "  });                                                             \n"
         );


### PR DESCRIPTION
Fixes:
- add `--port` and `--host` as valid flags
- remove `--stdin` (not implemented)
- remove flag duplicates from `build` command (those that are already in the `run`)
- fixes for help output and CLI.md