### PR TITLE
return 'denied' for unimplemented permissions queries

### DIFF
--- a/api/fetch/index.js
+++ b/api/fetch/index.js
@@ -72,7 +72,7 @@ async function initBody (body) {
 
       for await (const chunk of body) {
         controller.enqueue(chunk)
-        chunks.push(chunk)
+        chunks.push(new Uint8Array(chunk))
       }
 
       const buffer = Buffer.concat(chunks)

--- a/api/internal/init.js
+++ b/api/internal/init.js
@@ -648,8 +648,8 @@ if (typeof globalThis.XMLHttpRequest === 'function') {
 
     if (
       globalThis.__args?.config?.webview_fetch_allow_runtime_headers === true ||
-      /(socket|ipc|node|npm):/.test(url.protocol) ||
-      protocols.handlers.has(url.protocol.slice(0, -1)) ||
+      (url.protocol && /(socket|ipc|node|npm):/.test(url.protocol)) ||
+      (url.protocol && protocols.handlers.has(url.protocol.slice(0, -1))) ||
       url.hostname === globalThis.__args.config.meta_bundle_identifier
     ) {
       for (const key in additionalHeaders) {

--- a/src/ipc/routes.cc
+++ b/src/ipc/routes.cc
@@ -1858,6 +1858,10 @@ static void mapIPCRoutes (Router *router) {
       }];
     }
   #endif
+
+    // not implemented
+    auto data = JSON::Object::Entries {{"state", "denied"}};
+    return reply(Result::Data { message, data });
   });
 
   router->map("permissions.request", [=](auto message, auto router, auto reply) {


### PR DESCRIPTION
when calling `ipc://permissions.query?...` from android with `await` the process stalls.

this change simply returns 'denied' for all permissions request types and envs which have yet to be implemented.