### PR TITLE
Introduce VM module

### DIFF
--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -7234,6 +7234,275 @@ declare module "socket:test" {
     export default test;
     import test from "socket:test/index";
 }
+declare module "socket:internal/globals" {
+    /**
+     * Gets a runtime global value by name.
+     * @ignore
+     * @param {string} name
+     * @return {any|null}
+     */
+    export function get(name: string): any | null;
+    /**
+     * Symbolic global registry
+     * @ignore
+     */
+    export class GlobalsRegistry {
+        get global(): any;
+        symbol(name: any): symbol;
+        register(name: any, value: any): any;
+        get(name: any): any;
+    }
+    export default registry;
+    const registry: any;
+}
+declare module "socket:internal/shared-worker" {
+    export class SharedHybridWorkerProxy extends EventTarget {
+        constructor(url: any, options: any);
+        onChannelMessage(event: any): void;
+        get id(): any;
+        get port(): any;
+        #private;
+    }
+    export class SharedHybridWorker extends EventTarget {
+        constructor(url: any, nameOrOptions: any);
+        get port(): any;
+        #private;
+    }
+    export const SharedWorker: {
+        new (scriptURL: string | URL, options?: string | WorkerOptions): SharedWorker;
+        prototype: SharedWorker;
+    } | typeof SharedHybridWorkerProxy | typeof SharedHybridWorker;
+    export default SharedWorker;
+}
+declare module "socket:worker" {
+    export { SharedWorker };
+    /**
+     * @type {import('dom').Worker}
+     */
+    export const Worker: any;
+    export default Worker;
+    import SharedWorker from "socket:internal/shared-worker";
+}
+declare module "socket:vm" {
+    /**
+     * @ignore
+     * @param {object[]} transfer
+     * @param {object} object
+     * @param {object=} [options]
+     * @return {object[]}
+     */
+    export function findMessageTransfers(transfers: any, object: object, options?: object | undefined): object[];
+    /**
+     * @ignore
+     * @param {object} context
+     */
+    export function applyInputContextReferences(context: object): void;
+    /**
+     * @ignore
+     * @param {object} context
+     */
+    export function applyOutputContextReferences(context: object): void;
+    /**
+     * @ignore
+     * @param {object} context
+     */
+    export function filterNonTransferableValues(context: object): void;
+    /**
+     * @ignore
+     * @param {object=} [currentContext]
+     * @param {object=} [updatedContext]
+     * @param {object=} [contextReference]
+     * @return {{ deletions: string[], merges: string[] }}
+     */
+    export function applyContextDifferences(currentContext?: object | undefined, updatedContext?: object | undefined, contextReference?: object | undefined, preserveScriptArgs?: boolean): {
+        deletions: string[];
+        merges: string[];
+    };
+    /**
+     * Wrap a JavaScript function source.
+     * @ignore
+     * @param {string} source
+     * @param {object=} [options]
+     */
+    export function wrapFunctionSource(source: string, options?: object | undefined): string;
+    /**
+     * Gets the VM context window.
+     * This function will create it if it does not already exist.
+     * The current window will be used on Android or iOS platforms as there can
+     * only be one window.
+     * @return {Promise<import('./window.js').ApplicationWindow}
+     */
+    export function getContextWindow(): Promise<import("socket:window").ApplicationWindow>;
+    /**
+     * Gets the `SharedWorker` that for the VM context.
+     * @return {Promise<SharedWorker>}
+     */
+    export function getContextWorker(): Promise<SharedWorker>;
+    export function terminateContextWindow(): Promise<void>;
+    export function terminateContextWorker(): Promise<void>;
+    export function createIntrinsics(): any;
+    export function createGlobalObject(context: any): any;
+    export function compileFunction(source: any, options?: any): any;
+    export function runInContext(source: any, options: any, context: any): Promise<any>;
+    export function runInNewContext(source: any, options: any, context: any): Promise<any>;
+    export function runInThisContext(source: any, options: any): Promise<any>;
+    export function putReference(reference: any): void;
+    export function createReference(value: any, context: any): Reference;
+    export function getReference(id: any): any;
+    export function removeReference(id: any): void;
+    /**
+     * A container for a context worker message channel that looks like a "worker".
+     * @ignore
+     */
+    export class ContextWorkerInterface extends EventTarget {
+        get channel(): any;
+        get port(): any;
+        destroy(): void;
+        #private;
+    }
+    /**
+     * A container proxy for a context worker message channel that
+     * looks like a "worker".
+     * @ignore
+     */
+    export class ContextWorkerInterfaceProxy extends EventTarget {
+        constructor(globals: any);
+        get port(): any;
+        #private;
+    }
+    /**
+     * Global reserved values that a script context may not modify.
+     * @type {string[]}
+     */
+    export const RESERVED_GLOBAL_INTRINSICS: string[];
+    /**
+     * A unique reference to a value owner by a "context object" and a
+     * `Script` instance.
+     */
+    export class Reference {
+        /**
+         * `Reference` class constructor.
+         * @param {string} id
+         * @param {any} value
+         * @param {object=} [context]
+         */
+        constructor(id: string, value: any, context?: object | undefined);
+        /**
+         * The unique id of the reference
+         * @type {string}
+         */
+        get id(): string;
+        /**
+         * The underling primitive type of the reference value.
+         * @ignore
+         * @type {'undefined'|'object'|'number'|'boolean'|'function'|'symbol'}
+         */
+        get type(): "number" | "boolean" | "symbol" | "undefined" | "object" | "function";
+        /**
+         * The underlying value of the reference.
+         * @type {any?}
+         */
+        get value(): any;
+        /**
+         * The `Script` this value belongs to, if available.
+         * @type {Script?}
+         */
+        get script(): Script;
+        /**
+         * The "context object" this reference value belongs to.
+         * @type {object?}
+         */
+        get context(): any;
+        /**
+         * Releases strongly held value and weak references
+         * to the "context object".
+         */
+        release(): void;
+        /**
+         * Converts this `Reference` to a JSON object.
+         * @param {boolean=} [includeValue = false]
+         */
+        toJSON(includeValue?: boolean | undefined): {
+            __vmScriptReference__: boolean;
+            id: string;
+            type: "number" | "boolean" | "symbol" | "undefined" | "object" | "function";
+            value: any;
+        } | {
+            __vmScriptReference__: boolean;
+            id: string;
+            type: "number" | "boolean" | "symbol" | "undefined" | "object" | "function";
+            value?: undefined;
+        };
+        #private;
+    }
+    /**
+     * @typedef {{
+     *  filename?: string,
+     *  context?: object
+     * }} ScriptOptions
+     */
+    /**
+     * A `Script` is a container for raw JavaScript to be executed in
+     * a completely isolated virtual machine context, optionally with
+     * user supplied context. Context objects references are not actually
+     * shared, but instead provided to the script execution context using the
+     * structured cloning algorithm used by the Message Channel API. Context
+     * differences are computed and applied after execution so the user supplied
+     * context object realizes context changes after script execution. All script
+     * sources run in an "async" context so a "top level await" should work.
+     */
+    export class Script extends EventTarget {
+        /**
+         * `Script` class constructor
+         * @param {string} source
+         * @param {ScriptOptions} [options]
+         */
+        constructor(source: string, options?: ScriptOptions);
+        /**
+         * The script identifier.
+         */
+        get id(): any;
+        /**
+         * The source for this script.
+         * @type {string}
+         */
+        get source(): string;
+        /**
+         * The filename for this script.
+         * @type {string}
+         */
+        get filename(): string;
+        /**
+         * A promise that resolves when the script is ready.
+         * @type {Promise<Boolean>}
+         */
+        get ready(): Promise<boolean>;
+        destroy(): Promise<void>;
+        runInContext(context: any, options?: any): Promise<any>;
+        runInNewContext(context: any, options?: any): Promise<any>;
+        runInThisContext(options?: any): Promise<any>;
+        #private;
+    }
+    namespace _default {
+        export { compileFunction };
+        export { createReference };
+        export { getContextWindow };
+        export { getContextWorker };
+        export { getReference };
+        export { Reference };
+        export { removeReference };
+        export { runInContext };
+        export { runInNewContext };
+        export { runInThisContext };
+        export { Script };
+    }
+    export default _default;
+    export type ScriptOptions = {
+        filename?: string;
+        context?: object;
+    };
+    import { SharedWorker } from "socket:worker";
+}
 declare module "socket:module" {
     export function isBuiltin(name: any): boolean;
     /**
@@ -7269,6 +7538,19 @@ declare module "socket:module" {
         test: typeof test;
         util: typeof util;
         url: any;
+        vm: {
+            compileFunction: typeof import("socket:vm").compileFunction;
+            createReference: typeof import("socket:vm").createReference;
+            getContextWindow: typeof import("socket:vm").getContextWindow;
+            getContextWorker: typeof import("socket:vm").getContextWorker;
+            getReference: typeof import("socket:vm").getReference;
+            Reference: typeof import("socket:vm").Reference;
+            removeReference: typeof import("socket:vm").removeReference;
+            runInContext: typeof import("socket:vm").runInContext;
+            runInNewContext: typeof import("socket:vm").runInNewContext;
+            runInThisContext: typeof import("socket:vm").runInThisContext;
+            Script: typeof import("socket:vm").Script;
+        };
     };
     export const builtinModules: {
         buffer: typeof buffer;
@@ -7293,6 +7575,19 @@ declare module "socket:module" {
         test: typeof test;
         util: typeof util;
         url: any;
+        vm: {
+            compileFunction: typeof import("socket:vm").compileFunction;
+            createReference: typeof import("socket:vm").createReference;
+            getContextWindow: typeof import("socket:vm").getContextWindow;
+            getContextWorker: typeof import("socket:vm").getContextWorker;
+            getReference: typeof import("socket:vm").getReference;
+            Reference: typeof import("socket:vm").Reference;
+            removeReference: typeof import("socket:vm").removeReference;
+            runInContext: typeof import("socket:vm").runInContext;
+            runInNewContext: typeof import("socket:vm").runInNewContext;
+            runInThisContext: typeof import("socket:vm").runInThisContext;
+            Script: typeof import("socket:vm").Script;
+        };
     };
     /**
      * CommonJS module scope source wrapper.
@@ -7938,55 +8233,6 @@ declare module "socket:stream-relay" {
     export default def;
     import def from "socket:stream-relay/index";
 }
-declare module "socket:internal/globals" {
-    /**
-     * Gets a runtime global value by name.
-     * @ignore
-     * @param {string} name
-     * @return {any|null}
-     */
-    export function get(name: string): any | null;
-    /**
-     * Symbolic global registry
-     * @ignore
-     */
-    export class GlobalsRegistry {
-        get global(): any;
-        symbol(name: any): symbol;
-        register(name: any, value: any): any;
-        get(name: any): any;
-    }
-    export default registry;
-    const registry: any;
-}
-declare module "socket:internal/shared-worker" {
-    export class SharedHybridWorkerProxy extends EventTarget {
-        constructor(url: any, options: any);
-        onChannelMessage(event: any): void;
-        get id(): any;
-        get port(): any;
-        #private;
-    }
-    export class SharedHybridWorker extends EventTarget {
-        constructor(url: any, nameOrOptions: any);
-        get port(): any;
-        #private;
-    }
-    export const SharedWorker: {
-        new (scriptURL: string | URL, options?: string | WorkerOptions): SharedWorker;
-        prototype: SharedWorker;
-    } | typeof SharedHybridWorkerProxy | typeof SharedHybridWorker;
-    export default SharedWorker;
-}
-declare module "socket:worker" {
-    export { SharedWorker };
-    /**
-     * @type {import('dom').Worker}
-     */
-    export const Worker: any;
-    export default Worker;
-    import SharedWorker from "socket:internal/shared-worker";
-}
 declare module "socket:internal/events" {
     /**
      * An event dispatched when an application URL is opening the application.
@@ -8370,6 +8616,68 @@ declare module "socket:test/harness" {
     };
     import * as exports from "socket:test/harness";
     
+}
+declare module "socket:vm/init" {
+    export {};
+}
+declare function reportError(e: any): void;
+declare function reportError(err: any): void;
+declare function isTypedArray(object: any): boolean;
+declare function isArrayBuffer(object: any): boolean;
+declare function findMessageTransfers(transfers: any, object: any): any;
+declare const Uint8ArrayPrototype: Uint8Array;
+declare const TypedArrayPrototype: any;
+declare const TypedArray: any;
+declare class Client extends EventTarget {
+    constructor(id: any, port: any);
+    id: any;
+    port: any;
+    onMessage(event: any): void;
+    postMessage(...args: any[]): any;
+}
+declare class Realm {
+    constructor(state: any, port: any);
+    /**
+     * The `MessagePort` for the VM realm.
+     * @type {MessagePort}
+     */
+    port: MessagePort;
+    /**
+     * A reference to the top level worker statae
+     * @type {State}
+     */
+    state: State;
+    /**
+     * Known content worlds that exist in a realm
+     * @type {Map<String, World>}
+     */
+    worlds: Map<string, World>;
+    get clients(): Map<any, any>;
+    postMessage(...args: any[]): void;
+}
+declare class State {
+    static init(): State;
+    /**
+     * All known connected `MessagePort` instances
+     * @type {MessagePort[]}
+     */
+    ports: MessagePort[];
+    /**
+     * Pending events to be dispatched to realm
+     * @type {MessageEvent[]}
+     */
+    pending: MessageEvent[];
+    /**
+     * The realm for all virtual machines. This is a headless webview
+     */
+    realm: any;
+    clients: Map<any, any>;
+    onConnect(event: any): void;
+    init(): void;
+    onPortMessage(port: any, event: any): void;
+}
+declare module "socket:vm/world" {
+    export {};
 }
 type MenuItemSelection = {
     title: string

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -7338,18 +7338,98 @@ declare module "socket:vm" {
      * @return {Promise<SharedWorker>}
      */
     export function getContextWorker(): Promise<SharedWorker>;
+    /**
+     * Terminates the VM script context window.
+     * @ignore
+     */
     export function terminateContextWindow(): Promise<void>;
+    /**
+     * Terminates the VM script context worker.
+     * @ignore
+     */
     export function terminateContextWorker(): Promise<void>;
+    /**
+     * Creates a prototype object of known global reserved intrinsics.
+     * @ignore
+     */
     export function createIntrinsics(): any;
-    export function createGlobalObject(context: any): any;
-    export function compileFunction(source: any, options?: any): any;
-    export function runInContext(source: any, options: any, context: any): Promise<any>;
-    export function runInNewContext(source: any, options: any, context: any): Promise<any>;
-    export function runInThisContext(source: any, options: any): Promise<any>;
-    export function putReference(reference: any): void;
-    export function createReference(value: any, context: any): Reference;
-    export function getReference(id: any): any;
-    export function removeReference(id: any): void;
+    /**
+     * Creates a global proxy object for context execution.
+     * @ignore
+     * @param {object} context
+     * @return {Proxy}
+     */
+    export function createGlobalObject(context: object): ProxyConstructor;
+    /**
+     * @ignore
+     * @param {string} source
+     * @return {boolean}
+     */
+    export function detectFunctionSourceType(source: string): boolean;
+    /**
+     * Compiles `source`  with `options` into a function.
+     * @ignore
+     * @param {string} source
+     * @param {object=} [options]
+     * @return {function}
+     */
+    export function compileFunction(source: string, options?: object | undefined): Function;
+    /**
+     * Run `source` JavaScript in given context. The script context execution
+     * context is preserved until the `context` object that points to it is
+     * garbage collected or there are no longer any references to it and its
+     * associated `Script` instance.
+     * @param {string} source
+     * @param {ScriptOptions=} [options]
+     * @param {object=} [context]
+     * @return {Promise<any>}
+     */
+    export function runInContext(source: string, options?: ScriptOptions | undefined, context?: object | undefined): Promise<any>;
+    /**
+     * Run `source` JavaScript in new context. The script context is destroyed after
+     * execution. This is typically a "one off" isolated run.
+     * @param {string} source
+     * @param {ScriptOptions=} [options]
+     * @param {object=} [context]
+     * @return {Promise<any>}
+     */
+    export function runInNewContext(source: string, options?: ScriptOptions | undefined, context?: object | undefined): Promise<any>;
+    /**
+     * Run `source` JavaScript in this current context (`globalThis`).
+     * @param {string} source
+     * @param {ScriptOptions=} [options]
+     * @return {Promise<any>}
+     */
+    export function runInThisContext(source: string, options?: ScriptOptions | undefined): Promise<any>;
+    /**
+     * @ignore
+     * @param {Reference} reference
+     */
+    export function putReference(reference: Reference): void;
+    /**
+     * Create a `Reference` for a `value` in a script `context`.
+     * @param {any} value
+     * @param {object} context
+     * @return {Reference}
+     */
+    export function createReference(value: any, context: object): Reference;
+    /**
+     * Get a script context by ID or values
+     * @param {string|object|function} id
+     * @return {Reference?}
+     */
+    export function getReference(id: string | object | Function): Reference | null;
+    /**
+     * Remove a script context reference by ID.
+     * @param {string} id
+     */
+    export function removeReference(id: string): void;
+    /**
+     * Get all transferable values in the `object` hierarchy.
+     * @param {object} object
+     * @return {object[]}
+     */
+    export function getTrasferables(object: object): object[];
     /**
      * A container for a context worker message channel that looks like a "worker".
      * @ignore
@@ -7477,10 +7557,35 @@ declare module "socket:vm" {
          * @type {Promise<Boolean>}
          */
         get ready(): Promise<boolean>;
-        destroy(): Promise<void>;
-        runInContext(context: any, options?: any): Promise<any>;
-        runInNewContext(context: any, options?: any): Promise<any>;
-        runInThisContext(options?: any): Promise<any>;
+        /**
+         * Destroy the script execution context.
+         * @return {Promise}
+         */
+        destroy(): Promise<any>;
+        /**
+         * Run `source` JavaScript in given context. The script context execution
+         * context is preserved until the `context` object that points to it is
+         * garbage collected or there are no longer any references to it and its
+         * associated `Script` instance.
+         * @param {ScriptOptions=} [options]
+         * @param {object=} [context]
+         * @return {Promise<any>}
+         */
+        runInContext(context?: object | undefined, options?: ScriptOptions | undefined): Promise<any>;
+        /**
+         * Run `source` JavaScript in new context. The script context is destroyed after
+         * execution. This is typically a "one off" isolated run.
+         * @param {ScriptOptions=} [options]
+         * @param {object=} [context]
+         * @return {Promise<any>}
+         */
+        runInNewContext(context?: object | undefined, options?: ScriptOptions | undefined): Promise<any>;
+        /**
+         * Run `source` JavaScript in this current context (`globalThis`).
+         * @param {ScriptOptions=} [options]
+         * @return {Promise<any>}
+         */
+        runInThisContext(options?: ScriptOptions | undefined): Promise<any>;
         #private;
     }
     namespace _default {
@@ -7489,6 +7594,8 @@ declare module "socket:vm" {
         export { getContextWindow };
         export { getContextWorker };
         export { getReference };
+        export { getTrasferables };
+        export { putReference };
         export { Reference };
         export { removeReference };
         export { runInContext };
@@ -7544,6 +7651,8 @@ declare module "socket:module" {
             getContextWindow: typeof import("socket:vm").getContextWindow;
             getContextWorker: typeof import("socket:vm").getContextWorker;
             getReference: typeof import("socket:vm").getReference;
+            getTrasferables: typeof import("socket:vm").getTrasferables;
+            putReference: typeof import("socket:vm").putReference;
             Reference: typeof import("socket:vm").Reference;
             removeReference: typeof import("socket:vm").removeReference;
             runInContext: typeof import("socket:vm").runInContext;
@@ -7581,6 +7690,8 @@ declare module "socket:module" {
             getContextWindow: typeof import("socket:vm").getContextWindow;
             getContextWorker: typeof import("socket:vm").getContextWorker;
             getReference: typeof import("socket:vm").getReference;
+            getTrasferables: typeof import("socket:vm").getTrasferables;
+            putReference: typeof import("socket:vm").putReference;
             Reference: typeof import("socket:vm").Reference;
             removeReference: typeof import("socket:vm").removeReference;
             runInContext: typeof import("socket:vm").runInContext;
@@ -8624,7 +8735,7 @@ declare function reportError(e: any): void;
 declare function reportError(err: any): void;
 declare function isTypedArray(object: any): boolean;
 declare function isArrayBuffer(object: any): boolean;
-declare function findMessageTransfers(transfers: any, object: any): any;
+declare function findMessageTransfers(transfers: any, object: any, options?: any): any;
 declare const Uint8ArrayPrototype: Uint8Array;
 declare const TypedArrayPrototype: any;
 declare const TypedArray: any;

--- a/api/module.js
+++ b/api/module.js
@@ -31,6 +31,7 @@ import stream from './stream.js'
 import test from './test.js'
 import url from './url.js'
 import util from './util.js'
+import vm from './vm.js'
 
 /**
  * @typedef {function(string, Module, function): undefined} ModuleResolver
@@ -175,14 +176,15 @@ export const builtins = {
   stream,
   test,
   util,
-  url
+  url,
+  vm
 }
 
 // alias
 export const builtinModules = builtins
 
 export function isBuiltin (name) {
-  name = name.replace(/^socket:/, '')
+  name = name.replace(/^(socket|node):/, '')
 
   if (name in builtins) {
     return true

--- a/api/vm.js
+++ b/api/vm.js
@@ -1,0 +1,1296 @@
+/**
+ * @module VM
+ *
+ * This module enables compiling and running JavaScript source code in an
+ * isolated execution context optionally with a user supplied context object.
+ *
+ * Example usage:
+ * ```js
+ * import fs from 'socket:fs/promises'
+ * import vm from 'socket:vm'
+ *
+ * const data = await fs.readFile('data.json')
+ * const context = { data, value: null }
+ * const source = `
+ *   const text = new TextDecoder().decode(data)
+ *   const json = JSON.parse(text)
+ *
+ *   // get `.value` from parsed JSON and set it to global `value`
+ *   // that exists on the user context
+ *   value = json.value
+ * `
+ * const result = await vm.runIntContext(source, context)
+ * console.log(context.value) // set from `json.value` in VM context
+ * ```
+ */
+
+/* global ErrorEvent, EventTarget, MessagePort */
+import { maybeMakeError } from './ipc.js'
+import { SharedWorker } from './worker.js'
+import application from './application.js'
+import globals from './internal/globals.js'
+import console from './console.js'
+import crypto from './crypto.js'
+import os from './os.js'
+import gc from './gc.js'
+
+const AsyncFunction = (async () => {}).constructor
+const Uint8ArrayPrototype = Uint8Array.prototype
+const TypedArrayPrototype = Object.getPrototypeOf(Uint8ArrayPrototype)
+const TypedArray = TypedArrayPrototype.constructor
+
+const VM_WINDOW_INDEX = 47
+const VM_WINDOW_TITLE = 'socket:vm'
+const VM_WINDOW_PATH = `${globalThis.origin}/socket/vm/index.html`
+
+let contextWorker = null
+let contextWindow = null
+
+// A weak mapping of context objects to `Script` instances where "context"
+// objects own the `Script` until the "context" is no longer stronglyheld
+// in which the `Script` eventually becomes garbage collected triggering
+// the `gc.finalizer` callback to be invoked cleaning up any allocated
+// resources for the script context such as iframes and workers or any
+// resources created in the script "world" in the VM realm
+const scripts = new WeakMap()
+
+// A weak mapping of values to reference objects
+const references = Object.assign(new WeakMap(), {
+  // A mapping of reference IDs to weakly held `Reference` instances
+  index: new Map()
+})
+
+function isTypedArray (object) {
+  return object instanceof TypedArray
+}
+
+function isArrayBuffer (object) {
+  return object instanceof ArrayBuffer
+}
+
+/**
+ * @ignore
+ * @param {object[]} transfer
+ * @param {object} object
+ * @param {object=} [options]
+ * @return {object[]}
+ */
+export function findMessageTransfers (transfers, object, options = null) {
+  if (isTypedArray(object) || ArrayBuffer.isView(object)) {
+    transfers.push(object.buffer)
+  } else if (isArrayBuffer(object)) {
+    transfers.push(object)
+  } else if (object instanceof MessagePort) {
+    transfers.push(object)
+  } else if (Array.isArray(object)) {
+    for (const value of object) {
+      findMessageTransfers(transfers, value, options)
+    }
+  } else if (object && typeof object === 'object') {
+    for (const key in object) {
+      if (
+        key.startsWith('__vmScriptReferenceArgs_') &&
+        options?.ignoreScriptReferenceArgs === true
+      ) {
+        continue
+      }
+
+      findMessageTransfers(transfers, object[key], options)
+    }
+  }
+
+  return transfers
+}
+
+/**
+ * @ignore
+ * @param {object} context
+ */
+export function applyInputContextReferences (context) {
+  if (!context || typeof context !== 'object') {
+    return
+  }
+
+  visitObject(context)
+
+  function visitObject (object) {
+    for (const key in object) {
+      const value = object[key]
+      if (value && typeof value === 'object') {
+        if (value.__vmScriptReference__ === true && value.id) {
+          const reference = getReference(value.id)
+          if (reference) {
+            object[key] = reference.value
+            Object.defineProperty(context, value.id, {
+              configurable: false,
+              enumerable: false,
+              value: reference.value
+            })
+          }
+        } else {
+          visitObject(value)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @ignore
+ * @param {object} context
+ */
+export function applyOutputContextReferences (context) {
+  if (!context || typeof context !== 'object') {
+    return
+  }
+
+  visitObject(context)
+
+  function visitObject (object) {
+    for (const key in object) {
+      if (key.startsWith('__vmScriptReferenceArgs_')) {
+        Reflect.deleteProperty(object, key)
+        continue
+      }
+
+      const value = object[key]
+      if (value && typeof value === 'object') {
+        if (!(value.__vmScriptReference__ === true && value.id)) {
+          visitObject(value)
+        }
+      }
+
+      if (typeof value === 'function') {
+        const reference = getReference(value) ?? createReference(value, context)
+        object[key] = reference.toJSON()
+      }
+    }
+  }
+}
+
+/**
+ * @ignore
+ * @param {object} context
+ */
+export function filterNonTransferableValues (context) {
+  if (!context || typeof context !== 'object') {
+    return
+  }
+
+  visitObject(context)
+
+  function visitObject (object) {
+    for (const key in object) {
+      const value = object[key]
+      if (value && typeof value === 'object') {
+        visitObject(value)
+      } else if (typeof value === 'function') {
+        const reference = getReference(value)
+        if (reference) {
+          object[key] = reference.toJSON()
+        } else {
+          Reflect.deleteProperty(object, key)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @ignore
+ * @param {object=} [currentContext]
+ * @param {object=} [updatedContext]
+ * @param {object=} [contextReference]
+ * @return {{ deletions: string[], merges: string[] }}
+ */
+export function applyContextDifferences (
+  currentContext = null,
+  updatedContext = null,
+  contextReference = null,
+  preserveScriptArgs = false
+) {
+  if (!currentContext || typeof currentContext !== 'object') {
+    return
+  }
+
+  const deletions = []
+  const merges = []
+  const script = scripts.get(contextReference ?? currentContext)
+
+  for (const key in updatedContext) {
+    const updatedValue = Reflect.get(updatedContext, key)
+
+    if (updatedValue?.__vmScriptReference__ === true) {
+      const reference = updatedValue
+
+      if (reference.type === 'function') {
+        const ref = getReference(reference.id)
+        if (ref) {
+          Reflect.set(currentContext, key, ref.value)
+        } else if (script) {
+          const vmFunctionProxy = async function (...args) {
+            const scriptReferenceArgsKey = `__vmScriptReferenceArgs_${reference.id}__`
+
+            Reflect.set(contextReference, scriptReferenceArgsKey, args)
+            Reflect.set(contextReference, reference.id, reference)
+
+            const result = await script.runInContext(contextReference, {
+              mode: 'classic',
+              source: `globalObject['${reference.id}'](...globalObject['${scriptReferenceArgsKey}'])`
+            })
+
+            Reflect.deleteProperty(contextReference, reference.id)
+            Reflect.deleteProperty(contextReference, scriptReferenceArgsKey)
+
+            return result
+          }
+
+          putReference(new Reference(reference.id, vmFunctionProxy, contextReference))
+          Reflect.set(currentContext, key, vmFunctionProxy)
+        }
+      }
+    } else if (Reflect.has(currentContext, key)) {
+      const currentValue = Reflect.get(currentContext, key)
+      if (
+        currentValue && typeof currentValue === 'object' &&
+        updatedValue && typeof updatedValue === 'object'
+      ) {
+        merges.push([key, currentValue, updatedValue])
+      } else {
+        Reflect.set(currentContext, key, updatedValue)
+      }
+    } else {
+      Reflect.set(currentContext, key, updatedValue)
+    }
+  }
+
+  for (const key in currentContext) {
+    if (!preserveScriptArgs && key.startsWith('__vmScriptReferenceArgs_')) {
+      Reflect.deleteProperty(currentContext, key)
+    }
+
+    if (!Reflect.has(updatedContext, key)) {
+      deletions.push(key)
+      Reflect.deleteProperty(currentContext, key)
+    }
+  }
+
+  for (const merge of merges) {
+    const [key, currentValue, updatedValue] = merge
+    if (isTypedArray(updatedValue) || isArrayBuffer(updatedValue)) {
+      Reflect.set(currentContext, key, updatedValue)
+    } else if (!Array.isArray(currentValue) && Array.isArray(updatedValue)) {
+      Reflect.set(currentContext, key, updatedValue)
+    } else if (Array.isArray(currentValue) && Array.isArray(updatedValue)) {
+      currentValue.length = updatedValue.length
+      for (let i = 0; i < updatedValue.length; ++i) {
+        Reflect.set(currentValue, i, Reflect.get(updatedValue, i))
+      }
+    } else {
+      applyContextDifferences(currentValue, updatedValue, contextReference)
+    }
+  }
+
+  return { deletions, merges: merges.map((merge) => merge[0]) }
+}
+
+/**
+ * Wrap a JavaScript function source.
+ * @ignore
+ * @param {string} source
+ * @param {object=} [options]
+ */
+export function wrapFunctionSource (source, options = null) {
+  if (source.includes('return') || source.includes(';') || source.includes('throw')) {
+    source = `{ ${source} }`
+  } else if (source.includes('\n')) {
+    const parts = source.trim().split('\n')
+    const last = parts.pop()
+    const tmp = last.trim()
+    if (
+      !/^(if|return|while|do|switch|let|var|const|for)/.test(tmp) &&
+      !/^[{|;|/]/.test(tmp) &&
+      !/}$/.test(tmp) &&
+      !/\w\s*=\*\w/.test(tmp)
+    ) {
+      source = parts.concat(`return ${last}`).join('\n')
+    }
+
+    source = `{ ${source} }`
+  }
+
+  return `
+    with (this) { return ((${options?.async ? 'async' : ''} () => ${source})()) }
+    //# sourceURL=${options?.filename || 'wrapped-function-source.js'}
+  `.trim()
+}
+
+/**
+ * A container for a context worker message channel that looks like a "worker".
+ * @ignore
+ */
+export class ContextWorkerInterface extends EventTarget {
+  #channel = null
+
+  constructor () {
+    super()
+
+    this.#channel = new MessageChannel()
+  }
+
+  get channel () {
+    return this.#channel
+  }
+
+  get port () {
+    return this.#channel.port1
+  }
+
+  destroy () {
+    try {
+      this.#channel.port1.close()
+      this.#channel.port2.close()
+    } catch {}
+
+    this.#channel = null
+  }
+}
+
+/**
+ * A container proxy for a context worker message channel that
+ * looks like a "worker".
+ * @ignore
+ */
+export class ContextWorkerInterfaceProxy extends EventTarget {
+  #globals = null
+  constructor (globals) {
+    super()
+    this.#globals = globals
+    gc.ref(this)
+  }
+
+  get port () {
+    return this.#globals.get('vm.contextWorker')?.channel?.port2
+  }
+
+  [gc.finalizer] () {
+    return {
+      args: [this.port],
+      async handle (port) {
+        if (port) {
+          try {
+            port.close()
+          } catch {}
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Global reserved values that a script context may not modify.
+ * @type {string[]}
+ */
+export const RESERVED_GLOBAL_INTRINSICS = [
+  '__args',
+  '__globals',
+  'top',
+  'self',
+  'this',
+  'window',
+  'globalThis',
+  'globalObject',
+  'webkit',
+  'chrome',
+  'external',
+  'postMessage',
+  'console',
+  'globalThis',
+  'Infinity',
+  'NaN',
+  'undefined',
+  'eval',
+  'isFinite',
+  'isNaN',
+  'parseFloat',
+  'parseInt',
+  'decodeURI',
+  'decodeURIComponent',
+  'encodeURI',
+  'encodeURIComponent',
+  'AggregateError',
+  'Array',
+  'ArrayBuffer',
+  'Atomics',
+  'BigInt',
+  'BigInt64Array',
+  'BigUint64Array',
+  'Boolean',
+  'DataView',
+  'Date',
+  'Error',
+  'EvalError',
+  'FinalizationRegistry',
+  'Float32Array',
+  'Float64Array',
+  'Function',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'Map',
+  'Number',
+  'Object',
+  'Promise',
+  'Proxy',
+  'RangeError',
+  'ReferenceError',
+  'RegExp',
+  'Set',
+  'SharedArrayBuffer',
+  'String',
+  'Symbol',
+  'SyntaxError',
+  'TypeError',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Uint16Array',
+  'Uint32Array',
+  'URIError',
+  'WeakMap',
+  'WeakRef',
+  'WeakSet',
+  'Atomics',
+  'JSON',
+  'Math',
+  'Reflect'
+]
+
+/**
+ * A unique reference to a value owner by a "context object" and a
+ * `Script` instance.
+ */
+export class Reference {
+  /**
+   * The underlying reference ID.
+   * @ignore
+   * @type {string}
+   */
+  #id = null
+
+  /**
+   * The underling primitive type of the reference value.
+   * @ignore
+   * @type {'undefined'|'object'|'number'|'boolean'|'function'|'symbol'}
+   */
+  #type = 'undefined'
+
+  /**
+   * A strong reference to the underlying value.
+   * @ignore
+   * @type {any?}
+   */
+  #value = null
+
+  /**
+   * A weak reference to the underlying "context object", if available.
+   * @ignore
+   * @type {WeakRef?}
+   */
+  #context = null
+
+  /**
+   * `Reference` class constructor.
+   * @param {string} id
+   * @param {any} value
+   * @param {object=} [context]
+   */
+  constructor (id, value, context = null) {
+    this.#id = id
+    this.#type = value !== null ? typeof value : 'undefined'
+    this.#value = value !== null && value !== undefined
+      ? value
+      : null
+
+    this.#context = context !== null && context !== undefined
+      ? new WeakRef(context)
+      : null
+  }
+
+  /**
+   * The unique id of the reference
+   * @type {string}
+   */
+  get id () {
+    return this.#id
+  }
+
+  /**
+   * The underling primitive type of the reference value.
+   * @ignore
+   * @type {'undefined'|'object'|'number'|'boolean'|'function'|'symbol'}
+   */
+  get type () {
+    return this.#type
+  }
+
+  /**
+   * The underlying value of the reference.
+   * @type {any?}
+   */
+  get value () {
+    return this.#value
+  }
+
+  /**
+   * The `Script` this value belongs to, if available.
+   * @type {Script?}
+   */
+  get script () {
+    return scripts.get(this.context) ?? null
+  }
+
+  /**
+   * The "context object" this reference value belongs to.
+   * @type {object?}
+   */
+  get context () {
+    return this.#context?.deref?.() ?? null
+  }
+
+  /**
+   * Releases strongly held value and weak references
+   * to the "context object".
+   */
+  release () {
+    this.#value = null
+    this.#context = null
+  }
+
+  /**
+   * Converts this `Reference` to a JSON object.
+   * @param {boolean=} [includeValue = false]
+   */
+  toJSON (includeValue = false) {
+    const { value, type, id } = this
+
+    if (includeValue) {
+      return { __vmScriptReference__: true, id, type, value }
+    }
+
+    return { __vmScriptReference__: true, id, type }
+  }
+}
+
+/**
+ * @typedef {{
+ *  filename?: string,
+ *  context?: object
+ * }} ScriptOptions
+ */
+
+/**
+ * A `Script` is a container for raw JavaScript to be executed in
+ * a completely isolated virtual machine context, optionally with
+ * user supplied context. Context objects references are not actually
+ * shared, but instead provided to the script execution context using the
+ * structured cloning algorithm used by the Message Channel API. Context
+ * differences are computed and applied after execution so the user supplied
+ * context object realizes context changes after script execution. All script
+ * sources run in an "async" context so a "top level await" should work.
+ */
+export class Script extends EventTarget {
+  #id = null
+  #ready = null
+  #source = null
+  #context = null
+  #filename = '<script>'
+
+  /**
+   * `Script` class constructor
+   * @param {string} source
+   * @param {ScriptOptions} [options]
+   */
+  constructor (source, options = null) {
+    super()
+
+    if (typeof source !== 'string') {
+      throw new TypeError('Script source must be a string')
+    }
+
+    if (!source) {
+      throw new TypeError('Script source cannot be empty')
+    }
+
+    this.#id = crypto.randomBytes(8).toString('base64')
+    this.#source = source
+    this.#context = options?.context ?? null
+
+    if (typeof options?.filename === 'string' && options.filename) {
+      this.#filename = options.filename
+    }
+
+    gc.ref(this)
+
+    this.#ready = getContextWindow()
+      .then(getContextWorker())
+      .catch((error) => {
+        this.dispatchEvent(new ErrorEvent('error', { error }))
+      })
+  }
+
+  /**
+   * The script identifier.
+   */
+  get id () {
+    return this.#id
+  }
+
+  /**
+   * The source for this script.
+   * @type {string}
+   */
+  get source () {
+    return this.#source
+  }
+
+  /**
+   * The filename for this script.
+   * @type {string}
+   */
+  get filename () {
+    return this.#filename
+  }
+
+  /**
+   * A promise that resolves when the script is ready.
+   * @type {Promise<Boolean>}
+   */
+  get ready () {
+    return this.#ready
+  }
+
+  [gc.finalizer] () {
+    return {
+      args: [this.id],
+      async handle (id) {
+        const worker = await getContextWorker()
+        worker.port.postMessage({ id, type: 'destroy' })
+      }
+    }
+  }
+
+  async destroy () {
+    await this.ready
+    const worker = await getContextWorker()
+    worker.port.postMessage({ id: this.#id, type: 'destroy' })
+  }
+
+  async runInContext (context, options = null) {
+    await this.ready
+
+    const contextReference = context ?? this.context
+    context = { ...(context ?? this.#context) }
+
+    const filename = options?.filename || this.filename
+    const worker = await getContextWorker()
+    const source = options?.source ?? this.#source
+
+    const transfer = []
+    const nonce = crypto.randomBytes(8).toString('base64')
+    const mode = options?.mode ?? 'module'
+    const id = this.#id
+
+    return await new Promise((resolve, reject) => {
+      findMessageTransfers(transfer, context)
+      filterNonTransferableValues(context)
+
+      worker.port.postMessage({ type: 'client', id })
+      worker.port.postMessage({
+        type: 'script',
+        filename,
+        context,
+        source,
+        nonce,
+        mode,
+        id
+      }, {
+        transfer
+      })
+
+      worker.port.addEventListener('message', onMessage)
+
+      function onMessage (event) {
+        if (
+          event.data?.id === id &&
+          event.data?.nonce === nonce &&
+          event.data?.type === 'result'
+        ) {
+          worker.port.removeEventListener('message', onMessage)
+          if (event.data.context) {
+            applyContextDifferences(contextReference, event.data.context, contextReference)
+          }
+
+          if (event.data.err) {
+            reject(maybeMakeError(event.data.err))
+          } else {
+            const result = { data: event.data.data }
+            applyContextDifferences(result, event.data, contextReference)
+            resolve(result.data)
+          }
+        }
+      }
+    })
+  }
+
+  async runInNewContext (context, options = null) {
+    await this.ready
+
+    const contextReference = context ?? this.context
+    context = { ...context }
+
+    const filename = options?.filename || this.filename
+    const worker = await getContextWorker()
+    const source = options?.source ?? this.#source
+
+    const transfer = []
+    const nonce = crypto.randomBytes(8).toString('base64')
+    const mode = options?.mode ?? 'module'
+    const id = crypto.randomBytes(8).toString('base64')
+
+    const result = await new Promise((resolve, reject) => {
+      findMessageTransfers(transfer, context)
+      filterNonTransferableValues(context)
+
+      worker.port.postMessage({ type: 'client', id })
+      worker.port.postMessage({
+        type: 'script',
+        filename,
+        context,
+        source,
+        nonce,
+        mode,
+        id
+      }, {
+        transfer
+      })
+
+      worker.port.addEventListener('message', onMessage)
+
+      function onMessage (event) {
+        if (
+          event.data?.id === id &&
+          event.data?.nonce === nonce &&
+          event.data?.type === 'result'
+        ) {
+          worker.port.removeEventListener('message', onMessage)
+          if (event.data.context) {
+            applyContextDifferences(contextReference, event.data.context, contextReference)
+          }
+
+          if (event.data.err) {
+            reject(maybeMakeError(event.data.err))
+          } else {
+            const result = { data: event.data.data }
+            applyContextDifferences(result, event.data, contextReference)
+            resolve(result.data)
+          }
+        }
+      }
+    })
+
+    worker.port.postMessage({ id, type: 'destroy' })
+    return result
+  }
+
+  async runInThisContext (options = null) {
+    const filename = options?.filename || this.filename
+    const fn = compileFunction(options?.source ?? this.#source, {
+      async: true,
+      filename
+    })
+
+    return await fn()
+  }
+}
+
+/**
+ * Gets the VM context window.
+ * This function will create it if it does not already exist.
+ * The current window will be used on Android or iOS platforms as there can
+ * only be one window.
+ * @return {Promise<import('./window.js').ApplicationWindow}
+ */
+export async function getContextWindow () {
+  if (contextWindow) {
+    await contextWindow.ready
+    return contextWindow
+  }
+
+  const currentWindow = await application.getCurrentWindow()
+
+  // just return the current window for android/ios as there can only ever be one
+  if (os.platform() === 'ios' || os.platform() === 'android') {
+    contextWindow = currentWindow
+
+    if (!contextWindow.frame) {
+      const frameId = `__${os.platform()}-vm-frame__`
+      const existingFrame = globalThis.document.querySelector(
+        `iframe[id="${frameId}"]`
+      )
+
+      if (existingFrame) {
+        existingFrame.parentElement.removeChild(existingFrame)
+      }
+
+      const frame = globalThis.document.createElement('iframe')
+
+      frame.setAttribute('sandbox', 'allow-same-origin allow-scripts')
+      frame.src = VM_WINDOW_PATH
+      frame.id = frameId
+
+      Object.assign(frame.style, {
+        display: 'none',
+        height: 0,
+        width: 0
+      })
+
+      const target = (
+        globalThis.document.head ??
+        globalThis.document.body ??
+        globalThis.document
+      )
+
+      target.appendChild(frame)
+      contextWindow.frame = frame
+      contextWindow.ready = new Promise((resolve, reject) => {
+        frame.onload = resolve
+        frame.onerror = (event) => {
+          reject(new Error('Failed to load VM context window frame', {
+            cause: event.error ?? event
+          }))
+        }
+      })
+    }
+
+    await contextWindow.ready
+    return contextWindow
+  }
+
+  const existingContextWindow = await application.getWindow(VM_WINDOW_INDEX)
+  const pendingContextWindow = (
+    existingContextWindow ??
+    application.createWindow({
+      canExit: true,
+      headless: true,
+      debug: true,
+      index: VM_WINDOW_INDEX,
+      title: VM_WINDOW_TITLE,
+      path: VM_WINDOW_PATH
+    })
+  )
+
+  const promises = []
+  promises.push(pendingContextWindow)
+
+  if (!existingContextWindow) {
+    const eventName = `vm:${VM_WINDOW_INDEX}:ready`
+    promises.push(new Promise((resolve) => {
+      globalThis.addEventListener(eventName, resolve, { once: true })
+    }))
+  }
+
+  const ready = Promise.all(promises)
+  await ready
+  contextWindow = await pendingContextWindow
+  contextWindow.ready = ready
+  return contextWindow
+}
+
+/**
+ * Gets the `SharedWorker` that for the VM context.
+ * @return {Promise<SharedWorker>}
+ */
+export async function getContextWorker () {
+  if (contextWorker) {
+    return await contextWorker.ready
+  }
+
+  // just return the current window for android/ios as there can only ever be one
+  if (os.platform() === 'ios' || os.platform() === 'android') {
+    if (globalThis.window && globalThis.top === globalThis.window) {
+      // inside global top window
+      contextWorker = new ContextWorkerInterface()
+      contextWorker.ready = Promise.resolve(contextWorker)
+      globals.register('vm.contextWorker', contextWorker)
+    } else if (
+      globalThis.window &&
+      globalThis.top !== globalThis.window &&
+      globalThis.location.pathname === new URL(VM_WINDOW_PATH).pathname
+    ) {
+      // inside realm frame
+      contextWorker = new ContextWorkerInterfaceProxy(globalThis.top.__globals)
+      contextWorker.ready = Promise.resolve(contextWorker)
+    } else {
+      throw new TypeError('Unable to determine VM context worker')
+    }
+  } else {
+    contextWorker = new SharedWorker(`${globalThis.origin}/socket/vm/worker.js`, {
+      type: 'module'
+    })
+
+    contextWorker.ready = new Promise((resolve, reject) => {
+      contextWorker.addEventListener('error', (event) => {
+        reject(new Error('Failed to initialize VM Context SharedWorker', {
+          cause: event.error ?? event
+        }))
+      }, { once: true })
+
+      contextWorker.port.addEventListener('message', (event) => {
+        if (event.data === 'VM_SHARED_WORKER_ACK') {
+          resolve(contextWorker)
+        }
+      }, { once: true })
+    })
+  }
+
+  contextWorker.port.start()
+  contextWorker.addEventListener('message', (event) => {
+    if (event.data?.type === 'terminate-worker') {
+      if (typeof contextWorker?.destroy === 'function') {
+        contextWorker.destroy()
+      }
+
+      // unref
+      contextWorker = null
+
+      if (
+        globalThis.window &&
+        globalThis.top !== globalThis.window &&
+        globalThis.location.pathname === new URL(VM_WINDOW_INDEX).pathname
+      ) {
+        globalThis.top.__globals.register('vm.contextWorker', contextWorker)
+      }
+    }
+  })
+
+  return await contextWorker.ready
+}
+
+export async function terminateContextWindow () {
+  const pendingContextWindow = getContextWindow()
+
+  if (contextWindow.frame?.parentElement) {
+    contextWindow.frame.parentElement.removeChild(contextWindow.frame)
+  }
+
+  contextWindow = null
+  const currentContextWindow = await pendingContextWindow
+  await currentContextWindow.close()
+
+  const existingContextWindow = await application.getWindow(VM_WINDOW_INDEX)
+
+  if (existingContextWindow) {
+    await existingContextWindow.close()
+  }
+}
+
+export async function terminateContextWorker () {
+  if (!contextWorker) {
+    return
+  }
+
+  const worker = await getContextWorker()
+  worker.port.postMessage({ type: 'terminate-worker' })
+}
+
+export function createIntrinsics () {
+  const descriptors = Object.create(null)
+  const propertyNames = Object.getOwnPropertyNames(globalThis)
+  const propertySymbols = Object.getOwnPropertySymbols(globalThis)
+
+  for (const property of propertyNames) {
+    const intrinsic = Object.getOwnPropertyDescriptor(globalThis, property)
+    const descriptor = Object.assign(Object.create(null), {
+      configurable: false,
+      enumerable: true,
+      value: intrinsic.value ?? globalThis[property] ?? undefined
+    })
+
+    descriptors[property] = descriptor
+  }
+
+  for (const symbol of propertySymbols) {
+    descriptors[symbol] = {
+      configurable: false,
+      enumberale: false,
+      value: globalThis[symbol]
+    }
+  }
+
+  return Object.create(null, descriptors)
+}
+
+export function createGlobalObject (context) {
+  const prototype = Object.getPrototypeOf(globalThis)
+  const intrinsics = createIntrinsics()
+  const descriptors = Object.getOwnPropertyDescriptors(intrinsics)
+  const globalObject = Object.create(prototype, descriptors)
+
+  const symbols = Object.getOwnPropertySymbols(intrinsics)
+  const target = Object.create(null)
+
+  // restore symbols
+  for (const symbol of symbols) {
+    try {
+      Object.defineProperty(globalObject, symbol, intrinsics[symbol])
+    } catch {}
+  }
+
+  return new Proxy(target, {
+    get (_, property, receiver) {
+      if (property === 'console') {
+        return console
+      }
+
+      if (context && property in context) {
+        return Reflect.get(context, property)
+      }
+
+      if (property === 'top') {
+        return null
+      }
+
+      if (property in globalObject) {
+        return Reflect.get(globalObject, property)
+      }
+    },
+
+    set (_, property, value) {
+      if (context) {
+        if (Reflect.isExtensible(context)) {
+          Reflect.set(context, property, value)
+          return true
+        }
+
+        return false
+      }
+
+      if (property === 'top') {
+        return false
+      }
+
+      Reflect.set(globalObject, property, value)
+      return true
+    },
+
+    getPrototypeOf (_) {
+      if (context) {
+        return Reflect.getPrototypeOf(context)
+      }
+
+      return prototype
+    },
+
+    setPrototypeOf (_, prototype) {
+      return false
+    },
+
+    defineProperty (_, property, descriptor) {
+      if (RESERVED_GLOBAL_INTRINSICS.includes(property)) {
+        return false
+      }
+
+      if (context) {
+        Reflect.defineProperty(context, property, descriptor)
+        return true
+      }
+
+      Reflect.defineProperty(globalObject, property, descriptor)
+      return true
+    },
+
+    deleteProperty (_, property) {
+      if (RESERVED_GLOBAL_INTRINSICS.includes(property)) {
+        return false
+      }
+
+      if (context) {
+        return Reflect.deleteProperty(context, property)
+      }
+
+      return Reflect.deleteProperty(globalObject, property)
+    },
+
+    getOwnPropertyDescriptor (_, property) {
+      if (context) {
+        const descriptor = Reflect.getOwnPropertyDescriptor(context, property)
+        if (descriptor) {
+          return descriptor
+        }
+      }
+
+      if (property === 'top') {
+        return { enumerable: false, configurable: false, value: null }
+      }
+
+      return Reflect.getOwnPropertyDescriptor(globalObject, property)
+    },
+
+    has (_, property) {
+      if (context && Reflect.has(context, property)) {
+        return true
+      }
+
+      if (property === 'top') {
+        return true
+      }
+
+      return Reflect.has(globalObject, property)
+    },
+
+    isExtensible (_) {
+      if (context) {
+        return Reflect.isExtensible(context)
+      }
+
+      return true
+    },
+
+    ownKeys (_) {
+      const keys = []
+      if (context) {
+        keys.push(...Reflect.ownKeys(context))
+      }
+
+      keys.push(...Reflect
+        .ownKeys(globalObject)
+        .filter((key) => {
+          if (key === 'top') return false
+          return true
+        })
+      )
+
+      return Array.from(new Set(keys))
+    },
+
+    preventExtensions (_) {
+      if (context) {
+        Reflect.preventExtensions(context)
+        return true
+      }
+
+      return false
+    }
+  })
+}
+
+export function compileFunction (source, options = null) {
+  if (options?.type !== 'classic') {
+    const blob = new Blob([source], { type: 'text/javascript' })
+    const url = URL.createObjectURL(blob)
+    const moduleSource = `
+      const module = await import("${url}")
+      const exports = {}
+
+      if (module.default) {
+        return module.default
+      }
+
+      for (const key in module) {
+        exports[key] = module[key]
+      }
+
+      return exports
+    `
+    return compileFunction(moduleSource, {
+      ...options,
+      type: 'classic',
+      async: true,
+      wrap: false
+    })
+  } else {
+    const globalObject = createGlobalObject(options?.context)
+    const wrappedSource = options?.wrap === false
+      ? source
+      : wrapFunctionSource(source, options)
+
+    const compiled = options?.async === true
+      // eslint-disable-next-line
+      ? new AsyncFunction(wrappedSource)
+      // eslint-disable-next-line
+      : new Function(wrappedSource)
+
+    return compiled.bind(globalObject)
+  }
+}
+
+export async function runInContext (source, options, context) {
+  const script = scripts.get(options?.context ?? context) ?? new Script(source, options)
+
+  if (options?.context ?? context) {
+    scripts.set(options?.context ?? context, script)
+  }
+
+  return await script.runInContext(options?.context ?? context, { source })
+}
+
+export async function runInNewContext (source, options, context) {
+  const script = new Script(source, options)
+  const result = await script.runInNewContext(options.context ?? context)
+  await script.destroy()
+  return result
+}
+
+export async function runInThisContext (source, options) {
+  const script = new Script(source, options)
+  const result = await script.runInThisContext()
+  await script.destroy()
+  return result
+}
+
+export function putReference (reference) {
+  const { value } = reference
+  if (
+    value &&
+    typeof value !== 'string' &&
+    typeof value !== 'number' &&
+    typeof value !== 'boolean'
+  ) {
+    references.set(value, reference)
+  }
+
+  references.index.set(reference.id, reference)
+}
+
+export function createReference (value, context) {
+  const id = crypto.randomBytes(8).toString('base64')
+  const reference = new Reference(id, value, context)
+  putReference(reference)
+  return reference
+}
+
+export function getReference (id) {
+  return references.get(id) ?? references.index.get(id)
+}
+
+export function removeReference (id) {
+  const reference = getReference(id)
+  references.index.delete(id)
+  if (reference) {
+    references.delete(reference.value)
+  }
+}
+
+export default {
+  compileFunction,
+  createReference,
+  getContextWindow,
+  getContextWorker,
+  getReference,
+  Reference,
+  removeReference,
+  runInContext,
+  runInNewContext,
+  runInThisContext,
+  Script
+}

--- a/api/vm/index.html
+++ b/api/vm/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        connect-src http: https: ipc: socket:;
+        script-src https: blob: socket: 'unsafe-eval' 'unsafe-inline';
+        worker-src https: blob: socket: 'unsafe-eval' 'unsafe-inline';
+        img-src 'none';
+        child-src https: socket: blob:;
+        object-src 'none';
+      "
+    >
+    <title></title>
+    <script charset="utf-8" type="module" src="./init.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/api/vm/init.js
+++ b/api/vm/init.js
@@ -1,0 +1,171 @@
+import application from '../application.js'
+import * as vm from '../vm.js'
+import hooks from '../hooks.js'
+
+class World extends EventTarget {
+  ready = null
+  frame = null
+  state = null
+  id = null
+
+  constructor (state, id) {
+    super()
+    this.state = state
+    this.id = id
+    this.frame = createWorld({ id })
+    this.ready = new Promise((resolve) => {
+      this.frame.addEventListener('load', resolve, { once: true })
+    })
+  }
+
+  async postMessage (...args) {
+    await this.ready
+    this.frame.contentWindow.postMessage(...args)
+  }
+
+  async destroy () {
+    // send destroy signal
+    await this.postMessage({ id: this.id, type: 'destroy' })
+    // wait for state to emit 'destroyed' on instance, after GC
+    await new Promise((resolve) => {
+      this.addEventListener('destroyed', resolve, { once: true })
+    })
+  }
+}
+
+class State {
+  static init () {
+    const state = new State()
+    state.init()
+    return state
+  }
+
+  ports = []
+  worker = null
+
+  /**
+   * A mapping of client IDs to content worlds.
+   * @type {Map<String, World>}
+   */
+  worlds = new Map()
+  clients = new Map()
+
+  constructor () {
+    this.onMessage = this.onMessage.bind(this)
+    this.onWorkerMessage = this.onWorkerMessage.bind(this)
+    this.onWorkerMessageError = this.onWorkerMessageError.bind(this)
+  }
+
+  init () {
+    hooks.onReady(async () => {
+      this.worker = await vm.getContextWorker()
+      this.worker.port.addEventListener('message', this.onWorkerMessage)
+      this.worker.port.addEventListener('mesageerror', this.onWorkerMessageError)
+      this.worker.port.postMessage({ type: 'realm' })
+
+      const windows = await application.getWindows()
+      const currentWindow = await application.getCurrentWindow()
+
+      for (const index in windows) {
+        const window = windows[index]
+        if (window.index !== currentWindow.index) {
+          await currentWindow.send({
+            window: window.index,
+            event: `vm:${currentWindow.index}:ready`,
+            value: {}
+          })
+        }
+      }
+
+      globalThis.addEventListener('message', this.onMessage)
+    })
+  }
+
+  onMessage (event) {
+    if (event.data?.type === 'world.result') {
+      const transfer = []
+      vm.findMessageTransfers(transfer, event.data)
+      this.worker.port.postMessage({ ...event.data, type: 'result' }, { transfer })
+    }
+
+    if (event.data?.type === 'world.destroy') {
+      const { id } = event.data
+      const world = this.worlds.get(id)
+      if (world) {
+        world.dispatchEvent(new Event('destroyed'))
+        this.worlds.delete(id)
+        if (world.frame?.parentElement) {
+          world.frame.parentElement.removeChild(world.frame)
+        }
+      }
+    }
+  }
+
+  async onWorkerMessage (event) {
+    if (event.data?.type === 'terminate-worker') {
+      const pending = []
+      for (const world of this.worlds.values()) {
+        pending.push(world.destroy())
+      }
+
+      await Promise.all(pending)
+      const currentWindow = await application.getCurrentWindow()
+      await currentWindow.close()
+      this.worker = null
+    }
+
+    if (event.data?.type === 'script') {
+      const { id } = event.data
+      const transfer = []
+      const world = this.worlds.get(id) ?? new World(this, id)
+
+      if (!this.worlds.has(id)) {
+        this.worlds.set(id, world)
+      }
+
+      vm.findMessageTransfers(transfer, event.data)
+
+      world.postMessage(event.data, { transfer })
+    }
+
+    if (event.data?.type === 'destroy') {
+      const { id } = event.data
+      const world = this.worlds.get(id)
+      if (world) {
+        world.destroy()
+      }
+    }
+  }
+
+  onWorkerMessageError (event) {
+    console.error('onWorkerMessageError', event)
+  }
+}
+
+function createWorld (options) {
+  const frame = globalThis.document.createElement('iframe')
+
+  frame.setAttribute('sandbox', 'allow-same-origin allow-scripts')
+  frame.src = `${globalThis.origin}/socket/vm/world.html`
+  frame.id = options.id
+
+  Object.assign(frame.style, {
+    width: 0,
+    height: 0,
+    display: 'none'
+  })
+
+  const target = (
+    globalThis.document.head ??
+    globalThis.document.body ??
+    globalThis.document
+  )
+
+  target.appendChild(frame)
+
+  return frame
+}
+
+if (globalThis.window === globalThis) {
+  State.init()
+}

--- a/api/vm/worker.js
+++ b/api/vm/worker.js
@@ -1,0 +1,209 @@
+const Uint8ArrayPrototype = Uint8Array.prototype
+const TypedArrayPrototype = Object.getPrototypeOf(Uint8ArrayPrototype)
+const TypedArray = TypedArrayPrototype.constructor
+
+// eslint-disable-next-line
+function reportError (err) {
+  if (typeof globalThis.reportError === 'function') {
+    globalThis.reportError(err)
+  }
+}
+
+function isTypedArray (object) {
+  return object instanceof TypedArray
+}
+
+function isArrayBuffer (object) {
+  return object instanceof ArrayBuffer
+}
+
+function findMessageTransfers (transfers, object) {
+  if (isTypedArray(object) || ArrayBuffer.isView(object)) {
+    transfers.push(object.buffer)
+  } else if (isArrayBuffer(object)) {
+    transfers.push(object)
+  } else if (object instanceof MessagePort) {
+    transfers.push(object)
+  } else if (Array.isArray(object)) {
+    for (const value of object) {
+      findMessageTransfers(transfers, value)
+    }
+  } else if (object && typeof object === 'object') {
+    for (const key in object) {
+      findMessageTransfers(transfers, object[key])
+    }
+  }
+
+  return transfers
+}
+
+class Client extends EventTarget {
+  id = null
+  port = null
+
+  constructor (id, port) {
+    super()
+    this.id = id
+    this.port = port
+    this.onMessage = this.onMessage.bind(this)
+    this.port.addEventListener('message', this.onMessage)
+  }
+
+  onMessage (event) {
+    this.dispatchEvent(event)
+  }
+
+  postMessage (...args) {
+    return this.port.postMessage(...args)
+  }
+}
+
+class Realm {
+  /**
+   * The `MessagePort` for the VM realm.
+   * @type {MessagePort}
+   */
+  port = null
+
+  /**
+   * A reference to the top level worker statae
+   * @type {State}
+   */
+  state = null
+
+  /**
+   * Known content worlds that exist in a realm
+   * @type {Map<String, World>}
+   */
+  worlds = new Map()
+
+  constructor (state, port) {
+    this.state = state
+    this.port = port
+  }
+
+  get clients () {
+    return this.state.clients
+  }
+
+  postMessage (...args) {
+    return this.port.postMessage(...args)
+  }
+}
+
+class State {
+  static init () {
+    const state = new this()
+    state.init()
+    return state
+  }
+
+  /**
+   * All known connected `MessagePort` instances
+   * @type {MessagePort[]}
+   */
+  ports = []
+
+  /**
+   * Pending events to be dispatched to realm
+   * @type {MessageEvent[]}
+   */
+  pending = []
+
+  /**
+   * The realm for all virtual machines. This is a headless webview
+   */
+  realm = null
+
+  clients = new Map()
+
+  constructor () {
+    this.onConnect = this.onConnect.bind(this)
+  }
+
+  init () {
+    globalThis.addEventListener('connect', this.onConnect)
+  }
+
+  onConnect (event) {
+    for (const port of event.ports) {
+      this.ports.push(port)
+      port.start()
+      port.addEventListener('message', this.onPortMessage.bind(this, port))
+      port.postMessage('VM_SHARED_WORKER_ACK')
+    }
+  }
+
+  onPortMessage (port, event) {
+    // debug echo
+    // port.postMessage(event.data)
+
+    if (event.data?.type === 'terminate-worker') {
+      for (const port of this.ports) {
+        try {
+          port.postMessage({ type: 'terminate-worker' })
+        } catch {}
+      }
+
+      // timeout so realm can GC
+      setTimeout(() => {
+        globalThis.close()
+      }, 2000)
+      return
+    }
+
+    if (event.data?.type === 'client') {
+      const { id } = event.data
+      let client = null
+
+      if (this.clients.has(id)) {
+        client = this.clients.get(id)
+      } else {
+        client = new Client(id, port)
+        this.clients.set(id, client)
+      }
+    }
+
+    if (event.data?.type === 'script' || event.data?.type === 'destroy') {
+      const { id } = event.data
+      const client = this.clients.get(id)
+
+      if (client) {
+        if (!this.realm) {
+          this.pending.push(event)
+        } else {
+          const transfer = []
+          findMessageTransfers(transfer, event.data)
+          this.realm.postMessage(event.data, { transfer })
+        }
+      }
+    }
+
+    if (event.data?.type === 'result') {
+      const { id } = event.data
+      const client = this.clients.get(id)
+
+      if (client) {
+        const transfer = []
+        findMessageTransfers(transfer, event.data)
+        client.postMessage(event.data, { transfer })
+      }
+    }
+
+    if (event.data?.type === 'realm') {
+      this.realm = new Realm(this, port)
+      if (this.pending.length) {
+        for (const pendingEvent of this.pending) {
+          const transfer = []
+          findMessageTransfers(transfer, pendingEvent.data)
+          this.realm.postMessage(pendingEvent.data, { transfer })
+        }
+        this.pending.splice(0, this.pending.length)
+      }
+    }
+  }
+}
+
+if (globalThis.self && !globalThis.window) {
+  State.init()
+}

--- a/api/vm/world.html
+++ b/api/vm/world.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        connect-src http: https: ipc: socket:;
+        script-src https: blob: socket: 'unsafe-eval' 'unsafe-inline';
+        worker-src blob: socket: 'unsafe-eval' 'unsafe-inline';
+        img-src 'none';
+        child-src 'none';
+        object-src 'none';
+      "
+    />
+    <script charset="utf-8" type="module" src="./world.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/api/vm/world.js
+++ b/api/vm/world.js
@@ -1,0 +1,127 @@
+import * as vm from '../vm.js'
+import gc from '../gc.js'
+
+let realm = null
+
+function createTransferredError (error) {
+  const object = {
+    name: error.name,
+    type: Object.getPrototypeOf(error).constructor.name,
+    message: error.message
+  }
+
+  if (error.cause instanceof Error) {
+    object.cause = createTransferredError(object.cause)
+  }
+
+  if (error.stack) {
+    object.stack = error.stack
+  }
+
+  if (error.code) {
+    object.code = error.code
+  }
+
+  // assign any other enumerable properties
+  Object.assign(object, error)
+
+  return object
+}
+
+const context = {}
+Object.defineProperty(globalThis, 'globalObject', {
+  configurable: false,
+  enumerable: false,
+  value: context
+})
+
+globalThis.addEventListener('message', async (event) => {
+  if (!realm) {
+    realm = event.source
+  }
+
+  if (event.data?.type === 'script') {
+    const { id, mode, nonce, source } = event.data
+    const inputTransfers = []
+    const transfer = []
+    let result
+
+    vm.findMessageTransfers(inputTransfers, event.data.context, {
+      ignoreScriptReferenceArgs: true
+    })
+
+    for (const value of inputTransfers) {
+      if (value instanceof MessagePort) {
+        return realm.postMessage({
+          type: 'world.result',
+          err: createTransferredError(new TypeError('MessagePort cannot be in context')),
+          nonce,
+          id
+        })
+      }
+    }
+
+    const delta = vm.applyContextDifferences(
+      context,
+      event.data.context,
+      context,
+      true
+    )
+
+    for (const key in context) {
+      Object.defineProperty(globalThis, key, {
+        configurable: true,
+        enumerable: false,
+        get: () => Reflect.get(context, key)
+      })
+    }
+
+    for (const key of delta.deletions) {
+      Reflect.deleteProperty(globalThis, key)
+    }
+
+    try {
+      vm.applyInputContextReferences(context)
+      result = await vm.compileFunction(source, {
+        async: true,
+        type: mode !== 'module' ? 'classic' : 'module',
+        wrap: mode !== 'module',
+        context
+      })()
+    } catch (err) {
+      vm.applyOutputContextReferences(context)
+      vm.findMessageTransfers(transfer, context)
+      return realm.postMessage({
+        type: 'world.result',
+        err: createTransferredError(err),
+        context,
+        nonce,
+        id
+      }, { transfer })
+    }
+
+    if (typeof result === 'function') {
+      result = vm.createReference(result, context)
+    } else if (typeof result === 'object') {
+      vm.applyOutputContextReferences(result)
+    }
+
+    vm.applyOutputContextReferences(context)
+    vm.findMessageTransfers(transfer, context)
+    vm.findMessageTransfers(transfer, result)
+
+    return realm.postMessage({
+      type: 'world.result',
+      data: result,
+      context,
+      nonce,
+      id
+    }, { transfer })
+  }
+
+  if (event.data?.type === 'destroy') {
+    const { id } = event.data
+    await gc.release()
+    return realm.postMessage({ type: 'world.destroy', id })
+  }
+})

--- a/test/src/ipc.js
+++ b/test/src/ipc.js
@@ -19,6 +19,7 @@ test('ipc exports', async (t) => {
     'ERROR',
     'kDebugEnabled',
     'primordials',
+    'maybeMakeError',
     'Message',
     'parseSeq',
     'postMessage',


### PR DESCRIPTION
This pull request introduces the `socket:vm` module. It is similar in API surface to the `node:vm` module, but all exported functions are async as the internal semantics, context execution, and JavaScript environment are completely different.

```js
import vm from 'socket:vm'

const result = await vm.runInContext('1 + 2 + 3')
console.log(result) // 6
```

Users of this module can supply a custom context object that is available in the `globalThis` scope of the execution context. Values that can be passed to a script virtual machine are the same that can be passed to a worker. We introduce a "reference proxy" that can be used to reference object instances in a VM to the caller. Functions are automatically detected, referenced, and made available as a proxy call.

```js
import vm from 'socket:vm'

const context = {
  scope: {}
}

await vm.runInContext(
  `scope.decode = (buffer) => new TextDecoder().decode(buffer)`,
  { context }
)

const text = await scope.decode(new TextEncoder().encode('hello world')) // hello world
```

Virtual machine source scripts can be used in a `module` module or `classic` (default). When source scripts are modules, they can use `import/export` syntax. By default, all virtual machine scripts are executed in an async context granting "top level await" to the script.

```js
import vm from 'socket:vm'

const source = `
import fs from 'socket:fs/promises'
export default fs.readdir('.')
`

const module = await rm.runInContext(source)
console.log(module.default) // [ { name: 'Credits.html' }, { name: 'icon.png' },  { name: 'index.html' }, ... ]
```

Virtual machine source scripts run in isolated contexts that are actually a mostly complete implementation of a [Shadow Realm](https://tc39.es/proposal-shadowrealm/) context. All environment intrinsics are preserved and non-configurable. Every script VM has a context and global scope that can the caller can supply and interact with.

```js
import vm from 'socket:vm'

const channel = new MessageChannel()
const context = { scope: {} }
const source = `
let port = null

export function setMessagePort (messagePort) {
  port = messagePort
  port.start()
}

export function postMessage (message) {
  const transfer = vm.getTransferables(message)
  port.postMessage(message, { transfer })
}
`

const module = await rm.runInContext(source, { context })
const decoder = new TextDecoder()
const encoder = new TextEncoder()

channel.port1.start()
channel.port1.onmessage = (event) => {
  console.log(decoder.decode(event.data)) // 'hello world'
}

// send 'hello world' as buffer to VM module which
// will echo it back to us to decode above in the `onmessage`
// event handler for the `MessageChannel` we are sharing with
// the VM module
module.postMessage(encoder.encode('hello world'))
```