### PR TITLE
Remove narrow exports specifier

### DIFF
--- a/npm/packages/@socketsupply/socket/package.json
+++ b/npm/packages/@socketsupply/socket/package.json
@@ -5,10 +5,6 @@
   "type": "module",
   "main": "index.js",
   "types": "index.d.ts",
-  "exports": {
-    "types": "./index.d.ts",
-    "default": "./index.js"
-  },
   "bin": {
     "ssc": "bin/ssc.js"
   },


### PR DESCRIPTION
This causes problems with things like loaders...

```
> /usr/bin/node --experimental-loader @socketsupply/socket/node-esm-loader.js introducer.js

(node:864627) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
node:internal/errors:490
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './node-esm-loader.js' is not defined by "exports" in /opt/streamrelay/node_modules/@socketsupply/socket/package.json imported from /opt/streamrelay/
    at new NodeError (node:internal/errors:399:5)
    at exportsNotFound (node:internal/modules/esm/resolve:266:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:602:9)
    at packageResolve (node:internal/modules/esm/resolve:777:14)
    at moduleResolve (node:internal/modules/esm/resolve:843:20)
    at ESMLoader.defaultResolve (node:internal/modules/esm/resolve:1058:11)
    at ESMLoader.resolve (node:internal/modules/esm/loader:323:32)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:172:38)
    at ESMLoader.import (node:internal/modules/esm/loader:276:22)
    at initializeLoader (node:internal/process/esm_loader:50:63) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```