### PR TITLE
Improve 'Notification' api

### DIFF
--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -6967,9 +6967,14 @@ declare module "socket:notification" {
         static get maxActions(): number;
         /**
          * Requests permission from the user to display notifications.
+         * @param {object=} [options]
+         * @param {boolean=} [options.alert = true] - (macOS/iOS only)
+         * @param {boolean=} [options.sound = false] - (macOS/iOS only)
+         * @param {boolean=} [options.badge = false] - (macOS/iOS only)
+         * @param {boolean=} [options.force = false]
          * @return {Promise<'granted'|'default'|'denied'>}
          */
-        static requestPermission(): Promise<'granted' | 'default' | 'denied'>;
+        static requestPermission(options?: object | undefined): Promise<'granted' | 'default' | 'denied'>;
         /**
          * `Notification` class constructor.
          * @param {string} title

--- a/api/internal/permissions.js
+++ b/api/internal/permissions.js
@@ -12,6 +12,13 @@ import gc from '../gc.js'
 import os from '../os.js'
 
 /**
+ * The 'permissionchange' event name.
+ * @ignore
+ * @type {string}
+ */
+const PERMISSION_CHANGE_EVENT = 'permissionchange'
+
+/**
  * @typedef {{ name: string }} PermissionDescriptor
  */
 
@@ -227,7 +234,7 @@ export async function query (descriptor, options) {
     return platform.query(descriptor)
   }
 
-  const result = await ipc.send('permissions.query', { name, signal: options?.signal })
+  const result = await ipc.request('permissions.query', { name, signal: options?.signal })
 
   if (result.err) {
     throw result.err
@@ -279,10 +286,12 @@ export async function request (descriptor, options) {
   if (isLinux) {
     if (name === 'notifications' || name === 'push') {
       const currentState = Notification.permission
+      // `Notification.requestPermission` will use the native
+      // `requestPermission` API internally, so this won't be a cycle
       const state = await Notification.requestPermission()
 
       if (currentState !== state) {
-        const globalEvent = new CustomEvent('permissionchange', {
+        const globalEvent = new CustomEvent(PERMISSION_CHANGE_EVENT, {
           detail: { name, state }
         })
 
@@ -297,13 +306,19 @@ export async function request (descriptor, options) {
     return new PermissionStatus(name, 'prompt', options)
   }
 
-  const result = await ipc.send('permissions.request', { name, signal: options?.signal })
+  const { signal } = options || {}
+
+  if (options?.signal) {
+    delete options.signal
+  }
+
+  const result = await ipc.request('permissions.request', { ...options, name, signal })
 
   if (result.err) {
     throw result.err
   }
 
-  const globalEvent = new CustomEvent('permissionchange', {
+  const globalEvent = new CustomEvent(PERMISSION_CHANGE_EVENT, {
     detail: {
       name,
       state: result.data.state

--- a/src/ipc/bridge.cc
+++ b/src/ipc/bridge.cc
@@ -1088,7 +1088,12 @@ static void initRouterTable (Router *router) {
 
     auto performedActivation = [router->locationObserver getCurrentPositionWithCompletion: ^(NSError* error, CLLocation* location) {
       if (error != nullptr) {
-        auto err = JSON::Object::Entries {{ "message", String(error.localizedFailureReason.UTF8String) }};
+        auto message = String(
+           error.localizedDescription.UTF8String != nullptr
+             ? error.localizedDescription.UTF8String
+             : "An unknown error occurred"
+         );
+        auto err = JSON::Object::Entries {{ "message", message }};
         err["type"] = "GeolocationPositionError";
         return reply(Result::Err { message, err });
       }
@@ -1135,7 +1140,12 @@ static void initRouterTable (Router *router) {
 
     const int identifier = [router->locationObserver watchPositionForIdentifier: id  completion: ^(NSError* error, CLLocation* location) {
       if (error != nullptr) {
-        auto err = JSON::Object::Entries {{ "message", String(error.localizedFailureReason.UTF8String) }};
+        auto message = String(
+           error.localizedDescription.UTF8String != nullptr
+             ? error.localizedDescription.UTF8String
+             : "An unknown error occurred"
+        );
+        auto err = JSON::Object::Entries {{ "message", message }};
         err["type"] = "GeolocationPositionError";
         return reply(Result::Err { message, err });
       }
@@ -1298,8 +1308,8 @@ static void initRouterTable (Router *router) {
 
       if (error != nullptr) {
         auto message = String(
-          error.localizedFailureReason.UTF8String != nullptr
-            ? error.localizedFailureReason.UTF8String
+          error.localizedDescription.UTF8String != nullptr
+            ? error.localizedDescription.UTF8String
             : "An unknown error occurred"
         );
 
@@ -1341,8 +1351,8 @@ static void initRouterTable (Router *router) {
 
       if (error != nullptr) {
         auto message = String(
-          error.localizedFailureReason.UTF8String != nullptr
-            ? error.localizedFailureReason.UTF8String
+          error.localizedDescription.UTF8String != nullptr
+            ? error.localizedDescription.UTF8String
             : "An unknown error occurred"
         );
 
@@ -1393,9 +1403,12 @@ static void initRouterTable (Router *router) {
       ];
 
       if (error != nullptr) {
-        auto err = JSON::Object::Entries {
-          { "message", String(error.localizedFailureReason.UTF8String) }
-        };
+        auto message = String(
+           error.localizedDescription.UTF8String != nullptr
+             ? error.localizedDescription.UTF8String
+             : "An unknown error occurred"
+        );
+        auto err = JSON::Object::Entries {{ "message", message }};
 
         return reply(Result::Err { message, err });
       }
@@ -1422,8 +1435,8 @@ static void initRouterTable (Router *router) {
     [notificationCenter addNotificationRequest: request withCompletionHandler: ^(NSError* error) {
       if (error != nullptr) {
         auto message = String(
-          error.localizedFailureReason.UTF8String != nullptr
-            ? error.localizedFailureReason.UTF8String
+          error.localizedDescription.UTF8String != nullptr
+            ? error.localizedDescription.UTF8String
             : "An unknown error occurred"
         );
 
@@ -1705,8 +1718,14 @@ static void initRouterTable (Router *router) {
             return reply(Result::Data { message, data });
           } else if (settings.authorizationStatus == UNAuthorizationStatusNotDetermined) {
             if (error) {
+              auto message = String(
+                error.localizedDescription.UTF8String != nullptr
+                  ? error.localizedDescription.UTF8String
+                  : "An unknown error occurred"
+              );
+
               auto err = JSON::Object::Entries {
-                { "message", String(error.localizedFailureReason.UTF8String) }
+                { "message", message }
               };
 
               return reply(Result::Err { message, err });


### PR DESCRIPTION
This PR improves the `Notification` API and the `Notification.requestPermission` API by returning the correct permission value, defaulting to "alert" style notifications on macOS/iOS. User's can control this setting in the operating system settings app on macOS/iOS.