### PR TITLE
resolve xhr issues loading from worker

### DIFF
--- a/api/fetch/index.js
+++ b/api/fetch/index.js
@@ -72,7 +72,7 @@ async function initBody (body) {
 
       for await (const chunk of body) {
         controller.enqueue(chunk)
-        chunks.push(chunk)
+        chunks.push(new Uint8Array(chunk))
       }
 
       const buffer = Buffer.concat(chunks)

--- a/api/internal/init.js
+++ b/api/internal/init.js
@@ -621,8 +621,8 @@ if (typeof globalThis.XMLHttpRequest === 'function') {
 
     if (
       globalThis.__args?.config?.webview_fetch_allow_runtime_headers === true ||
-      /(socket|ipc|node|npm):/.test(url.protocol) ||
-      protocols.handlers.has(url.protocol.slice(0, -1)) ||
+      (url.protocol && /(socket|ipc|node|npm):/.test(url.protocol)) ||
+      (url.protocol && protocols.handlers.has(url.protocol.slice(0, -1))) ||
       url.hostname === globalThis.__args.config.meta_bundle_identifier
     ) {
       for (const key in additionalHeaders) {


### PR DESCRIPTION

## what

* `Buffer.concat` expects either a Uint8Array or Buffer ... but the fetch ReadableStream passes in a plain ArrayBuffer ... this makes it unhappy ... so this wraps in the TypedArray before giving to concat
* URL passing during xhr open seems to fail for some URLs (blob urls?) ... url can be either a string or a URL, and there were no checks so this was exploding

## why

I am attempting to get [three.js GLTFLoaders](https://threejs.org/docs/#examples/en/loaders/GLTFLoader) working, and running into the above issues.

## note

I am NOT confident that either of these are the right thing to do.

Should Buffer.concat actually be fixed to support plain ArrayBuffers instead?

Why is there a silent catch around the URL parsing?