### PR TITLE
Introduce '[build] build.forward_arguments'

### DIFF
--- a/api/CONFIG.md
+++ b/api/CONFIG.md
@@ -47,7 +47,7 @@ headless | false |  If true, the window will never be displayed.
 name |  |  The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
 output | "build" |  The binary output path. It's recommended to add this path to .gitignore.
 script |  |  The build script. It runs before the `[build] copy` phase.
-pass.build.arguments | false |  If true, it will pass build arguments to the build script. WARNING: this could be deprecated in the future.
+build.script.forward_arguments | false |  If true, it will pass build arguments to the build script. WARNING: this could be deprecated in the future.
 
 # `build.watch`
 

--- a/api/CONFIG.md
+++ b/api/CONFIG.md
@@ -47,6 +47,7 @@ headless | false |  If true, the window will never be displayed.
 name |  |  The name of the program and executable to be output. Can't contain spaces or special characters. Required field.
 output | "build" |  The binary output path. It's recommended to add this path to .gitignore.
 script |  |  The build script. It runs before the `[build] copy` phase.
+pass.build.arguments | false |  If true, it will pass build arguments to the build script. WARNING: this could be deprecated in the future.
 
 # `build.watch`
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -507,24 +507,15 @@ void handleBuildPhaseForUserScript (
   } while (0);
 
   const bool shouldPassBuildArgs = settings.contains("build_pass.build.arguments") && settings.at("build_pass.build.arguments") == "true";
-  StringStream buildArgs;
-
-  if (shouldPassBuildArgs) {
-    buildArgs << " " << pathResourcesRelativeToUserBuild.string();
-  }
+  String scriptArgs = shouldPassBuildArgs ? (" " + pathResourcesRelativeToUserBuild.string()) : "";
 
   if (settings.contains("build_script") && settings.at("build_script").size() > 0) {
-    auto scriptArgs = buildArgs.str();
     auto buildScript = settings.at("build_script");
 
     // Windows CreateProcess() won't work if the script has an extension other than exe (say .cmd or .bat)
     // cmd.exe can handle this translation
     if (platform.win) {
-      if (shouldPassBuildArgs) {
-        scriptArgs =  " /c \"" + buildScript  + " " + scriptArgs + "\"";
-      } else {
-        scriptArgs =  " /c \"" + buildScript + "\"";
-      }
+      scriptArgs = " /c \"" + buildScript + scriptArgs + "\"";
       buildScript = "cmd.exe";
     }
 
@@ -550,7 +541,6 @@ void handleBuildPhaseForUserScript (
 
   // runs async, does not block
   if (performAfterLifeCycle && settings.contains("build_script_after") && settings.at("build_script_after").size() > 0) {
-    auto scriptArgs = buildArgs.str();
     auto buildScript = settings.at("build_script_after");
 
     // Windows CreateProcess() won't work if the script has an extension other than exe (say .cmd or .bat)

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -546,11 +546,7 @@ void handleBuildPhaseForUserScript (
     // Windows CreateProcess() won't work if the script has an extension other than exe (say .cmd or .bat)
     // cmd.exe can handle this translation
     if (platform.win) {
-      if (shouldPassBuildArgs) {
-        scriptArgs =  " /c \"" + buildScript + " " + scriptArgs + "\"";
-      } else {
-        scriptArgs =  " /c \"" + buildScript + "\"";
-      }
+      scriptArgs = " /c \"" + buildScript + scriptArgs + "\"";
       buildScript = "cmd.exe";
     }
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -486,7 +486,6 @@ void handleBuildPhaseForUserScript (
   const String& targetPlatform,
   const Path pathResourcesRelativeToUserBuild,
   const Path& cwd,
-  const String& additionalArgs,
   bool performAfterLifeCycle
 ) {
   do {
@@ -512,7 +511,6 @@ void handleBuildPhaseForUserScript (
 
   if (shouldPassBuildArgs) {
     buildArgs << " " << pathResourcesRelativeToUserBuild.string();
-    buildArgs << " " << additionalArgs;
   }
 
   if (settings.contains("build_script") && settings.at("build_script").size() > 0) {
@@ -2625,7 +2623,6 @@ int main (const int argc, const char* argv[]) {
 
     String argvForward = "";
     String targetPlatform = optionsWithValue["--platform"];
-    String additionalBuildArgs = "";
 
     bool flagRunUserBuildOnly = optionsWithoutValue.find("--only-build") != optionsWithoutValue.end() || equal(rc["build_only"], "true");
     bool flagCodeSign = optionsWithoutValue.find("--codesign") != optionsWithoutValue.end() || equal(rc["build_codesign"], "true");
@@ -2814,16 +2811,6 @@ int main (const int argc, const char* argv[]) {
     }
 
     auto pathResourcesRelativeToUserBuild = paths.pathResourcesRelativeToUserBuild;
-
-    const bool shouldPassBuildArgs = settings.contains("build_pass.build.arguments") && settings.at("build_pass.build.arguments") == "true";
-
-    if (flagDebugMode && shouldPassBuildArgs) {
-      additionalBuildArgs += " --debug=true";
-    }
-
-    if (flagBuildTest && shouldPassBuildArgs) {
-      additionalBuildArgs += " --test=true";
-    }
 
     String flags;
     String files;
@@ -4518,7 +4505,6 @@ int main (const int argc, const char* argv[]) {
       targetPlatform,
       pathResourcesRelativeToUserBuild,
       oldCwd,
-      additionalBuildArgs,
       true
     );
 
@@ -6330,7 +6316,6 @@ int main (const int argc, const char* argv[]) {
           targetPlatform,
           pathResourcesRelativeToUserBuild,
           targetPath,
-          additionalBuildArgs,
           false
         );
 

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -506,7 +506,7 @@ void handleBuildPhaseForUserScript (
 #endif
   } while (0);
 
-  const bool shouldPassBuildArgs = settings.contains("build_pass.build.arguments") && settings.at("build_pass.build.arguments") == "true";
+  const bool shouldPassBuildArgs = settings.contains("build.script.forward_arguments") && settings.at("build.script.forward_arguments") == "true";
   String scriptArgs = shouldPassBuildArgs ? (" " + pathResourcesRelativeToUserBuild.string()) : "";
 
   if (settings.contains("build_script") && settings.at("build_script").size() > 0) {

--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -507,10 +507,10 @@ void handleBuildPhaseForUserScript (
 #endif
   } while (0);
 
-  const bool isLegacyBuildMode = settings.contains("build_pass.build.arguments") && settings.at("build_pass.build.arguments") == "true";
+  const bool shouldPassBuildArgs = settings.contains("build_pass.build.arguments") && settings.at("build_pass.build.arguments") == "true";
   StringStream buildArgs;
 
-  if (isLegacyBuildMode) {
+  if (shouldPassBuildArgs) {
     buildArgs << " " << pathResourcesRelativeToUserBuild.string();
     buildArgs << " " << additionalArgs;
   }
@@ -522,7 +522,7 @@ void handleBuildPhaseForUserScript (
     // Windows CreateProcess() won't work if the script has an extension other than exe (say .cmd or .bat)
     // cmd.exe can handle this translation
     if (platform.win) {
-      if (isLegacyBuildMode) {
+      if (shouldPassBuildArgs) {
         scriptArgs =  " /c \"" + buildScript  + " " + scriptArgs + "\"";
       } else {
         scriptArgs =  " /c \"" + buildScript + "\"";
@@ -558,7 +558,7 @@ void handleBuildPhaseForUserScript (
     // Windows CreateProcess() won't work if the script has an extension other than exe (say .cmd or .bat)
     // cmd.exe can handle this translation
     if (platform.win) {
-      if (isLegacyBuildMode) {
+      if (shouldPassBuildArgs) {
         scriptArgs =  " /c \"" + buildScript + " " + scriptArgs + "\"";
       } else {
         scriptArgs =  " /c \"" + buildScript + "\"";
@@ -2815,13 +2815,13 @@ int main (const int argc, const char* argv[]) {
 
     auto pathResourcesRelativeToUserBuild = paths.pathResourcesRelativeToUserBuild;
 
-    const bool isLegacyBuildMode = settings.contains("build_pass.build.arguments") && settings.at("build_pass.build.arguments") == "true";
+    const bool shouldPassBuildArgs = settings.contains("build_pass.build.arguments") && settings.at("build_pass.build.arguments") == "true";
 
-    if (flagDebugMode && isLegacyBuildMode) {
+    if (flagDebugMode && shouldPassBuildArgs) {
       additionalBuildArgs += " --debug=true";
     }
 
-    if (flagBuildTest && isLegacyBuildMode) {
+    if (flagBuildTest && shouldPassBuildArgs) {
       additionalBuildArgs += " --test=true";
     }
 

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1648,6 +1648,10 @@ output = "build"
 ; The build script. It runs before the `[build] copy` phase.
 ; script = "npm run build"
 
+; If true, it will pass build arguments to the build script. WARNING: this could be deprecated in the future.
+; default value: false
+; pass.build.arguments = true
+
 
 [build.watch]
 sources = "src"

--- a/src/cli/templates.hh
+++ b/src/cli/templates.hh
@@ -1650,7 +1650,7 @@ output = "build"
 
 ; If true, it will pass build arguments to the build script. WARNING: this could be deprecated in the future.
 ; default value: false
-; pass.build.arguments = true
+; build.script.forward_arguments = true
 
 
 [build.watch]


### PR DESCRIPTION
This is the simplest solution which fixes the #716. It doesn't pass any arguments as environment variables and just skips them until `[build] pass.build.arguments` is equal `true` explicitely