### PR TITLE
ci: update-stream-relay-source.sh

### DIFF
--- a/bin/update-stream-relay-source.sh
+++ b/bin/update-stream-relay-source.sh
@@ -8,7 +8,7 @@ cp -rf node_modules/@socketsupply/stream-relay/src api/stream-relay || exit $?
 rm -rf node_modules/@socketsupply/{socket,socket-{darwin,linux,win32}*,stream-relay} || exit $?
 
 for file in $(find api/stream-relay -type f); do
-  sed -i '' -e "s/'socket:\(.*\)'/'..\/\1.js'/g" "$file" || exit $?
+  sed -i.bak -e "s/'socket:\(.*\)'/'..\/\1.js'/g" "$file" && rm "$file.bak" || exit $?
 done
 
 {


### PR DESCRIPTION
Updated `sed` to be portable between OSX & Linux

I tried running this file in CI today and it failed due to the host OS being Linux:
```
sed: can't read : No such file or directory
```

This is due to portability issues between the OSX version of `sed` and the GNU `sed`.
The solution comes from suggestions in [this thread](https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux).