### PR TITLE
fix(npm index.js): convert file url to actual path

### DIFF
--- a/npm/src/index.js
+++ b/npm/src/index.js
@@ -1,10 +1,11 @@
 import path from 'node:path'
 import os from 'node:os'
 import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { spawn } from 'node:child_process'
 
 const dirname = path
-  .dirname(import.meta.url)
+  .dirname(fileURLToPath(import.meta.url))
   .replace(`file://${os.platform() === 'win32' ? '/' : ''}`, '')
 
 export const SOCKET_HOME = path.dirname(dirname)


### PR DESCRIPTION
This PR fixes an issue that happens, at least on Windows, when the user has a space character in their Username.

The symptom:
```
> ssc init
node:internal/modules/cjs/loader:1147
  throw err;
  ^

Error: Cannot find module 'C:\Users\Jan%20Starzak\AppData\Roaming\nvm\v20.11.1\node_modules\@socketsupply\socket\node_modules\@socketsupply\socket-win32-x64\bin\ssc-platform.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
    at Module._load (node:internal/modules/cjs/loader:985:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

On Windows (but maybe on other platforms too), file URLs can contain spaces which will be encoded as %20. When treating these URL strings as paths, the OS will claim it doesn't recognize these paths because it won't URL-decode them automatically. 
The ENOENT here is caused by the un-url'ed `cwd` property passed into `spawn`.
Therefore, the `import.meta.url` needs to be converted to an actual filePath before all the other path processing can be done to it.