### PR TITLE
feat(api/path): introduce well known path constants

### DIFF
--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1177,17 +1177,64 @@ declare module "socket:path/posix" {
     
     export { win32, Path };
 }
+declare module "socket:path/well-known" {
+    /**
+     * Well known path to the user's "Downloads" folder.
+     * @type {?string}
+     */
+    export const DOWNLOADS: string | null;
+    /**
+     * Well known path to the user's "Documents" folder.
+     * @type {?string}
+     */
+    export const DOCUMENTS: string | null;
+    /**
+     * Well known path to the user's "Pictures" folder.
+     * @type {?string}
+     */
+    export const PICTURES: string | null;
+    /**
+     * Well known path to the user's "Desktop" folder.
+     * @type {?string}
+     */
+    export const DESKTOP: string | null;
+    /**
+     * Well known path to the user's "Videos" folder.
+     * @type {?string}
+     */
+    export const VIDEOS: string | null;
+    /**
+     * Well known path to the user's "Music" folder.
+     * @type {?string}
+     */
+    export const MUSIC: string | null;
+    namespace _default {
+        export { DOWNLOADS };
+        export { DOCUMENTS };
+        export { PICTURES };
+        export { DESKTOP };
+        export { VIDEOS };
+        export { MUSIC };
+    }
+    export default _default;
+}
 declare module "socket:path/index" {
     export * as _default from "socket:path/index";
     
     import * as posix from "socket:path/posix";
     import * as win32 from "socket:path/win32";
     import { Path } from "socket:path/path";
-    export { posix, win32, Path };
+    import { DOWNLOADS } from "socket:path/well-known";
+    import { DOCUMENTS } from "socket:path/well-known";
+    import { PICTURES } from "socket:path/well-known";
+    import { DESKTOP } from "socket:path/well-known";
+    import { VIDEOS } from "socket:path/well-known";
+    import { MUSIC } from "socket:path/well-known";
+    export { posix, win32, Path, DOWNLOADS, DOCUMENTS, PICTURES, DESKTOP, VIDEOS, MUSIC };
 }
 declare module "socket:path" {
     export const sep: "/" | "\\";
-    export const delimiter: ";";
+    export const delimiter: ":" | ";";
     export const resolve: typeof posix.win32.resolve;
     export const join: typeof posix.win32.join;
     export const dirname: typeof posix.win32.dirname;
@@ -1204,7 +1251,13 @@ declare module "socket:path" {
     import { posix } from "socket:path/index";
     import { Path } from "socket:path/index";
     import { win32 } from "socket:path/index";
-    export { Path, posix, win32 };
+    import { DOWNLOADS } from "socket:path/index";
+    import { DOCUMENTS } from "socket:path/index";
+    import { PICTURES } from "socket:path/index";
+    import { DESKTOP } from "socket:path/index";
+    import { VIDEOS } from "socket:path/index";
+    import { MUSIC } from "socket:path/index";
+    export { Path, posix, win32, DOWNLOADS, DOCUMENTS, PICTURES, DESKTOP, VIDEOS, MUSIC };
 }
 declare module "socket:diagnostics/channels" {
     /**

--- a/api/path.js
+++ b/api/path.js
@@ -1,10 +1,22 @@
-import { Path, posix, win32 } from './path/index.js'
 import { primordials } from './ipc.js'
+import {
+  Path,
+  posix,
+  win32,
+
+  // well known
+  DOWNLOADS,
+  DOCUMENTS,
+  PICTURES,
+  DESKTOP,
+  VIDEOS,
+  MUSIC
+} from './path/index.js'
 
 const isWin32 = primordials.platform === 'win32'
 
 export const sep = isWin32 ? win32.sep : posix.sep
-export const delimiter = isWin32 ? win32.delimiter : win32.delimiter
+export const delimiter = isWin32 ? win32.delimiter : posix.delimiter
 
 export const resolve = isWin32 ? win32.resolve : posix.resolve
 export const join = isWin32 ? win32.join : posix.join
@@ -18,5 +30,17 @@ export const format = isWin32 ? win32.format : posix.format
 export const normalize = isWin32 ? win32.normalize : posix.normalize
 export const relative = isWin32 ? win32.relative : posix.relative
 
-export { Path, posix, win32 }
+export {
+  Path,
+  posix,
+  win32,
+
+  DOWNLOADS,
+  DOCUMENTS,
+  PICTURES,
+  DESKTOP,
+  VIDEOS,
+  MUSIC
+}
+
 export default isWin32 ? win32 : posix

--- a/api/path/index.js
+++ b/api/path/index.js
@@ -2,10 +2,27 @@ import { Path } from './path.js'
 import * as posix from './posix.js'
 import * as win32 from './win32.js'
 
+import {
+  DOWNLOADS,
+  DOCUMENTS,
+  PICTURES,
+  DESKTOP,
+  VIDEOS,
+  MUSIC
+} from './well-known.js'
+
 export * as default from './index.js'
 
 export {
   posix,
   win32,
-  Path
+  Path,
+
+  // well known
+  DOWNLOADS,
+  DOCUMENTS,
+  PICTURES,
+  DESKTOP,
+  VIDEOS,
+  MUSIC
 }

--- a/api/path/well-known.js
+++ b/api/path/well-known.js
@@ -1,0 +1,48 @@
+import ipc from '../ipc.js'
+
+const paths = ipc.sendSync('os.paths')
+
+/**
+ * Well known path to the user's "Downloads" folder.
+ * @type {?string}
+ */
+export const DOWNLOADS = paths.data.downloads || null
+
+/**
+ * Well known path to the user's "Documents" folder.
+ * @type {?string}
+ */
+export const DOCUMENTS = paths.data.documents || null
+
+/**
+ * Well known path to the user's "Pictures" folder.
+ * @type {?string}
+ */
+export const PICTURES = paths.data.pictures || null
+
+/**
+ * Well known path to the user's "Desktop" folder.
+ * @type {?string}
+ */
+export const DESKTOP = paths.data.desktop || null
+
+/**
+ * Well known path to the user's "Videos" folder.
+ * @type {?string}
+ */
+export const VIDEOS = paths.data.videos || null
+
+/**
+ * Well known path to the user's "Music" folder.
+ * @type {?string}
+ */
+export const MUSIC = paths.data.music || null
+
+export default {
+  DOWNLOADS,
+  DOCUMENTS,
+  PICTURES,
+  DESKTOP,
+  VIDEOS,
+  MUSIC
+}

--- a/src/android/bridge.kt
+++ b/src/android/bridge.kt
@@ -163,6 +163,32 @@ open class Bridge (runtime: Runtime, configuration: IBridgeConfiguration) {
     }
 
     when (message.command) {
+      "os.paths" -> {
+        val storage = android.os.Environment.getExternalStorageDirectory().absolutePath
+        val Environment.getExternalStoragePublicDirectory
+
+        var downloads = "$storage/Downloads"
+        var documents = android.os.Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS).absolutePath
+        var pictures = "$storage/Pictures"
+        var desktop = activity.getExternalFilesDir(null).absolutePath
+        var videos = "$storage/DCIM/Camera/"
+        var music = "$storage/Music"
+        var home = desktop
+
+        callback(Result(0, message.seq, message.command, """{
+          "data": {
+            "downloads": "$downloads",
+            "documents": "$documents",
+            "pictures": "$pictures",
+            "desktop": "$desktop",
+            "videos": "$videos",
+            "music": "$music",
+            "home": "$home"
+          }
+        }"""))
+        return true
+      }
+
       "permissions.request" -> {
         if (!message.has("name")) {
           callback(Result(0, message.seq, message.command, """{


### PR DESCRIPTION
This PR introduces well known path constants for use with path resolution or the `socket:fs` module.

It includes constants for the following:

- `path.DOWNLOADS` A path to the user's or app container `Downloads/` folder
- `path.DOCUMENTS` A path to the user's or app container `Documents/` folder
- `path.PICTURES` A path to the user's or app container `Pictures/` folder
- `path.DESKTOP` A path to the user's or app container `Desktop/` folder
- `path.VIDEOS` A path to the user's or app container `Videos/` folder
- `path.MUSIC` A path to the user's or app container `Music` folder
