### PR TITLE
Introduce platform hotkeys API

### DIFF
--- a/src/core/javascript.cc
+++ b/src/core/javascript.cc
@@ -86,18 +86,17 @@ namespace SSC {
       "}                                                                     \n"
       "                                                                      \n"
       "if (name === 'dropin' || name === 'drop') {                           \n"
-      "  globalThis.dispatchEvent(new CustomEvent('platformdrop', {          \n"
+      "  return globalThis.dispatchEvent(new CustomEvent('platformdrop', {          \n"
       "    detail: {                                                         \n"
       "      ...detail,                                                      \n"
       "      files: Array.from(detail?.src || detail?.files || [])           \n"
       "        .filter(Boolean)                                              \n"
       "    }                                                                 \n"
       "  }));                                                                \n"
+      "}                                                                     \n"
       "                                                                      \n"
       "const event = new CustomEvent(name, { detail, ...options });          \n"
       "target.dispatchEvent(event);                                          \n"
-      "                                                                      \n"
-      "}                                                                     \n"
     );
   }
 

--- a/src/core/preload.cc
+++ b/src/core/preload.cc
@@ -53,22 +53,24 @@ namespace SSC {
       "                                                                      \n"
     );
 
-    const auto start = argv.find("--test=");
-    if (start != std::string::npos) {
-      auto end = argv.find("'", start);
-      if (end == std::string::npos) {
-        end = argv.size();
-      }
-      const auto file = argv.substr(start + 7, end - start - 7);
-      if (file.size() > 0) {
-        preload += (
-          "  document.addEventListener('DOMContentLoaded', () => {           \n"
-          "    const script = document.createElement('script')               \n"
-          "    script.setAttribute('type', 'module')                         \n"
-          "    script.setAttribute('src', '" + file + "')                    \n"
-          "    document.head.appendChild(script)                             \n"
-          "  });                                                             \n"
-        );
+    if (opts.index == 0) {
+      const auto start = argv.find("--test=");
+      if (start != std::string::npos) {
+        auto end = argv.find("'", start);
+        if (end == std::string::npos) {
+          end = argv.size();
+        }
+        const auto file = argv.substr(start + 7, end - start - 7);
+        if (file.size() > 0) {
+          preload += (
+            "  document.addEventListener('DOMContentLoaded', () => {           \n"
+            "    const script = document.createElement('script')               \n"
+            "    script.setAttribute('type', 'module')                         \n"
+            "    script.setAttribute('src', '" + file + "')                    \n"
+            "    document.head.appendChild(script)                             \n"
+            "  });                                                             \n"
+          );
+        }
       }
     }
 

--- a/src/window/win.cc
+++ b/src/window/win.cc
@@ -1093,7 +1093,15 @@ namespace SSC {
 
                               if (mount.path.size() > 0) {
                                 if (mount.resolution.redirect) {
-                                  auto redirectURL = mount.resolution.path + "?" + parsedPath.queryString + "#" + parsedPath.fragment;
+                                  auto redirectURL = mount.resolution.path;
+                                  if (parsedPath.queryString.size() > 0) {
+                                    redirectURL += "?" + parsedPath.queryString;
+                                  }
+
+                                  if (parsedPath.fragment.size() > 0) {
+                                    redirectURL += "#" + parsedPath.fragment;
+                                  }
+
                                   ICoreWebView2WebResourceResponse* res = nullptr;
                                   env->CreateWebResourceResponse(
                                     nullptr,
@@ -1113,7 +1121,15 @@ namespace SSC {
                               } else if (path.size() == 0 && userConfig.contains("webview_default_index")) {
                                 path = userConfig["webview_default_index"];
                               } else if (resolved.redirect) {
-                                auto redirectURL = path + "?" + parsedPath.queryString + "#" + parsedPath.fragment;
+                                auto redirectURL = resolved.path;
+                                if (parsedPath.queryString.size() > 0) {
+                                  redirectURL += "?" + parsedPath.queryString;
+                                }
+
+                                if (parsedPath.fragment.size() > 0) {
+                                  redirectURL += "#" + parsedPath.fragment;
+                                }
+
                                 ICoreWebView2WebResourceResponse* res = nullptr;
                                 env->CreateWebResourceResponse(
                                   nullptr,


### PR DESCRIPTION
This PR introduces support for creating platform hotkey bindings on desktop environments only.

```js
import { hotkey } from 'socket:window'

await hotkey.bind('ctrl + k')

hotkey.addEventListener('hotkey', (event) => {
  console.log(event.id, event.sequence) // 1025, ['ctrl', 'k']
})
```

## re: Linux

Hot key bindings only work when the application is focused. Supporting global hot keys involves working with `libx11` which we'd rather not do at the moment.