### PR TITLE
fix: use a `shared_ptr` for IPC HTTP request cancellation callback

### DIFF
--- a/src/extension/ipc.cc
+++ b/src/extension/ipc.cc
@@ -147,12 +147,14 @@ bool sapi_ipc_set_cancellation_handler (
   void (*handler)(void*),
   void* data
 ) {
-  if (result == nullptr || !result->message.isHTTP) {
+  if (result == nullptr || result->message.cancel == nullptr) {
     return false;
   }
   auto message = result->message;
-  message.cancel = handler;
-  message.cancel_data = data;
+  *message.cancel = {
+    .handler = handler,
+    .data = data
+  };
   return true;
 }
 

--- a/src/ipc/bridge.cc
+++ b/src/ipc/bridge.cc
@@ -2404,9 +2404,8 @@ static void registerSchemeHandler (Router *router) {
   Lock lock(mutex);
   if (tasks.contains(task)) {
     auto message = tasks[task];
-    if (message.cancel != nullptr) {
-      message.cancel(message.cancel_data);
-      message.cancel = nullptr;
+    if (message.cancel->handler != nullptr) {
+      message.cancel->handler(message.cancel->data);
     }
   }
   [self finalizeTask: task];
@@ -2421,6 +2420,7 @@ static void registerSchemeHandler (Router *router) {
   auto url = String(request.URL.absoluteString.UTF8String);
   auto message = Message(url, true);
   message.isHTTP = true;
+  message.cancel = std::make_shared<MessageCancellation>();
 
   if (String(request.HTTPMethod.UTF8String) == "OPTIONS") {
     auto headers = [NSMutableDictionary dictionary];

--- a/src/ipc/ipc.cc
+++ b/src/ipc/ipc.cc
@@ -33,6 +33,7 @@ namespace SSC::IPC {
     this->uri = message.uri;
     this->args = message.args;
     this->isHTTP = message.isHTTP;
+    this->cancel = message.cancel;
   }
 
   Message::Message (const String& source, char *bytes, size_t size)

--- a/src/ipc/ipc.hh
+++ b/src/ipc/ipc.hh
@@ -136,6 +136,11 @@ namespace SSC::IPC {
     MessageBuffer() = default;
   };
 
+  struct MessageCancellation {
+    void (*handler)(void*) = nullptr;
+    void *data = nullptr;
+  };
+
   class Message {
     public:
       using Seq = String;
@@ -147,8 +152,7 @@ namespace SSC::IPC {
       Seq seq = "";
       Map args;
       bool isHTTP = false;
-      void (*cancel)(void*) = nullptr;
-      void *cancel_data = nullptr;
+      std::shared_ptr<MessageCancellation> cancel;
 
       Message () = default;
       Message (const Message& message);


### PR DESCRIPTION
Since the message is copied, we need a pointer for `sapi_ipc_set_cancellation_handler` to work as expected.

Currently, only HTTP requests to `ipc://` addresses can have a cancellation handler set by an extension route (and only on macOS). But in the future, this could be added to other platforms or even other transport types.