### PR TITLE
update ssc init

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2190,23 +2190,14 @@ int main (const int argc, const char* argv[]) {
     { { "--name", "-n" }, true, true }
   };
   createSubcommand("init", initOptions, false, [&](Map optionsWithValue, std::unordered_set<String> optionsWithoutValue) -> void {
-    auto isCurrentPathEmpty = fs::is_empty(fs::current_path());
+    auto isTargetPathEmpty = fs::exists(targetPath) ? fs::is_empty(targetPath) : true;
     auto configOnly = optionsWithoutValue.find("--config") != optionsWithoutValue.end();
-    auto projectName = optionsWithValue["--name"];
+    auto projectName = optionsWithValue["--name"].size() > 0 ? optionsWithValue["--name"] : targetPath.filename().string();
 
-    // create socket.ini
-    if (fs::exists(targetPath / "socket.ini")) {
-      log("socket.ini already exists in " + targetPath.string());
-    } else {
-      if (projectName.size() > 0) {
-        defaultTemplateAttrs["project_name"] = projectName;
-      }
-      writeFile(targetPath / "socket.ini", tmpl(gDefaultConfig, defaultTemplateAttrs));
-      log("socket.ini created in " + targetPath.string());
-    }
+    log("project name: " + projectName);
 
     if (!configOnly) {
-      if (isCurrentPathEmpty) {
+      if (isTargetPathEmpty) {
         // create src/index.html
         fs::create_directories(targetPath / "src");
         writeFile(targetPath / "src" / "index.html", gHelloWorld);
@@ -2226,6 +2217,18 @@ int main (const int argc, const char* argv[]) {
         log(".gitignore already exists in " + targetPath.string());
       }
     }
+
+    // create socket.ini
+    if (fs::exists(targetPath / "socket.ini")) {
+      log("socket.ini already exists in " + targetPath.string());
+    } else {
+      if (projectName.size() > 0) {
+        defaultTemplateAttrs["project_name"] = projectName;
+      }
+      writeFile(targetPath / "socket.ini", tmpl(gDefaultConfig, defaultTemplateAttrs));
+      log("socket.ini created in " + targetPath.string());
+    }
+
     exit(0);
   });
 


### PR DESCRIPTION
make `<path>` work, take name from path when possible

@jwerle probably same changes needed in the CLI refactor branch.

- Project name will be the last child directory name (current directory name if `ssc init` is run without a path)
- `--name` have preference over the one from the path