### PR TITLE
show if proxing on RemotePeer

### DIFF
--- a/api/latica/proxy.js
+++ b/api/latica/proxy.js
@@ -270,7 +270,8 @@ class PeerWorkerProxy {
           lastUpdate: arg.lastUpdate,
           natType: arg.natType,
           peerId: arg.peerId,
-          port: arg.port
+          port: arg.port,
+          proxy: !!arg.proxy,
         }
 
         delete args[i].localPeer // don't copy this over


### PR DESCRIPTION
## what

exposes `proxy` as a flag on `RemotePeer`

## why

It is very useful to know if another peer is proxying your writes (so you can respectfully slow down for example) ... however the RemotePeer doesn't pass through the proxy value over the worker divide which means this data is unavailable.

## note

PR against `next`

on Peer proper, the value of `proxy` is a more complex object, which makes this inconsistent when running network with `worker:{true/false}` ... I opted to make it just a boolean for simplicity, but the inconsistency is a bit of a smell, so open to suggestions.
