### PR TITLE
fix(internal/worker): ensure blobs are importable

### DIFF
--- a/api/internal/worker.js
+++ b/api/internal/worker.js
@@ -91,8 +91,16 @@ if (source && typeof source === 'string') {
     // wait for everything to be ready, then import
     hooks.onReady(async () => {
       try {
+        let workerSource = source;
+        // make sure any blobs have an importable mime type
+        if (source.startsWith('blob:')) {
+          const b = await fetch(source).then(r => r.blob());
+          if (b.type !== 'text/javascript') {
+            workerSource = URL.createObjectURL(new Blob([b], {type: 'text/javascript'}));
+          }
+        }
         // @ts-ignore
-        await import(source)
+        await import(workerSource)
         if (Array.isArray(globalThis.RUNTIME_WORKER_MESSAGE_EVENT_BACKLOG)) {
           for (const event of globalThis.RUNTIME_WORKER_MESSAGE_EVENT_BACKLOG) {
             globalThis.dispatchEvent(new MessageEvent(event.type, event))


### PR DESCRIPTION
## what

attempt to resolve issue #985 , where a Blob url with a missing / non javascript mime type is attempted to be passed to `import()` during worker spawn.

## why

because `new Worker(URL.createObjectURL(new Blob([`let x = 1;`])))` works in browsers and should work in socket too.

## note

This fix feels dirty. If there are suggestions for a better place for this fix I will be happy to amend it.

PR against `next`