### PR TITLE
Fix os.platform bug

### DIFF
--- a/api/internal/permissions.js
+++ b/api/internal/permissions.js
@@ -23,7 +23,7 @@ const PERMISSION_CHANGE_EVENT = 'permissionchange'
  */
 
 const isAndroid = os.platform() === 'android'
-const isApple = os.platform() === 'darwin'
+const isApple = os.platform() === 'darwin' || os.platform() === 'ios'
 const isLinux = os.platform() === 'linux'
 
 /**


### PR DESCRIPTION
When os.platform was returning iOS, it wasn't being treated as an apple device.