### PR TITLE
cli: only replace file ext, not path

### DIFF
--- a/src/cli/cli.cc
+++ b/src/cli/cli.cc
@@ -4377,10 +4377,10 @@ int main (const int argc, const char* argv[]) {
             }
 
             auto objectFile = source;
-            objectFile = replace(objectFile, "\\.mm", ".o");
-            objectFile = replace(objectFile, "\\.m", ".o");
-            objectFile = replace(objectFile, "\\.cc", ".o");
-            objectFile = replace(objectFile, "\\.c", ".o");
+            objectFile = replace(objectFile, "\\.mm$", ".o");
+            objectFile = replace(objectFile, "\\.m$", ".o");
+            objectFile = replace(objectFile, "\\.cc$", ".o");
+            objectFile = replace(objectFile, "\\.c$", ".o");
 
             auto filename = Path(objectFile).filename();
             auto object = (
@@ -5758,10 +5758,10 @@ int main (const int argc, const char* argv[]) {
             }
 
             auto objectFile = source;
-            objectFile = replace(objectFile, "\\.mm", ".o");
-            objectFile = replace(objectFile, "\\.m", ".o");
-            objectFile = replace(objectFile, "\\.cc", ".o");
-            objectFile = replace(objectFile, "\\.c", ".o");
+            objectFile = replace(objectFile, "\\.mm$", ".o");
+            objectFile = replace(objectFile, "\\.m$", ".o");
+            objectFile = replace(objectFile, "\\.cc$", ".o");
+            objectFile = replace(objectFile, "\\.c$", ".o");
 
             auto object = Path(objectFile);
 


### PR DESCRIPTION
## what

fix `replace` calls in cli to only match the extension at end of file paths

## why

currently if you have a ".c", ".cc", ".m" in any directory names in your project working directory, then you are unable to compile an extension as all the ".c" etc will get replaced while the compile flags are being generated.

example:

"/src/github.com/chrisfarms/my-socket-app/extensions/something.c"

becomes

"/src/github.**oom**/chrisfarms/my-socket-app/extensions/something.o"

## note

⚠️ this PR is against `next`