### PR TITLE
Fix build watch cli shorthand (`-w`)

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -2591,7 +2591,7 @@ int main (const int argc, const char* argv[]) {
     { { "--quiet", "-q" }, true, false },
     { { "--only-build", "-o" }, true, false },
     { { "--run", "-r" }, true, false },
-    { { "--watch", "-W" }, true, false },
+    { { "--watch", "-w" }, true, false },
     { { "--package", "-p" }, true, false },
     { { "--package-format", "-f" }, true, true },
     { { "--codesign", "-c" }, true, false },


### PR DESCRIPTION
`ssc build -h` states that watch should run with either `--watch` or `-w`:

```
  -w, --watch                          watch for changes to rerun build step
```

`cli.cc`, however, sets the shorthand to `-W`.

This PR addresses this.